### PR TITLE
feat(daemon): persistent daemon mode for the last major test runtime gains!

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ qunitx daemon restart  # Stop + start in one step
 
 Running `qunitx daemon start` upfront is optional. With `QUNITX_DAEMON=1` set in your environment, a plain `qunitx <file>` invocation will spawn the daemon on its own when it doesn't find one already running — so the very first run pays the spawn cost and every run after that is warm. Without `QUNITX_DAEMON=1`, the cli skips auto-spawn and just runs locally; `qunitx daemon start` then becomes the explicit way to opt in.
 
+### Debugging the daemon
+
+The daemon process is detached with `stdio: 'ignore'`, so its idle/startup/shutdown output never reaches a terminal. Set `QUNITX_DAEMON_LOG=<path>` before `daemon start` to redirect the daemon's stdout + stderr to a file:
+
+```sh
+QUNITX_DAEMON_LOG=/tmp/qunitx-daemon.log qunitx daemon start
+tail -f /tmp/qunitx-daemon.log
+```
+
+The log captures startup banners, browser-crash recovery, idle-timeout shutdown, package.json-mutation restarts, and any unhandled rejection. During an active run the per-run interceptor still forwards stdout to the client; the log catches everything else.
+
 ## Writing Tests
 
 qunitx-cli runs [QUnitX](https://github.com/izelnakri/qunitx) tests — a superset of QUnit with async

--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ Options:
   --open=<binary>     Open output in a specific browser binary (e.g. brave, google-chrome-lts)
   --port=<n>          HTTP server port (auto-selects a free port if taken)
   --browser=<name>    Browser engine: chromium (default), firefox, or webkit
+  --no-daemon         Don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn
+
+Subcommands:
+  qunitx daemon start | stop | status     Manage the optional persistent daemon
+  qunitx init                             Bootstrap qunitx config + base HTML in this project
+  qunitx new <testFileName>               Create a new qunitx test file
 ```
 
 ## Timezone

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ output to the terminal.
 - `--port` defaults to 1234 and auto-increments if taken; fails fast if an explicit port is unavailable
 - `--browser` flag to run tests in Chromium, Firefox, or WebKit
 - `--version` / `-v` prints the installed version
+- Optional daemon mode (`qunitx daemon start`) keeps Chrome and the esbuild context warm across runs — roughly halves the wall-clock time of repeated invocations
 - Docker image for zero-install CI usage
 
 ## Installation
@@ -106,6 +107,45 @@ qunitx test/**/*.js --browser=webkit
 > npx playwright install webkit
 > ```
 
+## Daemon mode
+
+**`qunitx daemon start` is optional.** Set `QUNITX_DAEMON=1` once (in your shell, `.env`, or a CI step) and plain `qunitx <file>` invocations auto-spawn the daemon on first use, then transparently route through it on every run after — no extra commands, no flags, nothing to remember between invocations. The explicit `daemon start` / `stop` subcommands exist only for when you want to control the lifecycle yourself.
+
+What it does: cold-start cost dominates a single `qunitx` run — launching Chrome, loading playwright-core, and creating an esbuild incremental context together account for most of the wall-clock time on a small suite. The daemon keeps all three resources alive across runs so subsequent invocations skip them entirely — roughly **2-3× faster** on repeated runs of the same suite.
+
+A single one-off run won't get faster from spinning the daemon up; it's an opt-in optimization aimed at two situations:
+
+- **Local TDD loops.** Export `QUNITX_DAEMON=1` in your shell profile (or run `qunitx daemon start` once at the top of your session) and forget about it — subsequent runs reuse the daemon automatically until you `daemon stop` or 30 idle minutes pass.
+- **Monorepo CI** where each package shells out to `qunitx` separately. Set `QUNITX_DAEMON=1` for the job and a single daemon is auto-spawned and reused across every package's invocation.
+
+```sh
+# Start a background daemon for this project
+qunitx daemon start
+
+# Run tests as usual — the cli auto-detects the daemon and routes through it
+qunitx test/**/*.ts
+
+# Stop it when you're done
+qunitx daemon stop
+```
+
+`--watch` and `--open` manage their own browser lifecycle and bypass the daemon automatically. Single-invocation CI jobs (where `CI=1` is set) also bypass it by default — `QUNITX_DAEMON=1` overrides if you want it on anyway.
+
+### Daemon subcommands
+
+```sh
+qunitx daemon start    # Launch a detached daemon for this cwd (idempotent)
+qunitx daemon stop     # Ask the running daemon to exit and wait until it has
+qunitx daemon status   # Print the live daemon's pid, socket, and uptime
+qunitx daemon restart  # Stop + start in one step
+```
+
+### How it works
+
+`qunitx daemon start` spawns a detached Node process listening on a per-project Unix socket (named pipe on Windows). Subsequent `qunitx` invocations detect the live socket and forward `argv` + `cwd` + `env` to the daemon; the daemon executes the run in-process and streams TAP back to your terminal. Ctrl+C is forwarded — the daemon abandons the in-flight run cleanly and stays up for the next one. A single daemon serves one run at a time; concurrent invocations queue in arrival order.
+
+Running `qunitx daemon start` upfront is optional. With `QUNITX_DAEMON=1` set in your environment, a plain `qunitx <file>` invocation will spawn the daemon on its own when it doesn't find one already running — so the very first run pays the spawn cost and every run after that is warm. Without `QUNITX_DAEMON=1`, the cli skips auto-spawn and just runs locally; `qunitx daemon start` then becomes the explicit way to opt in.
+
 ## Writing Tests
 
 qunitx-cli runs [QUnitX](https://github.com/izelnakri/qunitx) tests — a superset of QUnit with async
@@ -177,17 +217,17 @@ All CLI flags can also be set in `package.json` under the `qunitx` key, so you d
 }
 ```
 
-| Key          | Default                       | Description                                                                                                                                                                 |
-| ------------ | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `inputs`     | `[]`                          | Glob patterns, file paths, or directories to use as test entry points. Merged with any paths given on the CLI.                                                              |
-| `htmlPaths`  | `[]`                          | Optional HTML templates to run tests inside. Any listed `.html` file that contains `{{qunitxScript}}` or other handlebars-style tokens is treated as a test runner template. |
-| `extensions` | `["js", "ts", "jsx", "tsx"]`  | File extensions tracked for test discovery (directory scans) and watch-mode rebuild triggers. Add `"mjs"`, `"cjs"`, or any other extension your project uses.               |
-| `output`     | `"tmp"`                       | Directory where compiled test bundles are written.                                                                                                                          |
-| `timeout`    | `20000`                       | Maximum milliseconds to wait for the full test suite before timing out.                                                                                                     |
-| `failFast`   | `false`                       | Stop the run after the first failing test.                                                                                                                                  |
-| `port`       | `1234`                        | Preferred HTTP server port. qunitx auto-selects a free port if this one is taken.                                                                                           |
-| `browser`    | `"chromium"`                  | Browser engine to use: `"chromium"`, `"firefox"`, or `"webkit"`. Overridden by `--browser` on the CLI.                                                                      |
-| `plugins`    | `[]`                          | esbuild plugin specifiers loaded from your `node_modules` and applied to the test bundle. See [esbuild plugins](#esbuild-plugins).                                          |
+| Key          | Default                      | Description                                                                                                                                                                  |
+| ------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `inputs`     | `[]`                         | Glob patterns, file paths, or directories to use as test entry points. Merged with any paths given on the CLI.                                                               |
+| `htmlPaths`  | `[]`                         | Optional HTML templates to run tests inside. Any listed `.html` file that contains `{{qunitxScript}}` or other handlebars-style tokens is treated as a test runner template. |
+| `extensions` | `["js", "ts", "jsx", "tsx"]` | File extensions tracked for test discovery (directory scans) and watch-mode rebuild triggers. Add `"mjs"`, `"cjs"`, or any other extension your project uses.                |
+| `output`     | `"tmp"`                      | Directory where compiled test bundles are written.                                                                                                                           |
+| `timeout`    | `20000`                      | Maximum milliseconds to wait for the full test suite before timing out.                                                                                                      |
+| `failFast`   | `false`                      | Stop the run after the first failing test.                                                                                                                                   |
+| `port`       | `1234`                       | Preferred HTTP server port. qunitx auto-selects a free port if this one is taken.                                                                                            |
+| `browser`    | `"chromium"`                 | Browser engine to use: `"chromium"`, `"firefox"`, or `"webkit"`. Overridden by `--browser` on the CLI.                                                                       |
+| `plugins`    | `[]`                         | esbuild plugin specifiers loaded from your `node_modules` and applied to the test bundle. See [esbuild plugins](#esbuild-plugins).                                           |
 
 CLI flags always override `package.json` values when both are present.
 
@@ -245,20 +285,20 @@ For file formats esbuild does not handle natively (e.g. `.vue` SFCs, `.svelte`),
 
 Each entry is one of:
 
-| Form                          | Behavior                                                                                                                                                  |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `"<package-name>"`             | Imports the package. If the default export is a function, it's called with no arguments to produce the plugin; otherwise the export is used as the plugin. |
+| Form                            | Behavior                                                                                                                                                   |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `"<package-name>"`              | Imports the package. If the default export is a function, it's called with no arguments to produce the plugin; otherwise the export is used as the plugin. |
 | `["<package-name>", <options>]` | Same, but the factory is called with `<options>` as its only argument. Use this form to pass plugin-specific configuration.                                |
-| `"./relative/plugin.js"`       | Loads a plugin you wrote yourself. Resolved against the project root (where your `package.json` lives).                                                   |
+| `"./relative/plugin.js"`        | Loads a plugin you wrote yourself. Resolved against the project root (where your `package.json` lives).                                                    |
 
 Don't forget to add the plugin's file extension(s) to `qunitx.extensions` so directory scans and watch-mode rebuilds pick them up.
 
 ### Environment variables
 
-| Variable         | Description                                                                                                   |
-|------------------|---------------------------------------------------------------------------------------------------------------|
+| Variable         | Description                                                                                                                                                                                           |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `CHROME_BIN`     | Path to the Chrome/Chromium executable. Required on systems where Chrome is not on `PATH` (e.g. many CI environments). Set automatically when using `browser-actions/setup-chrome` in GitHub Actions. |
-| `QUNITX_BROWSER` | Browser engine to use (`chromium`, `firefox`, `webkit`). Equivalent to `--browser` on the CLI. Useful in CI matrix jobs. |
+| `QUNITX_BROWSER` | Browser engine to use (`chromium`, `firefox`, `webkit`). Equivalent to `--browser` on the CLI. Useful in CI matrix jobs.                                                                              |
 
 If you do not provide any HTML template, qunitx falls back to its built-in `test/tests.html` boilerplate internally, so `qunitx init` is optional.
 
@@ -298,11 +338,11 @@ The browser inherits the **OS system timezone** automatically — no Playwright 
 
 ### Setting a timezone for tests
 
-| Platform | How Chrome resolves the timezone | Override |
-|----------|----------------------------------|---------|
-| **Linux** | glibc reads `TZ` env var first, then `/etc/localtime` | `TZ=America/New_York npx qunitx …` works |
-| **macOS** | CoreFoundation reads the system timezone (ignores `TZ`) | Must set the system timezone: `sudo systemsetup -settimezone America/New_York` |
-| **Windows** | Reads the registry timezone (ignores `TZ`) | Must set the system timezone: `tzutil /s "Eastern Standard Time"` |
+| Platform    | How Chrome resolves the timezone                        | Override                                                                       |
+| ----------- | ------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| **Linux**   | glibc reads `TZ` env var first, then `/etc/localtime`   | `TZ=America/New_York npx qunitx …` works                                       |
+| **macOS**   | CoreFoundation reads the system timezone (ignores `TZ`) | Must set the system timezone: `sudo systemsetup -settimezone America/New_York` |
+| **Windows** | Reads the registry timezone (ignores `TZ`)              | Must set the system timezone: `tzutil /s "Eastern Standard Time"`              |
 
 On Linux, the `TZ` env var is the simplest way to run tests in a specific timezone:
 
@@ -356,12 +396,18 @@ module('Invoice formatting', (hooks) => {
     // Pin "now" to a fixed instant for the whole module
     const FIXED = new realDate('2024-06-01T12:00:00Z');
     globalThis.Date = class extends realDate {
-      constructor(...args) { super(args.length ? args : [FIXED]); }
-      static now() { return FIXED.getTime(); }
+      constructor(...args) {
+        super(args.length ? args : [FIXED]);
+      }
+      static now() {
+        return FIXED.getTime();
+      }
     };
   });
 
-  hooks.after(() => { globalThis.Date = realDate; });
+  hooks.after(() => {
+    globalThis.Date = realDate;
+  });
 
   test('formats the current date correctly', (assert) => {
     assert.equal(new Date().toISOString().slice(0, 10), '2024-06-01');
@@ -377,8 +423,12 @@ import sinon from 'sinon';
 module('Debounce logic', (hooks) => {
   let clock;
 
-  hooks.before(() => { clock = sinon.useFakeTimers({ now: new Date('2024-06-01T00:00:00Z') }); });
-  hooks.after(() => { clock.restore(); });
+  hooks.before(() => {
+    clock = sinon.useFakeTimers({ now: new Date('2024-06-01T00:00:00Z') });
+  });
+  hooks.after(() => {
+    clock.restore();
+  });
 
   test('fires after 300 ms', (assert) => {
     // clock.tick(300) advances fake time without waiting in real time
@@ -393,11 +443,15 @@ If you need the mock active across the entire test run rather than inside a sing
 ```js
 // scripts/mock-date.js  (passed as: qunitx … --before=scripts/mock-date.js)
 const realDate = globalThis.Date;
-const FIXED    = new realDate('2024-06-01T12:00:00Z');
+const FIXED = new realDate('2024-06-01T12:00:00Z');
 
 globalThis.Date = class extends realDate {
-  constructor(...args) { super(args.length ? args : [FIXED]); }
-  static now() { return FIXED.getTime(); }
+  constructor(...args) {
+    super(args.length ? args : [FIXED]);
+  }
+  static now() {
+    return FIXED.getTime();
+  }
 };
 ```
 
@@ -415,6 +469,8 @@ make test-all-browsers          # run full suite on all three browsers
 make demo                       # regenerate docs/demo.gif
 make release LEVEL=patch        # bump version, update changelog, tag, push
 ```
+
+For a tight TDD loop on this repo (or any consuming project), run `qunitx daemon start` once at the top of your session — every subsequent `qunitx` invocation reuses the warm Chrome and esbuild context, roughly halving the wait-per-iteration. AI/LLM coding agents benefit even more, since their inner loop is dozens of `qunitx <file>` invocations per feature. Caveat: agents running inside containers or CI-style environments (GitHub Actions Copilot, sandboxed coding agents) often have `CI=1` set, which bypasses the daemon by default — set `QUNITX_DAEMON=1` in those environments to opt back in.
 
 Use `--trace-perf` to print internal timing to stderr — useful when investigating startup or e2e regressions:
 

--- a/TODO
+++ b/TODO
@@ -1,28 +1,24 @@
-  │                          │          │ Mostly yes. Most CI jobs invoke qunitx once per job. Spawning a daemon (~1.5s) + routing (~0.7s) = 2.2s — slower than the local 2.0s  │
-  │ CI=1                     │ yes      │ for one invocation. Daemon only wins on multi-invocation CI flows. The current default is correct. Possible refinement: have explicit │
-  │                          │          │  QUNITX_DAEMON=1 override CI=1 so multi-invocation CI users can opt in. Easy follow-up if anyone asks.                                │
-
-
-  - Cross-cwd daemon sharing. Currently each cwd gets its own daemon (sha256(cwd) keyed). This is right — different projects have different package.json / extensions / plugins.
-  Sharing a daemon across them would require config validation per-request and isn't worth the complexity.
-
-
-
-
-Why CI=true exists? Is there a good reason?
-
-Is the successful(and errorful) test output ideal today?
-
-  Out of scope for v1 (mentioned in the design discussion):
-  - Browser-crash recovery (daemon shuts down on any unhandled rejection; user restarts)
-  - Concurrent multi-group runs through the daemon (always single-group)
-  - Auto-spawn (user explicitly runs qunitx daemon start)
-
 Should I add benchmarks for this daemon feature(s)? Is there anyway we can optimize the overall performance of the 
 runtime further? What about test suite?
 
 Did I document daemon feature well on README.md, document it well for first or subsequent viewers/developers.
 Document `daemon` related important things on `$ qunitx` and `$ qunitx help`
+
+=======
+Review daemon PR/ask for changes
+=======
+
+Is the successful(and errorful) test output ideal today?
+
+These should be in another releases each one:
+  - fsTree caching (~30-80ms) — has cache-invalidation risk across runs (file additions/deletions during daemon lifetime would need fs.watch with the same correctness contract
+  complexity as the esbuild context cache).
+  - cachedContent caching (~20-50ms) — needs a type-split refactor of CachedContent (mixing stable + run-specific fields), and HTML-file mtime invalidation.
+  - HTTPServer instance reuse (~50ms) — the STATIC_FILES_PATH constraint at server creation captures config.output once, so reuse requires either fixing output paths daemon-wide
+  (behavior change) or refactoring web-server.ts route handlers to read current cachedContent per request (instability across runs while requests are in flight).
+
+  Each of those three is a real optimization, but each requires non-trivial cache-invalidation contracts that — based on this PR's track record of cache-invalidation bugs surfacing
+   only on Windows or under load — I'd want to land in a follow-up PR with their own focused test coverage rather than smuggle into this one.
 
 
 Also make sure cli/binary can be built in deno and would work on macos and windows but first probably daemon mode

--- a/TODO
+++ b/TODO
@@ -1,7 +1,6 @@
-Should I add benchmarks for this daemon feature(s)? Is there anyway we can optimize the overall performance of the runtime of the qunitx-cli further? What about my own test suite? Check both in-depth
+Document `daemon` related important things on `$ qunitx` and `$ qunitx help`. It should follow the current style and have the right balance between being useful, minimal, it should be the most UX friendly.
 
-Did I document daemon feature well on README.md, document it well for first or subsequent viewers/developers.
-Document `daemon` related important things on `$ qunitx` and `$ qunitx help`
+Make `qunitx daemon` and `qunitx daemon --help` the same thing. Should it match qunitx --help output in terms of style? Analyze it well and give your best suggestion
 
 =======
 Review daemon PR/ask for changes
@@ -19,7 +18,12 @@ Review daemon PR/ask for changes
   Risk: low. V8 invalidates cache when source content changes. Stale cache would manifest as actual test failures (visible). Worst case: someone rm's the cache directory.
 
   Concrete change: 1 line in test/runner.ts spawn env. ~5-10x ROI on the implementation effort.
+
 =====
+
+  3. README perf section mentioning NODE_COMPILE_CACHE for non-daemon users — documentation, not code.
+
+
 
 Is the successful(and errorful) test output ideal today?
 

--- a/TODO
+++ b/TODO
@@ -1,6 +1,6 @@
-Document `daemon` related important things on `$ qunitx` and `$ qunitx help`. It should follow the current style and have the right balance between being useful, minimal, it should be the most UX friendly.
+CI is flaky: https://github.com/izelnakri/qunitx-cli/actions/runs/25026906458/job/73299935841 Find the core issue, write a test case to reproduce it/verify, then implement the best fix/solution, commit and push
 
-Make `qunitx daemon` and `qunitx daemon --help` the same thing. Should it match qunitx --help output in terms of style? Analyze it well and give your best suggestion
+Make `qunitx daemon` and `qunitx daemon --help` the same thing. Should it match `$ qunitx --help` output in terms of style? Analyze it well and give your best suggestion
 
 =======
 Review daemon PR/ask for changes

--- a/TODO
+++ b/TODO
@@ -1,7 +1,3 @@
-CI is flaky: https://github.com/izelnakri/qunitx-cli/actions/runs/25026906458/job/73299935841 Find the core issue, write a test case to reproduce it/verify, then implement the best fix/solution, commit and push
-
-Make `qunitx daemon` and `qunitx daemon --help` the same thing. Should it match `$ qunitx --help` output in terms of style? Analyze it well and give your best suggestion
-
 =======
 Review daemon PR/ask for changes
 =======

--- a/TODO
+++ b/TODO
@@ -1,3 +1,14 @@
+  │                          │          │ Mostly yes. Most CI jobs invoke qunitx once per job. Spawning a daemon (~1.5s) + routing (~0.7s) = 2.2s — slower than the local 2.0s  │
+  │ CI=1                     │ yes      │ for one invocation. Daemon only wins on multi-invocation CI flows. The current default is correct. Possible refinement: have explicit │
+  │                          │          │  QUNITX_DAEMON=1 override CI=1 so multi-invocation CI users can opt in. Easy follow-up if anyone asks.                                │
+
+
+  - Cross-cwd daemon sharing. Currently each cwd gets its own daemon (sha256(cwd) keyed). This is right — different projects have different package.json / extensions / plugins.
+  Sharing a daemon across them would require config validation per-request and isn't worth the complexity.
+
+
+
+
 Why CI=true exists? Is there a good reason?
 
 Is the successful(and errorful) test output ideal today?

--- a/TODO
+++ b/TODO
@@ -3,7 +3,8 @@
   - Concurrent multi-group runs through the daemon (always single-group)
   - Auto-spawn (user explicitly runs qunitx daemon start)
 
-Should I add benchmarks for this daemon feature(s)?
+Should I add benchmarks for this daemon feature(s)? Is there anyway we can optimize the overall performance of the 
+runtime further? What about test suite?
 
 Did I document daemon feature well on README.md, document it well for first or subsequent viewers/developers.
 Document `daemon` related important things on `$ qunitx` and `$ qunitx help`

--- a/TODO
+++ b/TODO
@@ -1,3 +1,7 @@
+Why CI=true exists? Is there a good reason?
+
+Is the successful(and errorful) test output ideal today?
+
   Out of scope for v1 (mentioned in the design discussion):
   - Browser-crash recovery (daemon shuts down on any unhandled rejection; user restarts)
   - Concurrent multi-group runs through the daemon (always single-group)

--- a/TODO
+++ b/TODO
@@ -1,6 +1,13 @@
-- add jsx/tsx support, from conversation(claude --resume 80202453-1a12-424a-a785-d13f8914ec72)
+  Out of scope for v1 (mentioned in the design discussion):
+  - Browser-crash recovery (daemon shuts down on any unhandled rejection; user restarts)
+  - Concurrent multi-group runs through the daemon (always single-group)
+  - Auto-spawn (user explicitly runs qunitx daemon start)
 
-- Allow the test runner to accept esbuild plugins in the config file, like "esbuild-plugin-vue-next"
+Should I add benchmarks for this daemon feature(s)?
+
+Did I document daemon feature well on README.md, document it well for first or subsequent viewers/developers.
+Document `daemon` related important things on `$ qunitx` and `$ qunitx help`
+
 
 Also make sure cli/binary can be built in deno and would work on macos and windows but first probably daemon mode
 
@@ -8,10 +15,7 @@ https://www.youtube.com/watch?v=SaZEdiV3A3M
 
 - investigate take screenshot feature & visual diffing(implement it percy-like)
 
-- maybe add persisten-daemon mode to shave off ~800ms saved on every run after the first.
-  Every qunitx invocation today: Node startup → load 40+ files → connect to Chrome → esbuild → navigate → run → exit. A qunitx serve daemon would keep Chrome alive and hold the
-  esbuild incremental context warm. qunitx run test/file.ts sends the file list over a Unix socket and streams TAP back. Subsequent runs: ~200–300ms (just esbuild rebuild +
-  navigate). This is the single biggest UX improvement possible for developers running tests frequently in a non-watch workflow.
+- maybe add persistent daemon mode to shave off ~800ms saved on every run after the first. Every qunitx invocation today: Node startup → load 40+ files → connect to Chrome → esbuild → navigate → run → exit. A qunitx serve daemon would keep Chrome alive and hold the esbuild incremental context warm. qunitx run test/file.ts sends the file list over a Unix socket and streams TAP back. Subsequent runs: ~200–300ms (just esbuild rebuild + navigate). This is the single biggest UX improvement possible for developers running tests frequently in a non-watch workflow.
   CLAUDE SESSION: claude --resume b0edfd88-98cb-4111-8322-f103e6d41515
 
 qunitx-cli JS API should be very usable from outside by JS/TS only, by users of this library. Do them, document it well

--- a/TODO
+++ b/TODO
@@ -1,5 +1,4 @@
-Should I add benchmarks for this daemon feature(s)? Is there anyway we can optimize the overall performance of the 
-runtime further? What about test suite?
+Should I add benchmarks for this daemon feature(s)? Is there anyway we can optimize the overall performance of the runtime of the qunitx-cli further? What about my own test suite? Check both in-depth
 
 Did I document daemon feature well on README.md, document it well for first or subsequent viewers/developers.
 Document `daemon` related important things on `$ qunitx` and `$ qunitx help`
@@ -7,6 +6,20 @@ Document `daemon` related important things on `$ qunitx` and `$ qunitx help`
 =======
 Review daemon PR/ask for changes
 =======
+
+======
+  a. NODE_COMPILE_CACHE in test/runner.ts spawn env — ~2-15s saved on the 175s Phase 1.
+
+  node --test runs each top-level test file in a separate worker subprocess. ~30 test files × ~50-100ms recompile cost = 1.5-3s minimum, more on slow CI runners. With compile
+  cache, the first test populates /tmp/qunitx-test-cache, the next 29 hit the cache.
+
+  Within a single CI run (ephemeral runner), the cache populates fresh and helps the 2nd-Nth test files. If you want cross-run benefit on CI, add actions/cache keyed on Node
+  version + relevant source hashes — but that's a CI-yaml change with its own maintenance, and the within-run win is already worth doing.
+
+  Risk: low. V8 invalidates cache when source content changes. Stale cache would manifest as actual test failures (visible). Worst case: someone rm's the cache directory.
+
+  Concrete change: 1 line in test/runner.ts spawn env. ~5-10x ROI on the implementation effort.
+=====
 
 Is the successful(and errorful) test output ideal today?
 
@@ -20,6 +33,17 @@ These should be in another releases each one:
   Each of those three is a real optimization, but each requires non-trivial cache-invalidation contracts that — based on this PR's track record of cache-invalidation bugs surfacing
    only on Windows or under load — I'd want to land in a follow-up PR with their own focused test coverage rather than smuggle into this one.
 
+
+====
+  The one remaining lever: NODE_COMPILE_CACHE. Node 22.8+ ships a V8 compile cache that persists bytecode-compiled modules across invocations. Setting NODE_COMPILE_CACHE=<dir>
+  makes the cli's heaviest cold-start phase (V8 parsing + TS-strip + bytecode-compile of ~40 modules) reuse cached bytecode on subsequent runs.
+
+  Empirically: shaves ~50-100ms off cold cli startup. Daemon mode bypasses this entirely (modules stay loaded in memory, no recompile), so this only benefits non-daemon users on
+  repeat runs.
+
+  It's an env-var setting, not a code change. The clean place to surface it: a one-line note in the README's performance section. Don't enable it programmatically inside cli.ts —
+  there's no hook to set it before our own process loads (it has to be in the parent shell env).
+===
 
 Also make sure cli/binary can be built in deno and would work on macos and windows but first probably daemon mode
 

--- a/benches/daemon.bench.ts
+++ b/benches/daemon.bench.ts
@@ -1,0 +1,71 @@
+/**
+ * Daemon-routed CLI benchmark — measures the headline value proposition of
+ * `qunitx daemon`: cli invocation routed through the persistent Unix-socket
+ * daemon, served from a warm Chrome and a warm esbuild incremental context.
+ *
+ * One bench, deliberately. Cold-spawn / cache-miss / concurrent-multi-file
+ * variants were considered and rejected: cold-spawn is dominated by Chrome
+ * launch noise and bench-check's threshold (~26%) wouldn't reliably detect
+ * realistic module-loading regressions; cache-miss appears as an *improvement*
+ * if the cache invalidation breaks (wrong-direction signal); concurrent
+ * multi-file mostly retests run.ts's existing concurrent-group orchestration
+ * without daemon-specific signal.
+ *
+ * The remaining bench catches the regressions that actually matter:
+ *   - cli.ts module-loading bloat (lazy-load reverted) — adds ~50–80ms
+ *   - daemon dispatch / IPC overhead (run-queue contention, NDJSON parser)
+ *   - run.ts daemon path breakage (e.g. browser re-launched per run)
+ *   - esbuild context cache-key bug (context recreated every iteration)
+ *   - setupBrowser per-run cost (page + new HTTPServer + bind)
+ *
+ * Compare against `cli: e2e run (1 passing test file)` in e2e.bench.ts —
+ * daemon is expected to be 3-4× faster. A regression here that shrinks the
+ * gap is the signal that the daemon's value prop has eroded.
+ *
+ * Note: this file is run in an isolated subprocess by scripts/check-benchmarks.ts
+ * (used by `bench:check` / `bench:update` / `make bench`), so the persistent
+ * daemon started below cannot affect other bench files there. It is intentionally
+ * NOT added to the in-process `bench` task, where top-level daemon startup would
+ * leak into e2e.bench.ts numbers. The daemon's 30-min idle timeout handles
+ * cleanup if this file's process exits before manual `qunitx daemon stop`.
+ */
+import { mkdir } from 'node:fs/promises';
+
+const PROJECT_ROOT = new URL('..', import.meta.url).pathname;
+const FIXTURE = 'test/helpers/passing-tests.ts';
+
+await mkdir(`${PROJECT_ROOT}/tmp`, { recursive: true });
+
+function spawnCLI(args: string[]): Promise<{ code: number }> {
+  const id = crypto.randomUUID();
+  return new Deno.Command('node', {
+    args: ['cli.ts', ...args, `--output=tmp/bench-run-${id}`],
+    cwd: PROJECT_ROOT,
+    env: { ...Deno.env.toObject(), FORCE_COLOR: '0' },
+    stdout: 'null',
+    stderr: 'null',
+  }).output();
+}
+
+// Defensive: any leftover daemon from a previous bench run would falsify the
+// "fresh cold spawn" we're about to do. `daemon stop` is idempotent — returns
+// fast when no daemon is running.
+await spawnCLI(['daemon', 'stop']);
+// Start the daemon and prime the esbuild context cache against the same
+// fixture the bench iterates on. Subsequent measured iterations hit the
+// warm cache — the actual thing the daemon is supposed to optimize.
+await spawnCLI(['daemon', 'start']);
+await spawnCLI([FIXTURE]);
+
+Deno.bench(
+  'cli-daemon: e2e run (1 passing test file, warm)',
+  {
+    group: 'cli-daemon',
+    baseline: true,
+    n: 5,
+    warmup: 0,
+  },
+  async () => {
+    await spawnCLI([FIXTURE]);
+  },
+);

--- a/cli.ts
+++ b/cli.ts
@@ -10,16 +10,35 @@ import pkg from './package.json' with { type: 'json' };
 process.title = 'qunitx';
 
 (async () => {
-  if (!process.argv[2]) {
+  const cmd = process.argv[2];
+  if (!cmd) {
     return await displayHelpOutput();
-  } else if (['--version', '-v', 'version'].includes(process.argv[2])) {
+  } else if (['--version', '-v', 'version'].includes(cmd)) {
     return process.stdout.write(pkg.version + '\n');
-  } else if (['help', 'h', 'p', 'print'].includes(process.argv[2])) {
+  } else if (['help', 'h', 'p', 'print'].includes(cmd)) {
     return await displayHelpOutput();
-  } else if (['new', 'n', 'g', 'generate'].includes(process.argv[2])) {
+  } else if (['new', 'n', 'g', 'generate'].includes(cmd)) {
     return await generateTestFiles();
-  } else if (['init'].includes(process.argv[2])) {
+  } else if (cmd === 'init') {
     return await initializeProject();
+  } else if (cmd === 'daemon') {
+    const { runDaemonCommand } = await import('./lib/commands/daemon/index.ts');
+    process.exit(await runDaemonCommand());
+  }
+
+  // Daemon-routed run: when a live daemon exists for this cwd and the invocation is
+  // eligible (no --watch/--open, not CI, not opted out), dispatch the work over the
+  // Unix socket and stream TAP back. Saves ~800ms by reusing the daemon's persistent
+  // Chrome and warm esbuild context. Falls through on connect failure.
+  const { shouldUseDaemon, runViaDaemon } = await import('./lib/commands/daemon/client.ts');
+  if (shouldUseDaemon()) {
+    try {
+      const exitCode = await runViaDaemon(process.argv.slice(2));
+      process.stdout.write('', () => process.exit(exitCode));
+      return;
+    } catch {
+      // Daemon disappeared mid-handshake — fall through to a local run.
+    }
   }
 
   // Lazy import: run.js (and its static imports like esbuild and playwright-core) are

--- a/cli.ts
+++ b/cli.ts
@@ -1,26 +1,32 @@
 #!/usr/bin/env node
 import process from 'node:process';
 import { shutdownPrelaunch } from './lib/utils/chrome-prelaunch.ts';
-import { displayHelpOutput } from './lib/commands/help.ts';
-import { initializeProject } from './lib/commands/init.ts';
-import { generateTestFiles } from './lib/commands/generate.ts';
-import { setupConfig } from './lib/setup/config.ts';
 import pkg from './package.json' with { type: 'json' };
 
 process.title = 'qunitx';
 
+// Command-module imports are dynamic so the daemon-routed-run path doesn't
+// load `help.ts`, `init.ts`, `generate.ts`, or `setup/config.ts` (and its
+// transitive `fs-tree` / `find-project-root` / `parse-cli-flags` chain) just
+// to discard them. Saves ~50-80ms of unused module evaluation on every
+// daemon-routed cli invocation. The cost on the rare commands (help, init,
+// generate) is one extra ~5ms dynamic-import resolution — below human
+// perception and not on any hot path. chrome-prelaunch.ts stays static
+// because its module-eval kicks off Chrome pre-launch and must run before
+// playwright-core starts loading on local-run paths.
+
 (async () => {
   const cmd = process.argv[2];
   if (!cmd) {
-    return await displayHelpOutput();
+    return await (await import('./lib/commands/help.ts')).displayHelpOutput();
   } else if (['--version', '-v', 'version'].includes(cmd)) {
     return process.stdout.write(pkg.version + '\n');
   } else if (['help', 'h', 'p', 'print'].includes(cmd)) {
-    return await displayHelpOutput();
+    return await (await import('./lib/commands/help.ts')).displayHelpOutput();
   } else if (['new', 'n', 'g', 'generate'].includes(cmd)) {
-    return await generateTestFiles();
+    return await (await import('./lib/commands/generate.ts')).generateTestFiles();
   } else if (cmd === 'init') {
-    return await initializeProject();
+    return await (await import('./lib/commands/init.ts')).initializeProject();
   } else if (cmd === 'daemon') {
     const { runDaemonCommand } = await import('./lib/commands/daemon/index.ts');
     process.exit(await runDaemonCommand());
@@ -47,10 +53,14 @@ process.title = 'qunitx';
     }
   }
 
-  // Lazy import: run.js (and its static imports like esbuild and playwright-core) are
-  // only loaded when actually running tests. Importing in parallel with setupConfig()
-  // lets playwright-core start loading while config is being assembled.
-  const [config, { run }] = await Promise.all([setupConfig(), import('./lib/commands/run.ts')]);
+  // Local-run path: lazy-import setupConfig + run.ts (and their transitive
+  // chains: esbuild, playwright-core, fs-tree, etc.). Loading in parallel lets
+  // playwright-core's heavy module evaluation overlap with config assembly.
+  const [{ setupConfig }, { run }] = await Promise.all([
+    import('./lib/setup/config.ts'),
+    import('./lib/commands/run.ts'),
+  ]);
+  const config = await setupConfig();
 
   try {
     return await run(config);

--- a/cli.ts
+++ b/cli.ts
@@ -26,12 +26,18 @@ process.title = 'qunitx';
     process.exit(await runDaemonCommand());
   }
 
-  // Daemon-routed run: when a live daemon exists for this cwd and the invocation is
-  // eligible (no --watch/--open, not CI, not opted out), dispatch the work over the
-  // Unix socket and stream TAP back. Saves ~800ms by reusing the daemon's persistent
-  // Chrome and warm esbuild context. Falls through on connect failure.
-  const { shouldUseDaemon, runViaDaemon } = await import('./lib/commands/daemon/client.ts');
-  if (shouldUseDaemon()) {
+  // Daemon-routed run: when a live daemon exists for this cwd (or QUNITX_DAEMON=1
+  // opted into auto-spawn), dispatch the work over the Unix socket and stream TAP
+  // back. Saves ~800ms by reusing the daemon's persistent Chrome and warm esbuild
+  // context. Falls through on connect failure.
+  const { shouldUseDaemon, shouldAutoSpawnDaemon, runViaDaemon } =
+    await import('./lib/commands/daemon/client.ts');
+  let useDaemon = shouldUseDaemon();
+  if (!useDaemon && shouldAutoSpawnDaemon()) {
+    const { ensureDaemonRunning } = await import('./lib/commands/daemon/index.ts');
+    useDaemon = await ensureDaemonRunning();
+  }
+  if (useDaemon) {
     try {
       const exitCode = await runViaDaemon(process.argv.slice(2));
       process.stdout.write('', () => process.exit(exitCode));

--- a/deno.json
+++ b/deno.json
@@ -6,8 +6,8 @@
   },
   "tasks": {
     "bench": "deno bench --allow-all benches/esbuild.bench.ts benches/server.bench.ts benches/tap.bench.ts benches/e2e.bench.ts",
-    "bench:check": "deno run --allow-all scripts/check-benchmarks.ts --files benches/esbuild.bench.ts benches/server.bench.ts benches/tap.bench.ts benches/e2e.bench.ts",
-    "bench:update": "deno run --allow-all scripts/check-benchmarks.ts --save --files benches/esbuild.bench.ts benches/server.bench.ts benches/tap.bench.ts benches/e2e.bench.ts"
+    "bench:check": "deno run --allow-all scripts/check-benchmarks.ts --files benches/esbuild.bench.ts benches/server.bench.ts benches/tap.bench.ts benches/e2e.bench.ts benches/daemon.bench.ts",
+    "bench:update": "deno run --allow-all scripts/check-benchmarks.ts --save --files benches/esbuild.bench.ts benches/server.bench.ts benches/tap.bench.ts benches/e2e.bench.ts benches/daemon.bench.ts"
   },
   "lint": {
     "rules": {

--- a/lib/commands/daemon/client.ts
+++ b/lib/commands/daemon/client.ts
@@ -13,19 +13,35 @@ export function daemonSocketExists(cwd: string = process.cwd()): boolean {
 }
 
 /**
- * Decides whether the current invocation is a candidate for daemon dispatch.
- * Daemon is opt-in: only used when a live socket exists AND the run does not
- * require local browser/server lifecycle (watch / open / CI).
+ * True if the run could meaningfully use a daemon: not in CI, not opted out, and
+ * not a watch/open mode (those need their own browser lifecycle locally). Both
+ * `shouldUseDaemon` and `shouldAutoSpawnDaemon` build on this.
  */
-export function shouldUseDaemon(): boolean {
+function isDaemonEligible(): boolean {
   if (process.env.CI || process.env.QUNITX_NO_DAEMON) return false;
-  const argv = process.argv;
-  for (const arg of argv) {
+  for (const arg of process.argv) {
     if (arg === '--no-daemon') return false;
     if (arg === '--watch' || arg === '-w') return false;
     if (arg === '--open' || arg === '-o' || arg.startsWith('--open=')) return false;
   }
-  return daemonSocketExists();
+  return true;
+}
+
+/**
+ * True iff a live daemon socket exists and the invocation can use it. The cli's
+ * primary dispatch check.
+ */
+export function shouldUseDaemon(): boolean {
+  return isDaemonEligible() && daemonSocketExists();
+}
+
+/**
+ * True iff the user opted in to auto-spawn (`QUNITX_DAEMON=1`), the invocation
+ * is daemon-eligible, and no daemon is running yet — meaning cli should spawn
+ * one before dispatching the run.
+ */
+export function shouldAutoSpawnDaemon(): boolean {
+  return Boolean(process.env.QUNITX_DAEMON) && isDaemonEligible() && !daemonSocketExists();
 }
 
 /**

--- a/lib/commands/daemon/client.ts
+++ b/lib/commands/daemon/client.ts
@@ -1,4 +1,5 @@
 import net from 'node:net';
+import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { daemonSocketPath, daemonInfoPath } from '../../utils/daemon-socket-path.ts';
 import { attachLineParser, probeSocket } from './socket-utils.ts';
@@ -6,6 +7,13 @@ import type { Request, ResponseChunk } from './protocol.ts';
 
 const CONNECT_TIMEOUT_MS = 1_000;
 const SIGINT_EXIT_CODE = 130;
+// Maximum time to wait for the daemon process to fully exit after `daemon stop`
+// returns 'done'. The async cleanup (server.close + browser.close + exit) is
+// usually well under a second; 5s is generous headroom for a busy CI runner.
+const SHUTDOWN_PID_WAIT_MS = 5_000;
+// Poll interval while waiting for the daemon's pid to disappear. 50ms keeps the
+// follow-up `daemon start` snappy without burning CPU.
+const SHUTDOWN_PID_POLL_MS = 50;
 
 /**
  * True if a daemon appears to be present for the given cwd. Checks the sidecar JSON
@@ -90,14 +98,65 @@ export async function pingDaemon(): Promise<ResponseChunk | null> {
   return result;
 }
 
-/** Sends `shutdown`. Returns `true` if a daemon was reached and asked to stop, `false` otherwise. */
+/**
+ * Sends `shutdown` and waits until the daemon has actually fully exited — not just
+ * until the socket closes. The daemon's dispatch handler acks 'done' before its
+ * async cleanup (server.close / browser.close / process.exit) runs, so a naive
+ * "stop returned" signal leaves the daemon's socket / named-pipe handle still
+ * held. A fast follow-up `daemon start` would then race the dying daemon and hit
+ * EADDRINUSE — observed reliably on Windows where named-pipe handle release lags
+ * process exit by tens of milliseconds.
+ *
+ * Reads the pid upfront (before sending shutdown — the daemon sync-unlinks the
+ * info file in its dispatch handler, so we can't read it after) and polls
+ * `process.kill(pid, 0)` until ESRCH. Bounded by `SHUTDOWN_PID_WAIT_MS`.
+ *
+ * Returns `true` if a daemon was reached and asked to stop, `false` if no daemon
+ * was running.
+ */
 export async function shutdownDaemon(): Promise<boolean> {
+  const pid = await readDaemonPid();
+
   const socket = await tryConnect();
   if (!socket) return false;
   attachLineParser<ResponseChunk>(socket, () => {});
   send(socket, { type: 'shutdown' });
   await awaitClose(socket);
+
+  if (pid !== null) await waitForPidExit(pid, SHUTDOWN_PID_WAIT_MS);
   return true;
+}
+
+async function readDaemonPid(): Promise<number | null> {
+  try {
+    const info = JSON.parse(await fs.readFile(daemonInfoPath(), 'utf8')) as { pid?: unknown };
+    return typeof info.pid === 'number' ? info.pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function waitForPidExit(pid: number, timeoutMs: number): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const deadline = Date.now() + timeoutMs;
+    const poll = (): void => {
+      if (!pidIsAlive(pid) || Date.now() >= deadline) return resolve();
+      setTimeout(poll, SHUTDOWN_PID_POLL_MS);
+    };
+    poll();
+  });
+}
+
+function pidIsAlive(pid: number): boolean {
+  // process.kill(pid, 0) is the portable "does this pid exist?" check. Throws
+  // ESRCH when gone, EPERM when alive but not signalable. Daemon is our own
+  // child so EPERM is unexpected — treat as alive defensively.
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
 }
 
 /**

--- a/lib/commands/daemon/client.ts
+++ b/lib/commands/daemon/client.ts
@@ -1,15 +1,21 @@
 import net from 'node:net';
 import { existsSync } from 'node:fs';
-import { daemonSocketPath } from '../../utils/daemon-socket-path.ts';
+import { daemonSocketPath, daemonInfoPath } from '../../utils/daemon-socket-path.ts';
 import { attachLineParser, probeSocket } from './socket-utils.ts';
 import type { Request, ResponseChunk } from './protocol.ts';
 
 const CONNECT_TIMEOUT_MS = 1_000;
 const SIGINT_EXIT_CODE = 130;
 
-/** True if the daemon socket file exists on disk for the given cwd (cheap presence check). */
+/**
+ * True if a daemon appears to be present for the given cwd. Checks the sidecar JSON
+ * file rather than the socket path because Windows named pipes are not visible on the
+ * regular filesystem (existsSync on `\\.\pipe\...` always returns false). The info
+ * file is created at startup and unlinked at shutdown — a reliable cross-platform
+ * sentinel. Stale info files are caught downstream by tryConnect failing fast.
+ */
 export function daemonSocketExists(cwd: string = process.cwd()): boolean {
-  return existsSync(daemonSocketPath(cwd));
+  return existsSync(daemonInfoPath(cwd));
 }
 
 /**

--- a/lib/commands/daemon/client.ts
+++ b/lib/commands/daemon/client.ts
@@ -2,29 +2,26 @@ import net from 'node:net';
 import fs from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { daemonSocketPath, daemonInfoPath } from '../../utils/daemon-socket-path.ts';
+import { CLEANUP_GRACE_MS } from '../../utils/close-with-grace.ts';
 import { attachLineParser, probeSocket } from './socket-utils.ts';
 import type { Request, ResponseChunk } from './protocol.ts';
 
 const CONNECT_TIMEOUT_MS = 1_000;
 const SIGINT_EXIT_CODE = 130;
 // Maximum time to wait for the daemon process to fully exit after `daemon stop`
-// returns 'done'. The async cleanup (server.close + browser.close + exit) is
-// usually well under a second; 5s is generous headroom for a busy CI runner.
-const SHUTDOWN_PID_WAIT_MS = 5_000;
+// returns 'done'. Two reasons we cap this rather than poll forever:
+//   1. PID reuse — once the daemon's pid is freed, the OS can recycle it for an
+//      unrelated process within seconds; without a deadline `process.kill(pid, 0)`
+//      would succeed forever against the recycled pid and block stop indefinitely.
+//   2. CLI / scripting UX — a daemon stuck in cleanup (browser.close deadlock on
+//      Firefox+Windows, server.close hanging) shouldn't freeze the cli.
+// Same bound as CLEANUP_GRACE_MS — single source of truth for "worst tolerated
+// cleanup time" across the codebase. Generous enough for a loaded CI runner where
+// browser.close + esbuild dispose can take several seconds under contention.
+const SHUTDOWN_PID_WAIT_MS = CLEANUP_GRACE_MS;
 // Poll interval while waiting for the daemon's pid to disappear. 50ms keeps the
 // follow-up `daemon start` snappy without burning CPU.
 const SHUTDOWN_PID_POLL_MS = 50;
-
-/**
- * True if a daemon appears to be present for the given cwd. Checks the sidecar JSON
- * file rather than the socket path because Windows named pipes are not visible on the
- * regular filesystem (existsSync on `\\.\pipe\...` always returns false). The info
- * file is created at startup and unlinked at shutdown — a reliable cross-platform
- * sentinel. Stale info files are caught downstream by tryConnect failing fast.
- */
-export function daemonSocketExists(cwd: string = process.cwd()): boolean {
-  return existsSync(daemonInfoPath(cwd));
-}
 
 /**
  * True if the run could meaningfully use a daemon: not opted out, not a watch/open
@@ -44,12 +41,17 @@ function isDaemonEligible(): boolean {
   return true;
 }
 
+// daemonInfoPath() is the cross-platform "is a daemon present?" sentinel — checked
+// rather than the socket itself because on Windows named pipes (\\.\pipe\...) are
+// not visible to existsSync. The info file is created at startup and unlinked at
+// shutdown; stale files are caught downstream when tryConnect fails fast.
+
 /**
  * True iff a live daemon socket exists and the invocation can use it. The cli's
  * primary dispatch check.
  */
 export function shouldUseDaemon(): boolean {
-  return isDaemonEligible() && daemonSocketExists();
+  return isDaemonEligible() && existsSync(daemonInfoPath());
 }
 
 /**
@@ -58,7 +60,7 @@ export function shouldUseDaemon(): boolean {
  * one before dispatching the run.
  */
 export function shouldAutoSpawnDaemon(): boolean {
-  return Boolean(process.env.QUNITX_DAEMON) && isDaemonEligible() && !daemonSocketExists();
+  return Boolean(process.env.QUNITX_DAEMON) && isDaemonEligible() && !existsSync(daemonInfoPath());
 }
 
 /**
@@ -86,16 +88,17 @@ function awaitClose(socket: net.Socket): Promise<void> {
 export async function pingDaemon(): Promise<ResponseChunk | null> {
   const socket = await tryConnect();
   if (!socket) return null;
-  let result: ResponseChunk | null = null;
-  attachLineParser<ResponseChunk>(socket, (chunk) => {
-    if (chunk.type === 'pong') {
-      result = chunk;
-      socket.end();
-    }
+  const result = new Promise<ResponseChunk | null>((resolve) => {
+    attachLineParser<ResponseChunk>(socket, (chunk) => {
+      if (chunk.type === 'pong') resolve(chunk);
+    });
+    socket.once('close', () => resolve(null));
+    socket.once('error', () => resolve(null));
   });
   send(socket, { type: 'ping' });
-  await awaitClose(socket);
-  return result;
+  const pong = await result;
+  socket.end();
+  return pong;
 }
 
 /**
@@ -169,15 +172,21 @@ export async function runViaDaemon(argv: string[]): Promise<number> {
   const socket = await tryConnect();
   if (!socket) throw new Error('daemon connect failed');
 
-  let exitCode: number | null = null;
-  attachLineParser<ResponseChunk>(socket, (chunk) => {
-    if (chunk.type === 'stdout') process.stdout.write(chunk.data);
-    else if (chunk.type === 'stderr') process.stderr.write(chunk.data);
-    else if (chunk.type === 'done') exitCode = chunk.exitCode;
-    else if (chunk.type === 'fatal') {
-      process.stderr.write(`# [qunitx daemon] ${chunk.message}\n`);
-      exitCode = exitCode ?? 1;
-    }
+  // Per protocol.ts: exactly one terminal message ('done' or 'fatal') ends the
+  // stream. close/error here are last-resort fallbacks for a daemon that drops
+  // the connection without sending one.
+  const exitCode = new Promise<number>((resolve) => {
+    attachLineParser<ResponseChunk>(socket, (chunk) => {
+      if (chunk.type === 'stdout') process.stdout.write(chunk.data);
+      else if (chunk.type === 'stderr') process.stderr.write(chunk.data);
+      else if (chunk.type === 'done') resolve(chunk.exitCode);
+      else if (chunk.type === 'fatal') {
+        process.stderr.write(`# [qunitx daemon] ${chunk.message}\n`);
+        resolve(1);
+      }
+    });
+    socket.once('close', () => resolve(1));
+    socket.once('error', () => resolve(1));
   });
 
   const onSigint = () => {
@@ -195,10 +204,8 @@ export async function runViaDaemon(argv: string[]): Promise<number> {
   });
 
   try {
-    await awaitClose(socket);
+    return await exitCode;
   } finally {
     process.removeListener('SIGINT', onSigint);
   }
-
-  return exitCode ?? 1;
 }

--- a/lib/commands/daemon/client.ts
+++ b/lib/commands/daemon/client.ts
@@ -19,12 +19,15 @@ export function daemonSocketExists(cwd: string = process.cwd()): boolean {
 }
 
 /**
- * True if the run could meaningfully use a daemon: not in CI, not opted out, and
- * not a watch/open mode (those need their own browser lifecycle locally). Both
- * `shouldUseDaemon` and `shouldAutoSpawnDaemon` build on this.
+ * True if the run could meaningfully use a daemon: not opted out, not a watch/open
+ * mode (those need their own browser lifecycle locally). CI is bypassed by default
+ * (single-invocation CI jobs lose to daemon's spawn cost) but `QUNITX_DAEMON=1`
+ * overrides — multi-invocation CI flows (monorepos running qunitx per package) can
+ * opt in. Explicit user intent always beats environment-driven default.
  */
 function isDaemonEligible(): boolean {
-  if (process.env.CI || process.env.QUNITX_NO_DAEMON) return false;
+  if (process.env.QUNITX_NO_DAEMON) return false;
+  if (process.env.CI && !process.env.QUNITX_DAEMON) return false;
   for (const arg of process.argv) {
     if (arg === '--no-daemon') return false;
     if (arg === '--watch' || arg === '-w') return false;

--- a/lib/commands/daemon/client.ts
+++ b/lib/commands/daemon/client.ts
@@ -1,0 +1,120 @@
+import net from 'node:net';
+import { existsSync } from 'node:fs';
+import { daemonSocketPath } from '../../utils/daemon-socket-path.ts';
+import { attachLineParser, probeSocket } from './socket-utils.ts';
+import type { Request, ResponseChunk } from './protocol.ts';
+
+const CONNECT_TIMEOUT_MS = 1_000;
+const SIGINT_EXIT_CODE = 130;
+
+/** True if the daemon socket file exists on disk for the given cwd (cheap presence check). */
+export function daemonSocketExists(cwd: string = process.cwd()): boolean {
+  return existsSync(daemonSocketPath(cwd));
+}
+
+/**
+ * Decides whether the current invocation is a candidate for daemon dispatch.
+ * Daemon is opt-in: only used when a live socket exists AND the run does not
+ * require local browser/server lifecycle (watch / open / CI).
+ */
+export function shouldUseDaemon(): boolean {
+  if (process.env.CI || process.env.QUNITX_NO_DAEMON) return false;
+  const argv = process.argv;
+  for (const arg of argv) {
+    if (arg === '--no-daemon') return false;
+    if (arg === '--watch' || arg === '-w') return false;
+    if (arg === '--open' || arg === '-o' || arg.startsWith('--open=')) return false;
+  }
+  return daemonSocketExists();
+}
+
+/**
+ * Opens a connection to the daemon for the given cwd. Resolves the connected socket
+ * on success; resolves `null` on any failure (no socket file, ECONNREFUSED, timeout).
+ */
+export function tryConnect(cwd: string = process.cwd()): Promise<net.Socket | null> {
+  return probeSocket(daemonSocketPath(cwd), CONNECT_TIMEOUT_MS);
+}
+
+function send(socket: net.Socket, req: Request): void {
+  socket.write(JSON.stringify(req) + '\n');
+}
+
+/** Awaits socket close (any path: end / close / error). */
+function awaitClose(socket: net.Socket): Promise<void> {
+  return new Promise((resolve) => {
+    socket.once('end', () => resolve());
+    socket.once('close', () => resolve());
+    socket.once('error', () => resolve());
+  });
+}
+
+/** Sends a `ping` and resolves the daemon's `pong` response (or `null` on failure). */
+export async function pingDaemon(): Promise<ResponseChunk | null> {
+  const socket = await tryConnect();
+  if (!socket) return null;
+  let result: ResponseChunk | null = null;
+  attachLineParser<ResponseChunk>(socket, (chunk) => {
+    if (chunk.type === 'pong') {
+      result = chunk;
+      socket.end();
+    }
+  });
+  send(socket, { type: 'ping' });
+  await awaitClose(socket);
+  return result;
+}
+
+/** Sends `shutdown`. Returns `true` if a daemon was reached and asked to stop, `false` otherwise. */
+export async function shutdownDaemon(): Promise<boolean> {
+  const socket = await tryConnect();
+  if (!socket) return false;
+  attachLineParser<ResponseChunk>(socket, () => {});
+  send(socket, { type: 'shutdown' });
+  await awaitClose(socket);
+  return true;
+}
+
+/**
+ * Sends `argv` to the daemon and streams its TAP output back to local stdout/stderr.
+ * Returns the exit code reported by the daemon. Throws if the connection fails.
+ * Forwards the user's Ctrl+C: client exits with 130; daemon abandons the run cleanly
+ * when it sees the socket close (clientAlive=false stops further writes).
+ */
+export async function runViaDaemon(argv: string[]): Promise<number> {
+  const socket = await tryConnect();
+  if (!socket) throw new Error('daemon connect failed');
+
+  let exitCode: number | null = null;
+  attachLineParser<ResponseChunk>(socket, (chunk) => {
+    if (chunk.type === 'stdout') process.stdout.write(chunk.data);
+    else if (chunk.type === 'stderr') process.stderr.write(chunk.data);
+    else if (chunk.type === 'done') exitCode = chunk.exitCode;
+    else if (chunk.type === 'fatal') {
+      process.stderr.write(`# [qunitx daemon] ${chunk.message}\n`);
+      exitCode = exitCode ?? 1;
+    }
+  });
+
+  const onSigint = () => {
+    socket.end();
+    process.exit(SIGINT_EXIT_CODE);
+  };
+  process.once('SIGINT', onSigint);
+
+  send(socket, {
+    type: 'run',
+    argv,
+    cwd: process.cwd(),
+    env: { ...process.env },
+    nodeVersion: process.version,
+  });
+
+  try {
+    await awaitClose(socket);
+  } finally {
+    process.removeListener('SIGINT', onSigint);
+  }
+
+  return exitCode ?? 1;
+}

--- a/lib/commands/daemon/index.ts
+++ b/lib/commands/daemon/index.ts
@@ -1,0 +1,94 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { daemonSocketPath } from '../../utils/daemon-socket-path.ts';
+import { pingDaemon, shutdownDaemon, tryConnect } from './client.ts';
+
+const SPAWN_POLL_INTERVAL_MS = 100;
+const SPAWN_TIMEOUT_MS = 10_000;
+
+const __filename = fileURLToPath(import.meta.url);
+// daemon/index.ts → ../../../cli.ts
+const CLI_ENTRY = path.resolve(path.dirname(__filename), '..', '..', '..', 'cli.ts');
+
+/**
+ * Dispatches `qunitx daemon <subcommand>`. `_serve` runs the in-process daemon loop
+ * (spawned by `start`); all other subcommands are client operations.
+ */
+export function runDaemonCommand(): Promise<number> {
+  const sub = process.argv[3];
+  if (sub === '_serve') return runServeMode();
+  if (sub === 'start') return startDaemon();
+  if (sub === 'stop') return stopDaemon();
+  if (sub === 'status') return statusDaemon();
+  process.stderr.write(
+    'Usage: qunitx daemon <start|stop|status>\n' +
+      '  start   Spawn a persistent daemon for this project\n' +
+      '  stop    Stop the running daemon\n' +
+      '  status  Print whether a daemon is running\n',
+  );
+  return Promise.resolve(sub ? 1 : 0);
+}
+
+async function runServeMode(): Promise<number> {
+  const { runDaemonServer } = await import('./server.ts');
+  await runDaemonServer();
+  // Unreachable: runDaemonServer enters an event loop that exits via shutdownDaemon.
+  return 0;
+}
+
+async function startDaemon(): Promise<number> {
+  const existing = await pingDaemon();
+  if (existing && existing.type === 'pong') {
+    process.stdout.write(`Daemon already running (pid ${existing.pid})\n`);
+    return 0;
+  }
+
+  // Detached so the daemon outlives the current shell. stdio: 'ignore' detaches all
+  // pipes; daemon writes its own startup line to its stderr (now /dev/null analogue).
+  spawn(process.execPath, [CLI_ENTRY, 'daemon', '_serve'], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env, QUNITX_DAEMON_CWD: process.cwd() },
+  }).unref();
+
+  const deadline = Date.now() + SPAWN_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, SPAWN_POLL_INTERVAL_MS));
+    const sock = await tryConnect();
+    if (!sock) continue;
+    sock.destroy();
+    const pong = await pingDaemon();
+    if (pong && pong.type === 'pong') {
+      process.stdout.write(`Daemon started (pid ${pong.pid})\n`);
+      return 0;
+    }
+  }
+
+  process.stderr.write('Daemon did not start within 10s\n');
+  return 1;
+}
+
+async function stopDaemon(): Promise<number> {
+  const stopped = await shutdownDaemon();
+  process.stdout.write(stopped ? 'Daemon stopped\n' : 'No daemon was running\n');
+  return 0;
+}
+
+async function statusDaemon(): Promise<number> {
+  const pong = await pingDaemon();
+  if (!pong || pong.type !== 'pong') {
+    process.stdout.write('No daemon running for this project\n');
+    return 1;
+  }
+  const ageMin = Math.round((Date.now() - pong.startedAt) / 60_000);
+  process.stdout.write(
+    `Daemon running\n` +
+      `  pid:     ${pong.pid}\n` +
+      `  cwd:     ${pong.cwd}\n` +
+      `  node:    ${pong.nodeVersion}\n` +
+      `  uptime:  ${ageMin} min\n` +
+      `  socket:  ${daemonSocketPath(pong.cwd)}\n`,
+  );
+  return 0;
+}

--- a/lib/commands/daemon/index.ts
+++ b/lib/commands/daemon/index.ts
@@ -63,17 +63,15 @@ async function runServeMode(): Promise<number> {
  *
  * Two `existsSync` calls bracket the watcher attachment to close the TOCTOU gap:
  * the file may appear between the entry-point check and `fs.watch` actually being
- * subscribed in the kernel.
+ * subscribed in the kernel. Multiple `settle` calls are harmless: `resolve`,
+ * `clearTimeout`, and `fsWatcher.close` are all idempotent.
  */
 function waitForFile(filePath: string, timeoutMs: number): Promise<boolean> {
   if (existsSync(filePath)) return Promise.resolve(true);
   return new Promise<boolean>((resolve) => {
     const dir = path.dirname(filePath);
     const fileName = path.basename(filePath);
-    let settled = false;
     const settle = (ok: boolean) => {
-      if (settled) return;
-      settled = true;
       clearTimeout(timer);
       watcher.close();
       resolve(ok);

--- a/lib/commands/daemon/index.ts
+++ b/lib/commands/daemon/index.ts
@@ -13,7 +13,9 @@ const CLI_ENTRY = path.resolve(path.dirname(__filename), '..', '..', '..', 'cli.
 
 /**
  * Dispatches `qunitx daemon <subcommand>`. `_serve` runs the in-process daemon loop
- * (spawned by `start`); all other subcommands are client operations.
+ * (spawned by `start`); all other subcommands are client operations. No subcommand
+ * (or `--help` / `-h` / `help`) prints usage and exits 0; an unknown subcommand
+ * prints usage to stderr and exits 1.
  */
 export function runDaemonCommand(): Promise<number> {
   const sub = process.argv[3];
@@ -21,13 +23,17 @@ export function runDaemonCommand(): Promise<number> {
   if (sub === 'start') return startDaemon();
   if (sub === 'stop') return stopDaemon();
   if (sub === 'status') return statusDaemon();
-  process.stderr.write(
+  const helpRequested = !sub || sub === '--help' || sub === '-h' || sub === 'help';
+  const out = helpRequested ? process.stdout : process.stderr;
+  out.write(
     'Usage: qunitx daemon <start|stop|status>\n' +
-      '  start   Spawn a persistent daemon for this project\n' +
+      '  start   Spawn a persistent daemon for this project (~2× faster repeated runs)\n' +
       '  stop    Stop the running daemon\n' +
-      '  status  Print whether a daemon is running\n',
+      '  status  Print whether a daemon is running\n' +
+      '\n' +
+      'Tip: set QUNITX_DAEMON=1 to auto-spawn the daemon on the first qunitx run.\n',
   );
-  return Promise.resolve(sub ? 1 : 0);
+  return Promise.resolve(helpRequested ? 0 : 1);
 }
 
 async function runServeMode(): Promise<number> {

--- a/lib/commands/daemon/index.ts
+++ b/lib/commands/daemon/index.ts
@@ -37,13 +37,12 @@ async function runServeMode(): Promise<number> {
   return 0;
 }
 
-async function startDaemon(): Promise<number> {
-  const existing = await pingDaemon();
-  if (existing && existing.type === 'pong') {
-    process.stdout.write(`Daemon already running (pid ${existing.pid})\n`);
-    return 0;
-  }
-
+/**
+ * Spawns a detached daemon process and polls until it answers a ping.
+ * Returns the running daemon's pid on success, `null` on timeout. Used by both
+ * the explicit `daemon start` and the auto-spawn path from cli.ts.
+ */
+async function spawnAndWaitForDaemon(): Promise<{ pid: number } | null> {
   // Detached so the daemon outlives the current shell. stdio: 'ignore' detaches all
   // pipes; daemon writes its own startup line to its stderr (now /dev/null analogue).
   spawn(process.execPath, [CLI_ENTRY, 'daemon', '_serve'], {
@@ -59,12 +58,33 @@ async function startDaemon(): Promise<number> {
     if (!sock) continue;
     sock.destroy();
     const pong = await pingDaemon();
-    if (pong && pong.type === 'pong') {
-      process.stdout.write(`Daemon started (pid ${pong.pid})\n`);
-      return 0;
-    }
+    if (pong && pong.type === 'pong') return { pid: pong.pid };
   }
+  return null;
+}
 
+/**
+ * Ensures a daemon is reachable for the current cwd. Returns true if one was
+ * already running or was successfully spawned; false on spawn timeout. Silent —
+ * intended for the cli.ts auto-spawn path where the spawn is incidental to the run.
+ */
+export async function ensureDaemonRunning(): Promise<boolean> {
+  const existing = await pingDaemon();
+  if (existing && existing.type === 'pong') return true;
+  return Boolean(await spawnAndWaitForDaemon());
+}
+
+async function startDaemon(): Promise<number> {
+  const existing = await pingDaemon();
+  if (existing && existing.type === 'pong') {
+    process.stdout.write(`Daemon already running (pid ${existing.pid})\n`);
+    return 0;
+  }
+  const result = await spawnAndWaitForDaemon();
+  if (result) {
+    process.stdout.write(`Daemon started (pid ${result.pid})\n`);
+    return 0;
+  }
   process.stderr.write('Daemon did not start within 10s\n');
   return 1;
 }

--- a/lib/commands/daemon/index.ts
+++ b/lib/commands/daemon/index.ts
@@ -2,10 +2,29 @@ import { spawn } from 'node:child_process';
 import fs, { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { blue, magenta } from '../../utils/color.ts';
 import { daemonInfoPath, daemonSocketPath } from '../../utils/daemon-socket-path.ts';
 import { pingDaemon, shutdownDaemon } from './client.ts';
+import pkg from '../../../package.json' with { type: 'json' };
 
 const SPAWN_TIMEOUT_MS = 10_000;
+
+const highlight = (text: string): string => magenta().bold(text);
+const color = (text: string): string => blue(text);
+
+const USAGE = `${highlight(`[qunitx v${pkg.version}] Usage:`)} qunitx ${color('daemon <subcommand>')}
+
+${highlight('Subcommands:')}
+${color('$ qunitx daemon start')}    # Spawn a persistent daemon for this project (~2× faster repeated runs)
+${color('$ qunitx daemon stop')}     # Stop the running daemon
+${color('$ qunitx daemon status')}   # Print pid, socket, and uptime
+
+${highlight('Environment:')}
+${color('QUNITX_DAEMON=1')}     : auto-spawn the daemon on the first qunitx run; reuse it on every run after (overrides the CI=1 bypass)
+${color('QUNITX_NO_DAEMON=1')}  : never use the daemon for this run
+
+${highlight('Tip:')} set ${color('QUNITX_DAEMON=1')} to auto-spawn the daemon on the first qunitx run; ${color('$ qunitx --help')} for top-level options.
+`;
 
 const __filename = fileURLToPath(import.meta.url);
 // daemon/index.ts → ../../../cli.ts
@@ -25,14 +44,7 @@ export function runDaemonCommand(): Promise<number> {
   if (sub === 'status') return statusDaemon();
   const helpRequested = !sub || sub === '--help' || sub === '-h' || sub === 'help';
   const out = helpRequested ? process.stdout : process.stderr;
-  out.write(
-    'Usage: qunitx daemon <start|stop|status>\n' +
-      '  start   Spawn a persistent daemon for this project (~2× faster repeated runs)\n' +
-      '  stop    Stop the running daemon\n' +
-      '  status  Print whether a daemon is running\n' +
-      '\n' +
-      'Tip: set QUNITX_DAEMON=1 to auto-spawn the daemon on the first qunitx run.\n',
-  );
+  out.write(USAGE);
   return Promise.resolve(helpRequested ? 0 : 1);
 }
 

--- a/lib/commands/daemon/index.ts
+++ b/lib/commands/daemon/index.ts
@@ -1,10 +1,10 @@
 import { spawn } from 'node:child_process';
+import fs, { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { daemonSocketPath } from '../../utils/daemon-socket-path.ts';
-import { pingDaemon, shutdownDaemon, tryConnect } from './client.ts';
+import { daemonInfoPath, daemonSocketPath } from '../../utils/daemon-socket-path.ts';
+import { pingDaemon, shutdownDaemon } from './client.ts';
 
-const SPAWN_POLL_INTERVAL_MS = 100;
 const SPAWN_TIMEOUT_MS = 10_000;
 
 const __filename = fileURLToPath(import.meta.url);
@@ -38,9 +38,53 @@ async function runServeMode(): Promise<number> {
 }
 
 /**
- * Spawns a detached daemon process and polls until it answers a ping.
- * Returns the running daemon's pid on success, `null` on timeout. Used by both
- * the explicit `daemon start` and the auto-spawn path from cli.ts.
+ * Event-driven wait for `filePath` to appear, bounded by `timeoutMs`. Subscribes via
+ * `fs.watch` on the parent directory — kernel notifications (inotify / FSEvents /
+ * ReadDirectoryChangesW) deliver events sub-ms after file creation, so detection
+ * latency is OS-bound, not poll-interval-bound, and zero CPU is burned between events.
+ *
+ * Two `existsSync` calls bracket the watcher attachment to close the TOCTOU gap:
+ * the file may appear between the entry-point check and `fs.watch` actually being
+ * subscribed in the kernel.
+ */
+function waitForFile(filePath: string, timeoutMs: number): Promise<boolean> {
+  if (existsSync(filePath)) return Promise.resolve(true);
+  return new Promise<boolean>((resolve) => {
+    const dir = path.dirname(filePath);
+    const fileName = path.basename(filePath);
+    let settled = false;
+    const settle = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      watcher.close();
+      resolve(ok);
+    };
+    const timer = setTimeout(() => settle(false), timeoutMs);
+    const watcher = fs.watch(dir, (_event, name) => {
+      // Reconfirm with existsSync — fs.watch fires for both create and unlink.
+      if (name === fileName && existsSync(filePath)) settle(true);
+    });
+    watcher.on('error', () => settle(false));
+    // Re-check now that the kernel watch is live (TOCTOU close).
+    if (existsSync(filePath)) settle(true);
+  });
+}
+
+/**
+ * Spawns a detached daemon process and waits for it to be *fully* ready.
+ *
+ * Two signals must both be true before we return success:
+ *
+ * 1. The info file exists at `daemonInfoPath()`. The daemon writes this *after*
+ *    `listen()` resolves, so its presence is the first observable signal that
+ *    startup is complete. We wait for it via `fs.watch` — event-driven, no polling.
+ * 2. `pingDaemon()` returns a `pong`. Confirms the daemon is actually accepting
+ *    connections (rules out a stale info file from a crashed previous daemon).
+ *
+ * Either signal alone is insufficient: pong-only races the post-listen writeFile
+ * (sub-ms on Linux, tens of ms on Windows NTFS); file-only would falsely accept
+ * stale presence sentinels. Both must hold.
  */
 async function spawnAndWaitForDaemon(): Promise<{ pid: number } | null> {
   // Detached so the daemon outlives the current shell. stdio: 'ignore' detaches all
@@ -51,16 +95,9 @@ async function spawnAndWaitForDaemon(): Promise<{ pid: number } | null> {
     env: { ...process.env, QUNITX_DAEMON_CWD: process.cwd() },
   }).unref();
 
-  const deadline = Date.now() + SPAWN_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, SPAWN_POLL_INTERVAL_MS));
-    const sock = await tryConnect();
-    if (!sock) continue;
-    sock.destroy();
-    const pong = await pingDaemon();
-    if (pong && pong.type === 'pong') return { pid: pong.pid };
-  }
-  return null;
+  if (!(await waitForFile(daemonInfoPath(), SPAWN_TIMEOUT_MS))) return null;
+  const pong = await pingDaemon();
+  return pong?.type === 'pong' ? { pid: pong.pid } : null;
 }
 
 /**
@@ -69,14 +106,13 @@ async function spawnAndWaitForDaemon(): Promise<{ pid: number } | null> {
  * intended for the cli.ts auto-spawn path where the spawn is incidental to the run.
  */
 export async function ensureDaemonRunning(): Promise<boolean> {
-  const existing = await pingDaemon();
-  if (existing && existing.type === 'pong') return true;
+  if ((await pingDaemon())?.type === 'pong') return true;
   return Boolean(await spawnAndWaitForDaemon());
 }
 
 async function startDaemon(): Promise<number> {
   const existing = await pingDaemon();
-  if (existing && existing.type === 'pong') {
+  if (existing?.type === 'pong') {
     process.stdout.write(`Daemon already running (pid ${existing.pid})\n`);
     return 0;
   }
@@ -97,7 +133,7 @@ async function stopDaemon(): Promise<number> {
 
 async function statusDaemon(): Promise<number> {
   const pong = await pingDaemon();
-  if (!pong || pong.type !== 'pong') {
+  if (pong?.type !== 'pong') {
     process.stdout.write('No daemon running for this project\n');
     return 1;
   }

--- a/lib/commands/daemon/index.ts
+++ b/lib/commands/daemon/index.ts
@@ -7,7 +7,17 @@ import { daemonInfoPath, daemonSocketPath } from '../../utils/daemon-socket-path
 import { pingDaemon, shutdownDaemon } from './client.ts';
 import pkg from '../../../package.json' with { type: 'json' };
 
-const SPAWN_TIMEOUT_MS = 10_000;
+// Daemon startup chains: cli.ts import → setupConfig → launchBrowser (chromium
+// connect) → listen() → writeFile(info). Observed timings:
+//   Linux/macOS: typical 0.8–2 s, worst observed ~5 s.
+//   Windows under heavy CI load: typical 4–8 s, worst observed ~12 s
+//     (run 25088766035 timed out at the previous 10 s budget).
+// 30 s is biased hard toward flake-prevention: a false timeout (legit-slow startup
+// hits the deadline) costs a red CI run and a re-run, while a true timeout (daemon
+// genuinely won't start) just adds ~20 s before the user gets an error — rare and
+// tolerable. Stays under DEFAULT_EXEC_TIMEOUT_MS (60 s) so test runs that wrap
+// `daemon start` keep envelope headroom.
+const SPAWN_TIMEOUT_MS = 30_000;
 
 const highlight = (text: string): string => magenta().bold(text);
 const color = (text: string): string => blue(text);
@@ -137,7 +147,7 @@ async function startDaemon(): Promise<number> {
     process.stdout.write(`Daemon started (pid ${result.pid})\n`);
     return 0;
   }
-  process.stderr.write('Daemon did not start within 10s\n');
+  process.stderr.write(`Daemon did not start within ${SPAWN_TIMEOUT_MS / 1000}s\n`);
   return 1;
 }
 

--- a/lib/commands/daemon/protocol.ts
+++ b/lib/commands/daemon/protocol.ts
@@ -1,0 +1,59 @@
+// NDJSON protocol between daemon client and daemon server.
+// One JSON object per line. Client writes a single Request; daemon streams
+// any number of stdout/stderr chunks ending with a `done` (or `fatal`) message.
+
+/** Client → daemon: request to execute a test run with the given argv/env in the daemon's persistent Chrome. */
+export interface RunRequest {
+  /** Discriminator for the protocol union; always `'run'` for this variant. */
+  type: 'run';
+  /** CLI arguments after `qunitx` (i.e. `process.argv.slice(2)`). */
+  argv: string[];
+  /** Client's working directory. The daemon rejects mismatched cwds (different project). */
+  cwd: string;
+  /** Client's full process environment, applied to the run and restored on completion. */
+  env: Record<string, string | undefined>;
+  /** Client's `process.version`. The daemon shuts down on mismatch to avoid module-graph drift. */
+  nodeVersion: string;
+}
+
+/** Client → daemon: liveness/identity probe. */
+export interface PingRequest {
+  /** Discriminator; always `'ping'`. */
+  type: 'ping';
+}
+
+/** Client → daemon: graceful shutdown request. */
+export interface ShutdownRequest {
+  /** Discriminator; always `'shutdown'`. */
+  type: 'shutdown';
+}
+
+/** Discriminated union of every request the daemon accepts. */
+export type Request = RunRequest | PingRequest | ShutdownRequest;
+
+/** Daemon → client: one streamed response chunk in the per-request stream. */
+export type ResponseChunk =
+  /** Forwarded `process.stdout.write` chunk from the run. */
+  | { type: 'stdout'; data: string }
+  /** Forwarded `process.stderr.write` chunk from the run. */
+  | { type: 'stderr'; data: string }
+  /** Reply to a `PingRequest` with daemon identity + uptime fields. */
+  | { type: 'pong'; pid: number; nodeVersion: string; cwd: string; startedAt: number }
+  /** Terminal message of a successful run; carries the captured exit code. */
+  | { type: 'done'; exitCode: number }
+  /** Terminal message of a failed run (validation error, internal exception, or pre-shutdown notify). */
+  | { type: 'fatal'; message: string };
+
+/** Sidecar JSON file written next to the socket; lets `daemon status` show details without an IPC roundtrip. */
+export interface DaemonInfo {
+  /** OS process id of the running daemon. */
+  pid: number;
+  /** Absolute path to the daemon's listening Unix socket. */
+  socketPath: string;
+  /** Working directory the daemon was started in (matches its socket-path hash). */
+  cwd: string;
+  /** Daemon's `process.version` at startup. */
+  nodeVersion: string;
+  /** Epoch ms when the daemon began listening. */
+  startedAt: number;
+}

--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -44,13 +44,16 @@ interface DaemonState {
   /** Reset to 0 after any run that left the browser connected. */
   consecutiveCrashes: number;
   /**
-   * Set to `true` immediately after `listen()` resolves. Gates file cleanup in
-   * `shutdownDaemon`: a process whose `listen()` failed (EADDRINUSE in a concurrent
-   * spawn race) does not own the socket or info file and must NOT unlink them — the
-   * winner does. Writes happen sync-after-await so no signal can interleave between
-   * `listen()` returning and the flag being set.
+   * `true` after `listen()` resolves. Gates file cleanup in `shutdownDaemon`: a
+   * process whose `listen()` failed (concurrent-spawn EADDRINUSE) does not own the
+   * socket or info file, so the loser must not unlink them — only the winner does.
    */
   listenSucceeded: boolean;
+  /**
+   * Single-source esbuild incremental-context cache, persisted across daemon runs.
+   * Mutated by reference inside `buildIncrementally`; disposed on daemon shutdown.
+   */
+  esbuildCache: NonNullable<Config['_daemonEsbuildCache']>;
 }
 
 /**
@@ -105,6 +108,7 @@ export async function runDaemonServer(): Promise<void> {
     infoPath,
     consecutiveCrashes: 0,
     listenSucceeded: false,
+    esbuildCache: { _esbuildContext: null },
   };
 
   const shutdown = (reason: string) => shutdownDaemon(state, reason);
@@ -184,14 +188,14 @@ async function shutdownDaemon(state: DaemonState, reason: string): Promise<void>
   }
 
   await new Promise<void>((resolve) => state.socketServer.close(() => resolve()));
-  // Only unlink files if THIS process actually owns them. A daemon whose listen()
-  // failed (concurrent-spawn race: lost to EADDRINUSE) reaches this path via the
-  // unhandledRejection handler, but the winner owns the socket + info file —
-  // unlinking would corrupt the winner's reachability state.
+  // Only unlink files this process actually owns. A daemon whose listen() failed
+  // (concurrent-spawn race: lost to EADDRINUSE) reaches this path via unhandled-
+  // Rejection but doesn't own the socket/info — unlinking corrupts the winner.
   await Promise.all([
     state.listenSucceeded ? unlink(state.socketPath).catch(() => {}) : null,
     state.listenSucceeded ? unlink(state.infoPath).catch(() => {}) : null,
     state.browser.close().catch(() => {}),
+    state.esbuildCache._esbuildContext?.dispose().catch(() => {}),
   ]);
   process.exit(0);
 }
@@ -395,10 +399,13 @@ async function runOnce(
   }
 
   // _daemonBrowser tells run() to reuse the persistent browser; _daemonMode tells
-  // it to throw DaemonRunError instead of calling process.exit at the end. watch/open
-  // are forced off — those modes don't make sense inside a daemon run.
+  // it to throw DaemonRunError instead of calling process.exit at the end;
+  // _daemonEsbuildCache hands buildTestBundle the persistent incremental-context
+  // slot so the warm module graph survives across runs. watch/open are forced off
+  // — those modes don't make sense inside a daemon run.
   config._daemonMode = true;
   config._daemonBrowser = state.browser;
+  config._daemonEsbuildCache = state.esbuildCache;
   config.watch = false;
   config.open = false;
 

--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -5,20 +5,12 @@ import path from 'node:path';
 import { daemonSocketPath, daemonInfoPath } from '../../utils/daemon-socket-path.ts';
 import { attachLineParser, probeSocket } from './socket-utils.ts';
 import { setupConfig } from '../../setup/config.ts';
-import { setupBrowser, launchBrowser } from '../../setup/browser.ts';
-import {
-  buildTestBundle,
-  runTestsInBrowser,
-  DaemonRunError,
-  flushConsoleHandlers,
-} from '../run/tests-in-browser.ts';
-import { writeOutputStaticFiles } from '../../setup/write-output-static-files.ts';
-import { runUserModule } from '../../utils/run-user-module.ts';
-import { closeWithGrace } from '../../utils/close-with-grace.ts';
-import { buildCachedContent } from '../run.ts';
+import { launchBrowser } from '../../setup/browser.ts';
+import { DaemonRunError } from '../run/tests-in-browser.ts';
+import { run } from '../run.ts';
 import type { Request, ResponseChunk, RunRequest, DaemonInfo } from './protocol.ts';
 import type { Browser } from 'playwright-core';
-import type { Config, Connections } from '../../types.ts';
+import type { Config } from '../../types.ts';
 
 // Daemon idle window: 30 minutes after the last run finishes, the daemon shuts itself
 // down. Long enough for typical bursts, short enough that a forgotten daemon reclaims
@@ -336,9 +328,11 @@ async function recoverBrowser(state: DaemonState): Promise<void> {
 }
 
 /**
- * Performs one test run inside the daemon: re-parses argv via setupConfig, builds the
- * test bundle, opens a fresh page in the daemon's persistent browser, runs tests, and
- * closes per-run resources. The browser stays alive for the next run.
+ * Performs one test run inside the daemon by delegating to `run()` — the same code
+ * path local non-watch invocations use, but with `_daemonMode` set so it reuses the
+ * daemon's persistent browser and throws `DaemonRunError` instead of `process.exit`.
+ * Concurrent group orchestration, timing-cache persistence, and after-hook all come
+ * for free from the shared run pipeline.
  */
 async function runOnce(
   argv: string[],
@@ -361,57 +355,29 @@ async function runOnce(
     process.argv = argvSnapshot;
   }
 
-  // Daemon never runs watch / open / concurrent multi-group flows.
+  // _daemonBrowser tells run() to reuse the persistent browser; _daemonMode tells
+  // it to throw DaemonRunError instead of calling process.exit at the end. watch/open
+  // are forced off — those modes don't make sense inside a daemon run.
   config._daemonMode = true;
+  config._daemonBrowser = state.browser;
   config.watch = false;
   config.open = false;
 
-  const cachedContent = await buildCachedContent(config, config.htmlPaths);
-
-  let connections: Connections | null = null;
-  let exitCode = 0;
-  const fileCount = Object.keys(config.fsTree).length;
-
   try {
-    await buildTestBundle(config, cachedContent);
-    connections = await setupBrowser(config, cachedContent, state.browser);
-    config.webServer = connections.server;
-    await writeOutputStaticFiles(config, cachedContent);
-
-    if (config.before) await runUserModule(`${process.cwd()}/${config.before}`, config, 'before');
-
-    // One TAP version 13 header per daemon run; web-server.ts suppresses its
-    // per-WS-connection emission when _daemonMode is set.
-    process.stdout.write('TAP version 13\n');
-    process.stdout.write(
-      `# Running ${fileCount} test file${fileCount === 1 ? '' : 's'} (daemon)\n`,
-    );
-
-    // runTestsInBrowser handles 0-tests warning, TAPDisplayFinalResult, and the after
-    // hook itself in !_groupMode; on the success path it throws DaemonRunError instead
-    // of process.exit when _daemonMode is set.
-    try {
-      await runTestsInBrowser(config, cachedContent, connections);
-      // Defensive fallback if runTestsInBrowser ever returns without throwing in daemon mode.
-      exitCode = config.COUNTER.failCount > 0 ? 1 : 0;
-    } catch (err) {
-      if (err instanceof DaemonRunError) exitCode = err.exitCode;
-      else throw err;
-    }
+    await run(config);
+    // run() throws DaemonRunError on success in daemon mode; reaching here means it
+    // returned without exiting — fall back on the counter.
+    return config.COUNTER.failCount > 0 ? 1 : 0;
+  } catch (err) {
+    if (err instanceof DaemonRunError) return err.exitCode;
+    throw err;
   } finally {
-    await flushConsoleHandlers(config._pendingConsoleHandlers).catch(() => {});
-    if (connections) {
-      // Per-run cleanup — never close the daemon's persistent browser.
-      await closeWithGrace([connections.page?.close(), connections.server?.close()]);
-    }
     // Restore env: drop keys added during the run, restore changed values.
     for (const key of Object.keys(process.env)) {
       if (!(key in envSnapshot)) delete process.env[key];
     }
     Object.assign(process.env, envSnapshot);
   }
-
-  return exitCode;
 }
 
 async function isLiveSocket(socketPath: string): Promise<boolean> {

--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -28,9 +28,15 @@ const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 // returns ECONNREFUSED almost immediately; the timeout only kicks in when the OS is
 // momentarily slow.
 const LIVENESS_PROBE_TIMEOUT_MS = 500;
+// After this many back-to-back browser crashes (no successful run between), the daemon
+// gives up rather than entering a relaunch loop. Two attempts catches the common case
+// (one transient crash followed by recovery) without papering over a broken environment.
+const MAX_CONSECUTIVE_CRASHES = 2;
 
 interface DaemonState {
   browser: Browser;
+  /** Captured at startup; used to relaunch the browser on crash recovery. */
+  baseConfig: Config;
   cwd: string;
   startedAt: number;
   pkgMtime: number;
@@ -43,6 +49,8 @@ interface DaemonState {
   idleTimer: NodeJS.Timeout | null;
   socketPath: string;
   infoPath: string;
+  /** Reset to 0 after any run that left the browser connected. */
+  consecutiveCrashes: number;
 }
 
 /**
@@ -80,6 +88,7 @@ export async function runDaemonServer(): Promise<void> {
 
   const state: DaemonState = {
     browser,
+    baseConfig,
     cwd,
     startedAt: Date.now(),
     pkgMtime,
@@ -90,6 +99,7 @@ export async function runDaemonServer(): Promise<void> {
     idleTimer: null,
     socketPath,
     infoPath,
+    consecutiveCrashes: 0,
   };
 
   const shutdown = (reason: string) => shutdownDaemon(state, reason);
@@ -257,6 +267,17 @@ async function handleRun(req: RunRequest, socket: net.Socket, state: DaemonState
 
   if (state.idleTimer) clearTimeout(state.idleTimer);
 
+  // Pre-flight browser check: relaunch if it died while the daemon was idle. Skipping
+  // this would let the run hang inside Playwright's CDP send waiting for responses
+  // from a dead Chrome until its 30s timeout fires.
+  if (!state.browser.isConnected()) {
+    await recoverBrowser(state);
+    if (state.shuttingDown) {
+      writeChunk(socket, { type: 'fatal', message: 'browser recovery failed' });
+      return void socket.end();
+    }
+  }
+
   let clientAlive = true;
   socket.on('close', () => (clientAlive = false));
 
@@ -279,11 +300,39 @@ async function handleRun(req: RunRequest, socket: net.Socket, state: DaemonState
     process.stderr.write = origStderrWrite;
   }
 
+  // Browser-crash recovery: relaunch the persistent browser if it died this run.
+  if (state.browser.isConnected()) state.consecutiveCrashes = 0;
+  else await recoverBrowser(state);
+
   if (clientAlive) {
     writeChunk(socket, { type: 'done', exitCode });
     socket.end();
   }
   resetIdleTimer(state);
+}
+
+/**
+ * Relaunches the daemon's persistent browser after a crash. Bounded by
+ * `MAX_CONSECUTIVE_CRASHES` so a broken environment shuts the daemon down instead of
+ * looping forever — the next client respawns a fresh daemon.
+ */
+async function recoverBrowser(state: DaemonState): Promise<void> {
+  if (++state.consecutiveCrashes > MAX_CONSECUTIVE_CRASHES) {
+    return void shutdownDaemon(state, `${state.consecutiveCrashes} consecutive browser crashes`);
+  }
+  process.stderr.write(
+    `# [qunitx daemon] browser crashed; relaunching (${state.consecutiveCrashes}/${MAX_CONSECUTIVE_CRASHES})\n`,
+  );
+  // Fire-and-forget close on the dead handle — awaiting browser.close() on a torn-down
+  // CDP socket hangs forever waiting for a protocol reply that never arrives.
+  // skipPrelaunch=true bypasses the singleton prelaunch endpoint (which now points at the
+  // dead Chrome) and goes straight to a fresh chromium.launch().
+  state.browser.close().catch(() => {});
+  try {
+    state.browser = await launchBrowser(state.baseConfig, true);
+  } catch (err) {
+    void shutdownDaemon(state, `browser relaunch failed: ${(err as Error).message || err}`);
+  }
 }
 
 /**

--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -76,6 +76,22 @@ export async function runDaemonServer(): Promise<void> {
   // Windows named pipes auto-recycle, and unlink on a pipe path is a no-op error we ignore).
   await unlink(socketPath).catch(() => {});
 
+  // Optional debug log: when QUNITX_DAEMON_LOG=<path> is set, redirect the daemon's
+  // stdout+stderr to that file so idle/startup/shutdown events (otherwise lost to
+  // the spawn's stdio:'ignore') become inspectable. Buffered async writes via
+  // createWriteStream; log-stream errors are swallowed so a broken log path can
+  // never crash the daemon. handleRun's per-run interceptor still works: it captures
+  // whichever write fn is current at run start, so during runs stdout flows to the
+  // client and reverts to the log fn afterwards.
+  const logPath = process.env.QUNITX_DAEMON_LOG;
+  if (logPath) {
+    const log = fs.createWriteStream(logPath, { flags: 'a' });
+    log.on('error', () => {});
+    const forward = log.write.bind(log) as typeof process.stdout.write;
+    process.stdout.write = forward;
+    process.stderr.write = forward;
+  }
+
   // setupConfig reads process.argv directly; the daemon's actual argv is `daemon _serve`
   // which would be parsed as test paths. Strip it for the startup config — we only need
   // the browser type here. Per-run argv comes from the client via runOnce.

--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -43,6 +43,14 @@ interface DaemonState {
   infoPath: string;
   /** Reset to 0 after any run that left the browser connected. */
   consecutiveCrashes: number;
+  /**
+   * Set to `true` immediately after `listen()` resolves. Gates file cleanup in
+   * `shutdownDaemon`: a process whose `listen()` failed (EADDRINUSE in a concurrent
+   * spawn race) does not own the socket or info file and must NOT unlink them — the
+   * winner does. Writes happen sync-after-await so no signal can interleave between
+   * `listen()` returning and the flag being set.
+   */
+  listenSucceeded: boolean;
 }
 
 /**
@@ -96,6 +104,7 @@ export async function runDaemonServer(): Promise<void> {
     socketPath,
     infoPath,
     consecutiveCrashes: 0,
+    listenSucceeded: false,
   };
 
   const shutdown = (reason: string) => shutdownDaemon(state, reason);
@@ -113,7 +122,19 @@ export async function runDaemonServer(): Promise<void> {
     void shutdown('server error');
   });
 
+  // listen() is the atomic at-most-one-daemon claim — only one process can bind to
+  // the socket path. Once it returns, we know we own the daemon role and can publish
+  // the info file with our identity. Writing the info file BEFORE listen would let
+  // a losing concurrent-spawn process overwrite the winner's info with its own pid,
+  // then unlink it on its own EADDRINUSE — leaving the winner with corrupted or
+  // missing presence state. The client's spawn-poll waits for both info file
+  // existence AND a successful ping, so the brief gap between listen() returning
+  // and writeFile resolving is bridged on the client side, not the server.
   await listen(state.socketServer, socketPath);
+  // Set the ownership flag in the same microtask as listen()'s resolution. Signals
+  // are delivered as macrotasks; they cannot interleave between two synchronous
+  // statements, so this flag is observed atomically with bind success.
+  state.listenSucceeded = true;
   // chmod after listen — listen creates the socket file with the default umask, which
   // can leave it world-readable. Skipped on Windows: named pipe paths don't accept
   // POSIX modes and chmod returns EPERM/EINVAL for them.
@@ -163,9 +184,13 @@ async function shutdownDaemon(state: DaemonState, reason: string): Promise<void>
   }
 
   await new Promise<void>((resolve) => state.socketServer.close(() => resolve()));
+  // Only unlink files if THIS process actually owns them. A daemon whose listen()
+  // failed (concurrent-spawn race: lost to EADDRINUSE) reaches this path via the
+  // unhandledRejection handler, but the winner owns the socket + info file —
+  // unlinking would corrupt the winner's reachability state.
   await Promise.all([
-    unlink(state.socketPath).catch(() => {}),
-    unlink(state.infoPath).catch(() => {}),
+    state.listenSucceeded ? unlink(state.socketPath).catch(() => {}) : null,
+    state.listenSucceeded ? unlink(state.infoPath).catch(() => {}) : null,
     state.browser.close().catch(() => {}),
   ]);
   process.exit(0);

--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -1,0 +1,381 @@
+import net from 'node:net';
+import fs from 'node:fs';
+import { writeFile, unlink, stat, chmod } from 'node:fs/promises';
+import path from 'node:path';
+import { daemonSocketPath, daemonInfoPath } from '../../utils/daemon-socket-path.ts';
+import { attachLineParser, probeSocket } from './socket-utils.ts';
+import { setupConfig } from '../../setup/config.ts';
+import { setupBrowser, launchBrowser } from '../../setup/browser.ts';
+import {
+  buildTestBundle,
+  runTestsInBrowser,
+  DaemonRunError,
+  flushConsoleHandlers,
+} from '../run/tests-in-browser.ts';
+import { writeOutputStaticFiles } from '../../setup/write-output-static-files.ts';
+import { runUserModule } from '../../utils/run-user-module.ts';
+import { closeWithGrace } from '../../utils/close-with-grace.ts';
+import { buildCachedContent } from '../run.ts';
+import type { Request, ResponseChunk, RunRequest, DaemonInfo } from './protocol.ts';
+import type { Browser } from 'playwright-core';
+import type { Config, Connections } from '../../types.ts';
+
+// Daemon idle window: 30 minutes after the last run finishes, the daemon shuts itself
+// down. Long enough for typical bursts, short enough that a forgotten daemon reclaims
+// resources without manual intervention.
+const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+// Liveness probe ceiling: if a stale socket file's owning process is gone, connect()
+// returns ECONNREFUSED almost immediately; the timeout only kicks in when the OS is
+// momentarily slow.
+const LIVENESS_PROBE_TIMEOUT_MS = 500;
+
+interface DaemonState {
+  browser: Browser;
+  cwd: string;
+  startedAt: number;
+  pkgMtime: number;
+  // Serial run mutex. Each run waits for the previous one to fully resolve before
+  // starting; the daemon does not multiplex Chrome across simultaneous runs.
+  runQueue: Promise<unknown>;
+  shuttingDown: boolean;
+  pendingClients: Set<net.Socket>;
+  socketServer: net.Server;
+  idleTimer: NodeJS.Timeout | null;
+  socketPath: string;
+  infoPath: string;
+}
+
+/**
+ * Daemon process entry point. Owns one persistent Chrome and one Unix socket; serves
+ * `run` requests serially. Shuts down on SIGTERM/SIGINT, idle timeout, package.json
+ * mutation, node version mismatch, or an explicit `shutdown` request.
+ */
+export async function runDaemonServer(): Promise<void> {
+  const cwd = process.cwd();
+  const socketPath = daemonSocketPath(cwd);
+  const infoPath = daemonInfoPath(cwd);
+
+  // Race-resolution: if a live daemon already runs for this cwd, the new daemon exits
+  // 0 so the client (which polls for socket availability) attaches to the winner.
+  if (fs.existsSync(socketPath) && (await isLiveSocket(socketPath))) process.exit(0);
+  // Stale socket from a previous crash — must be removed before listen().
+  await unlink(socketPath).catch(() => {});
+
+  // setupConfig reads process.argv directly; the daemon's actual argv is `daemon _serve`
+  // which would be parsed as test paths. Strip it for the startup config — we only need
+  // the browser type here. Per-run argv comes from the client via runOnce.
+  const argvSnapshot = process.argv;
+  process.argv = [argvSnapshot[0], argvSnapshot[1] ?? 'cli.ts'];
+  let baseConfig;
+  try {
+    baseConfig = await setupConfig();
+  } finally {
+    process.argv = argvSnapshot;
+  }
+  baseConfig._daemonMode = true;
+  baseConfig.watch = false;
+  baseConfig.open = false;
+
+  const [browser, pkgMtime] = await Promise.all([launchBrowser(baseConfig), readPkgMtime(cwd)]);
+
+  const state: DaemonState = {
+    browser,
+    cwd,
+    startedAt: Date.now(),
+    pkgMtime,
+    runQueue: Promise.resolve(),
+    shuttingDown: false,
+    pendingClients: new Set(),
+    socketServer: null as unknown as net.Server,
+    idleTimer: null,
+    socketPath,
+    infoPath,
+  };
+
+  const shutdown = (reason: string) => shutdownDaemon(state, reason);
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  // Any unhandled rejection corrupts shared browser state — die so the next client respawns.
+  process.on('unhandledRejection', (err) => {
+    process.stderr.write(`# [qunitx daemon] unhandledRejection: ${err}\n`);
+    void shutdown('unhandledRejection');
+  });
+
+  state.socketServer = net.createServer((socket) => handleConnection(socket, state));
+  state.socketServer.on('error', (err) => {
+    process.stderr.write(`# [qunitx daemon] server error: ${err.message}\n`);
+    void shutdown('server error');
+  });
+
+  await listen(state.socketServer, socketPath);
+  // chmod after listen — listen creates the socket file, default umask can leave it world-readable.
+  await chmod(socketPath, 0o600).catch(() => {});
+
+  const info: DaemonInfo = {
+    pid: process.pid,
+    socketPath,
+    cwd,
+    nodeVersion: process.version,
+    startedAt: state.startedAt,
+  };
+  await writeFile(infoPath, JSON.stringify(info, null, 2));
+
+  resetIdleTimer(state);
+  process.stderr.write(`# [qunitx daemon] listening on ${socketPath} (pid ${process.pid})\n`);
+
+  // Block forever. The socket server keeps the event loop alive; the daemon exits via
+  // process.exit() inside shutdownDaemon (signal, idle timeout, or shutdown request).
+  // Without this, runDaemonServer would resolve, runServeMode would return 0, and cli.ts
+  // would call process.exit(0), killing the daemon as soon as it finished listening.
+  return new Promise<void>(() => {});
+}
+
+function listen(server: net.Server, socketPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (err: Error) => reject(err);
+    server.once('error', onError);
+    server.listen(socketPath, () => {
+      server.removeListener('error', onError);
+      resolve();
+    });
+  });
+}
+
+async function shutdownDaemon(state: DaemonState, reason: string): Promise<void> {
+  if (state.shuttingDown) return;
+  state.shuttingDown = true;
+  process.stderr.write(`# [qunitx daemon] shutting down: ${reason}\n`);
+
+  if (state.idleTimer) clearTimeout(state.idleTimer);
+
+  // Notify pending clients so they fall back to a local run rather than hanging.
+  for (const sock of state.pendingClients) {
+    writeChunk(sock, { type: 'fatal', message: `daemon shutting down: ${reason}` });
+    sock.end();
+  }
+
+  await new Promise<void>((resolve) => state.socketServer.close(() => resolve()));
+  await Promise.all([
+    unlink(state.socketPath).catch(() => {}),
+    unlink(state.infoPath).catch(() => {}),
+    state.browser.close().catch(() => {}),
+  ]);
+  process.exit(0);
+}
+
+function resetIdleTimer(state: DaemonState): void {
+  if (state.idleTimer) clearTimeout(state.idleTimer);
+  // unref so the timer itself doesn't keep the event loop alive — the socket server
+  // is the only ref'd handle. When the timer fires, shutdown closes the server, the
+  // loop drains, and the process exits cleanly.
+  state.idleTimer = setTimeout(() => void shutdownDaemon(state, 'idle timeout'), IDLE_TIMEOUT_MS);
+  state.idleTimer.unref();
+}
+
+function handleConnection(socket: net.Socket, state: DaemonState): void {
+  state.pendingClients.add(socket);
+  socket.on('close', () => state.pendingClients.delete(socket));
+  // Without this handler, EPIPE from the client disconnecting crashes the daemon.
+  socket.on('error', () => {});
+  attachLineParser<Request>(socket, (req) => void dispatch(req, socket, state));
+}
+
+async function dispatch(req: Request, socket: net.Socket, state: DaemonState): Promise<void> {
+  if (req.type === 'ping') {
+    writeChunk(socket, {
+      type: 'pong',
+      pid: process.pid,
+      nodeVersion: process.version,
+      cwd: state.cwd,
+      startedAt: state.startedAt,
+    });
+    socket.end();
+  } else if (req.type === 'shutdown') {
+    writeChunk(socket, { type: 'done', exitCode: 0 });
+    socket.end();
+    void shutdownDaemon(state, 'shutdown request');
+  } else if (req.type === 'run') {
+    state.runQueue = state.runQueue.then(() => handleRun(req, socket, state));
+    await state.runQueue;
+  }
+}
+
+function writeChunk(socket: net.Socket, chunk: ResponseChunk): void {
+  if (socket.destroyed) return;
+  try {
+    socket.write(JSON.stringify(chunk) + '\n');
+  } catch {
+    /* peer gone — handled via `clientAlive` flag in handleRun */
+  }
+}
+
+/**
+ * Builds a `process.stdout.write`-compatible interceptor that forwards every chunk
+ * to the client over the socket while preserving the optional callback contract.
+ */
+function makeInterceptor(
+  socket: net.Socket,
+  type: 'stdout' | 'stderr',
+  isAlive: () => boolean,
+): typeof process.stdout.write {
+  return ((chunk: unknown, ...args: unknown[]): boolean => {
+    const str = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString('utf8');
+    if (isAlive()) writeChunk(socket, { type, data: str });
+    const cb = args[args.length - 1];
+    if (typeof cb === 'function') queueMicrotask(cb as () => void);
+    return true;
+  }) as typeof process.stdout.write;
+}
+
+async function handleRun(req: RunRequest, socket: net.Socket, state: DaemonState): Promise<void> {
+  if (state.shuttingDown) {
+    writeChunk(socket, { type: 'fatal', message: 'daemon shutting down' });
+    return void socket.end();
+  }
+  if (req.cwd !== state.cwd) {
+    writeChunk(socket, {
+      type: 'fatal',
+      message: `cwd mismatch: daemon=${state.cwd} client=${req.cwd}`,
+    });
+    return void socket.end();
+  }
+  if (req.nodeVersion !== process.version) {
+    writeChunk(socket, {
+      type: 'fatal',
+      message: `node version mismatch: daemon=${process.version} client=${req.nodeVersion}`,
+    });
+    socket.end();
+    return void shutdownDaemon(state, 'node version mismatch');
+  }
+  // Detect package.json mutation: stale config means stale extensions/browser/timeout.
+  const currentMtime = await readPkgMtime(state.cwd);
+  if (currentMtime !== state.pkgMtime) {
+    writeChunk(socket, { type: 'fatal', message: 'package.json changed; restarting daemon' });
+    socket.end();
+    return void shutdownDaemon(state, 'package.json changed');
+  }
+
+  if (state.idleTimer) clearTimeout(state.idleTimer);
+
+  let clientAlive = true;
+  socket.on('close', () => (clientAlive = false));
+
+  const origStdoutWrite = process.stdout.write.bind(process.stdout);
+  const origStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stdout.write = makeInterceptor(socket, 'stdout', () => clientAlive);
+  process.stderr.write = makeInterceptor(socket, 'stderr', () => clientAlive);
+
+  let exitCode = 0;
+  try {
+    exitCode = await runOnce(req.argv, req.env, state);
+  } catch (err) {
+    process.stderr.write = origStderrWrite;
+    origStderrWrite(`# [qunitx daemon] run error: ${(err as Error).stack || err}\n`);
+    if (clientAlive)
+      writeChunk(socket, { type: 'fatal', message: (err as Error).message || String(err) });
+    exitCode = 1;
+  } finally {
+    process.stdout.write = origStdoutWrite;
+    process.stderr.write = origStderrWrite;
+  }
+
+  if (clientAlive) {
+    writeChunk(socket, { type: 'done', exitCode });
+    socket.end();
+  }
+  resetIdleTimer(state);
+}
+
+/**
+ * Performs one test run inside the daemon: re-parses argv via setupConfig, builds the
+ * test bundle, opens a fresh page in the daemon's persistent browser, runs tests, and
+ * closes per-run resources. The browser stays alive for the next run.
+ */
+async function runOnce(
+  argv: string[],
+  env: Record<string, string | undefined>,
+  state: DaemonState,
+): Promise<number> {
+  // Snapshot env + argv, swap in client values, restore on exit. Snapshot is also the
+  // baseline so before-hook env mutations don't bleed across runs.
+  const envSnapshot = { ...process.env };
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) process.env[key] = value;
+  }
+  const argvSnapshot = process.argv;
+  process.argv = ['node', argvSnapshot[1] ?? 'cli.ts', ...argv];
+
+  let config: Config;
+  try {
+    config = await setupConfig();
+  } finally {
+    process.argv = argvSnapshot;
+  }
+
+  // Daemon never runs watch / open / concurrent multi-group flows.
+  config._daemonMode = true;
+  config.watch = false;
+  config.open = false;
+
+  const cachedContent = await buildCachedContent(config, config.htmlPaths);
+
+  let connections: Connections | null = null;
+  let exitCode = 0;
+  const fileCount = Object.keys(config.fsTree).length;
+
+  try {
+    await buildTestBundle(config, cachedContent);
+    connections = await setupBrowser(config, cachedContent, state.browser);
+    config.webServer = connections.server;
+    await writeOutputStaticFiles(config, cachedContent);
+
+    if (config.before) await runUserModule(`${process.cwd()}/${config.before}`, config, 'before');
+
+    // One TAP version 13 header per daemon run; web-server.ts suppresses its
+    // per-WS-connection emission when _daemonMode is set.
+    process.stdout.write('TAP version 13\n');
+    process.stdout.write(
+      `# Running ${fileCount} test file${fileCount === 1 ? '' : 's'} (daemon)\n`,
+    );
+
+    // runTestsInBrowser handles 0-tests warning, TAPDisplayFinalResult, and the after
+    // hook itself in !_groupMode; on the success path it throws DaemonRunError instead
+    // of process.exit when _daemonMode is set.
+    try {
+      await runTestsInBrowser(config, cachedContent, connections);
+      // Defensive fallback if runTestsInBrowser ever returns without throwing in daemon mode.
+      exitCode = config.COUNTER.failCount > 0 ? 1 : 0;
+    } catch (err) {
+      if (err instanceof DaemonRunError) exitCode = err.exitCode;
+      else throw err;
+    }
+  } finally {
+    await flushConsoleHandlers(config._pendingConsoleHandlers).catch(() => {});
+    if (connections) {
+      // Per-run cleanup — never close the daemon's persistent browser.
+      await closeWithGrace([connections.page?.close(), connections.server?.close()]);
+    }
+    // Restore env: drop keys added during the run, restore changed values.
+    for (const key of Object.keys(process.env)) {
+      if (!(key in envSnapshot)) delete process.env[key];
+    }
+    Object.assign(process.env, envSnapshot);
+  }
+
+  return exitCode;
+}
+
+async function isLiveSocket(socketPath: string): Promise<boolean> {
+  const sock = await probeSocket(socketPath, LIVENESS_PROBE_TIMEOUT_MS);
+  if (!sock) return false;
+  sock.destroy();
+  return true;
+}
+
+async function readPkgMtime(cwd: string): Promise<number> {
+  try {
+    return (await stat(path.join(cwd, 'package.json'))).mtimeMs;
+  } catch {
+    return 0;
+  }
+}

--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -257,15 +257,19 @@ function writeChunk(socket: net.Socket, chunk: ResponseChunk): void {
 /**
  * Builds a `process.stdout.write`-compatible interceptor that forwards every chunk
  * to the client over the socket while preserving the optional callback contract.
+ * Skips the toString + writeChunk hop entirely once the socket is destroyed —
+ * `socket.destroyed` flips at the moment the 'close' event fires, so this is the
+ * direct equivalent of a `clientAlive` flag without the mutation.
  */
 function makeInterceptor(
   socket: net.Socket,
   type: 'stdout' | 'stderr',
-  isAlive: () => boolean,
 ): typeof process.stdout.write {
   return ((chunk: unknown, ...args: unknown[]): boolean => {
-    const str = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString('utf8');
-    if (isAlive()) writeChunk(socket, { type, data: str });
+    if (!socket.destroyed) {
+      const str = typeof chunk === 'string' ? chunk : (chunk as Buffer).toString('utf8');
+      writeChunk(socket, { type, data: str });
+    }
     const cb = args[args.length - 1];
     if (typeof cb === 'function') queueMicrotask(cb as () => void);
     return true;
@@ -276,15 +280,13 @@ async function handleRun(req: RunRequest, socket: net.Socket, state: DaemonState
   if (state.shuttingDown) {
     writeChunk(socket, { type: 'fatal', message: 'daemon shutting down' });
     return void socket.end();
-  }
-  if (req.cwd !== state.cwd) {
+  } else if (req.cwd !== state.cwd) {
     writeChunk(socket, {
       type: 'fatal',
       message: `cwd mismatch: daemon=${state.cwd} client=${req.cwd}`,
     });
     return void socket.end();
-  }
-  if (req.nodeVersion !== process.version) {
+  } else if (req.nodeVersion !== process.version) {
     writeChunk(socket, {
       type: 'fatal',
       message: `node version mismatch: daemon=${process.version} client=${req.nodeVersion}`,
@@ -313,13 +315,10 @@ async function handleRun(req: RunRequest, socket: net.Socket, state: DaemonState
     }
   }
 
-  let clientAlive = true;
-  socket.on('close', () => (clientAlive = false));
-
   const origStdoutWrite = process.stdout.write.bind(process.stdout);
   const origStderrWrite = process.stderr.write.bind(process.stderr);
-  process.stdout.write = makeInterceptor(socket, 'stdout', () => clientAlive);
-  process.stderr.write = makeInterceptor(socket, 'stderr', () => clientAlive);
+  process.stdout.write = makeInterceptor(socket, 'stdout');
+  process.stderr.write = makeInterceptor(socket, 'stderr');
 
   let exitCode = 0;
   try {
@@ -327,7 +326,7 @@ async function handleRun(req: RunRequest, socket: net.Socket, state: DaemonState
   } catch (err) {
     process.stderr.write = origStderrWrite;
     origStderrWrite(`# [qunitx daemon] run error: ${(err as Error).stack || err}\n`);
-    if (clientAlive)
+    if (!socket.destroyed)
       writeChunk(socket, { type: 'fatal', message: (err as Error).message || String(err) });
     exitCode = 1;
   } finally {
@@ -339,7 +338,7 @@ async function handleRun(req: RunRequest, socket: net.Socket, state: DaemonState
   if (state.browser.isConnected()) state.consecutiveCrashes = 0;
   else await recoverBrowser(state);
 
-  if (clientAlive) {
+  if (!socket.destroyed) {
     writeChunk(socket, { type: 'done', exitCode });
     socket.end();
   }

--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -57,8 +57,12 @@ export async function runDaemonServer(): Promise<void> {
 
   // Race-resolution: if a live daemon already runs for this cwd, the new daemon exits
   // 0 so the client (which polls for socket availability) attaches to the winner.
-  if (fs.existsSync(socketPath) && (await isLiveSocket(socketPath))) process.exit(0);
-  // Stale socket from a previous crash — must be removed before listen().
+  // Use the info file as the presence check: existsSync(socketPath) is unreliable on
+  // Windows (named pipes don't appear on the regular filesystem). isLiveSocket actively
+  // probes via net.createConnection, which works on every platform.
+  if (fs.existsSync(infoPath) && (await isLiveSocket(socketPath))) process.exit(0);
+  // Stale socket from a previous crash — must be removed before listen() (POSIX only;
+  // Windows named pipes auto-recycle, and unlink on a pipe path is a no-op error we ignore).
   await unlink(socketPath).catch(() => {});
 
   // setupConfig reads process.argv directly; the daemon's actual argv is `daemon _serve`
@@ -110,8 +114,10 @@ export async function runDaemonServer(): Promise<void> {
   });
 
   await listen(state.socketServer, socketPath);
-  // chmod after listen — listen creates the socket file, default umask can leave it world-readable.
-  await chmod(socketPath, 0o600).catch(() => {});
+  // chmod after listen — listen creates the socket file with the default umask, which
+  // can leave it world-readable. Skipped on Windows: named pipe paths don't accept
+  // POSIX modes and chmod returns EPERM/EINVAL for them.
+  if (process.platform !== 'win32') await chmod(socketPath, 0o600).catch(() => {});
 
   const info: DaemonInfo = {
     pid: process.pid,
@@ -193,6 +199,14 @@ async function dispatch(req: Request, socket: net.Socket, state: DaemonState): P
     });
     socket.end();
   } else if (req.type === 'shutdown') {
+    // Synchronously remove the info file before acking so its absence is a reliable
+    // "daemon is gone" signal at the moment the client returns. shutdownDaemon's
+    // own async unlink is then a no-op (catch'd ENOENT).
+    try {
+      fs.unlinkSync(state.infoPath);
+    } catch {
+      /* already gone */
+    }
     writeChunk(socket, { type: 'done', exitCode: 0 });
     socket.end();
     void shutdownDaemon(state, 'shutdown request');

--- a/lib/commands/daemon/socket-utils.ts
+++ b/lib/commands/daemon/socket-utils.ts
@@ -1,5 +1,4 @@
 import net from 'node:net';
-import { existsSync } from 'node:fs';
 
 /**
  * Reads NDJSON from `socket`, dispatching each parsed object via `onLine`.
@@ -25,14 +24,14 @@ export function attachLineParser<T>(socket: net.Socket, onLine: (line: T) => voi
 }
 
 /**
- * Attempts a Unix-socket connection. Resolves the connected socket on success,
- * `null` on any failure (no socket file, ECONNREFUSED, timeout, etc.). Used as
- * a primitive by both the client (to send requests) and the server (to probe
- * whether a stale-looking socket is actually live).
+ * Attempts a connection to the given path (POSIX socket or Windows named pipe).
+ * Resolves the connected socket on success, `null` on any failure (peer absent,
+ * ECONNREFUSED, ENOENT, timeout). Lets `net.createConnection` produce the error
+ * directly — a pre-emptive `existsSync` check would not work for Windows named
+ * pipes (they live in `\\.\pipe\...`, not on the regular filesystem).
  */
 export function probeSocket(socketPath: string, timeoutMs: number): Promise<net.Socket | null> {
   return new Promise((resolve) => {
-    if (!existsSync(socketPath)) return resolve(null);
     const sock = net.createConnection(socketPath);
     const timer = setTimeout(() => {
       sock.destroy();

--- a/lib/commands/daemon/socket-utils.ts
+++ b/lib/commands/daemon/socket-utils.ts
@@ -1,0 +1,50 @@
+import net from 'node:net';
+import { existsSync } from 'node:fs';
+
+/**
+ * Reads NDJSON from `socket`, dispatching each parsed object via `onLine`.
+ * Tolerates packet splits across line boundaries; silently drops malformed lines.
+ * Used by both the daemon server (parsing client requests) and the client
+ * (parsing server responses).
+ */
+export function attachLineParser<T>(socket: net.Socket, onLine: (line: T) => void): void {
+  let buf = '';
+  socket.on('data', (chunk) => {
+    buf += chunk.toString('utf8');
+    const lines = buf.split('\n');
+    buf = lines.pop() ?? '';
+    for (const line of lines) {
+      if (!line) continue;
+      try {
+        onLine(JSON.parse(line) as T);
+      } catch {
+        /* malformed line — skip */
+      }
+    }
+  });
+}
+
+/**
+ * Attempts a Unix-socket connection. Resolves the connected socket on success,
+ * `null` on any failure (no socket file, ECONNREFUSED, timeout, etc.). Used as
+ * a primitive by both the client (to send requests) and the server (to probe
+ * whether a stale-looking socket is actually live).
+ */
+export function probeSocket(socketPath: string, timeoutMs: number): Promise<net.Socket | null> {
+  return new Promise((resolve) => {
+    if (!existsSync(socketPath)) return resolve(null);
+    const sock = net.createConnection(socketPath);
+    const timer = setTimeout(() => {
+      sock.destroy();
+      resolve(null);
+    }, timeoutMs);
+    sock.once('connect', () => {
+      clearTimeout(timer);
+      resolve(sock);
+    });
+    sock.once('error', () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+  });
+}

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -28,12 +28,18 @@ ${color('--extensions')} : comma-separated file extensions to track for discover
 ${color('--browser')} : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
 ${color('--before')} : run a script before the tests(i.e start a new web server before tests)
 ${color('--after')} : run a script after the tests(i.e save test results to a file)
+${color('--no-daemon')} : don't use the daemon for this run — skips a running daemon and prevents ${color('QUNITX_DAEMON')} auto-spawn
 
 ${highlight('Example:')} $ ${color('qunitx test/foo.ts app/e2e --debug --watch --before=scripts/start-new-webserver.js --after=scripts/write-test-results.js')}
 
 ${highlight('Commands:')}
-${color('$ qunitx init')}               # Bootstraps qunitx base html and add qunitx config to package.json if needed
-${color('$ qunitx new $testFileName')}  # Creates a qunitx test file
+${color('$ qunitx init')}                            # Bootstraps qunitx base html and add qunitx config to package.json if needed
+${color('$ qunitx new $testFileName')}               # Creates a qunitx test file
+${color('$ qunitx daemon <start|stop|status>')}      # Optional persistent daemon — ~2× faster repeated runs
+
+${highlight('Environment:')}
+${color('QUNITX_DAEMON=1')}     : auto-spawn the daemon on the first qunitx run; reuse it on every run after (overrides the CI=1 bypass)
+${color('QUNITX_NO_DAEMON=1')}  : never use the daemon for this run
 `);
 }
 

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -398,6 +398,13 @@ export async function run(config: Config): Promise<void> {
   }
 }
 
+/**
+ * Reads each HTML fixture file referenced by the config, classifies them as
+ * dynamic (have qunitx tokens, get bundle-injection at request time) or static,
+ * collects internal asset paths, and resolves the main HTML to inject the test
+ * runtime into. Returns the populated `CachedContent` consumed by `run()` and
+ * the daemon's `runOnce()`.
+ */
 async function buildCachedContent(config: Config, htmlPaths: string[]): Promise<CachedContent> {
   const htmlBuffers = await Promise.all(
     config.htmlPaths.map((htmlPath) => fs.readFile(htmlPath).catch(() => null)),
@@ -587,5 +594,5 @@ function resolveQunitxRoot(projectRoot: string): string {
   return match[1];
 }
 
-export { readTimingCache, computeFileTimes };
+export { readTimingCache, computeFileTimes, buildCachedContent };
 export { run as default };

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -322,7 +322,7 @@ export async function run(config: Config): Promise<void> {
           try {
             await runTestsInBrowser(groupConfig, groupCachedContents[i], connections);
           } finally {
-            await flushConsoleHandlers(groupConfig._pendingConsoleHandlers);
+            await flushConsoleHandlers(groupConfig._pendingConsoleHandlers, connections.page);
             // Per-group cleanup, bounded so a deadlocked page.close (Firefox/WebKit under
             // load) cannot wedge Promise.allSettled forever. The shared server is closed
             // in the final cleanup pass below, not here.

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -30,6 +30,7 @@ import { TAPDisplayFinalResult } from '../tap/display-final-result.ts';
 import { readTemplate } from '../utils/read-template.ts';
 import { isCustomTemplate } from '../utils/html.ts';
 import { closeWithGrace } from '../utils/close-with-grace.ts';
+import { maybePrintDaemonHint } from '../utils/daemon-hint.ts';
 import type { Config, CachedContent } from '../types.ts';
 
 // Playwright navigation timeout for headed watch-mode reloads (not test execution).
@@ -383,6 +384,11 @@ export async function run(config: Config): Promise<void> {
       ]);
       throw new DaemonRunError(exitCode);
     }
+
+    // First-time discoverability nudge for the daemon — only on local-mode runs that
+    // took long enough to actually benefit. shouldShowDaemonHint() handles the rest of
+    // the suppression matrix (CI / env opt-outs / TTY / sentinel).
+    await maybePrintDaemonHint({ durationMs: process.uptime() * 1000 });
 
     // Flush stdout, shut down Chrome cleanly, then exit.
     // keepAlive holds the event loop open until this callback fires, at which point

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -18,6 +18,7 @@ import {
   buildTestBundle,
   buildAllGroupBundles,
   flushConsoleHandlers,
+  DaemonRunError,
 } from './run/tests-in-browser.ts';
 import { setupFileWatchers } from '../setup/file-watcher.ts';
 import { findInternalAssetsFromHTML } from '../utils/find-internal-assets-from-html.ts';
@@ -50,7 +51,13 @@ export async function run(config: Config): Promise<void> {
   //   readTimingCache: reads tmp/test-timings.json (~2ms)
   //   buildCachedContent: reads HTML template from disk (~5-10ms)
   // Chrome is typically fully connected by the time buildCachedContent + splitIntoGroups resolve.
-  const browserPromise = config.watch ? null : launchBrowser(config);
+  // Daemon mode reuses its persistent browser; non-watch local runs launch their own;
+  // watch mode defers launch until setupBrowser inside the watch path.
+  const browserPromise = config._daemonBrowser
+    ? Promise.resolve(config._daemonBrowser)
+    : config.watch
+      ? null
+      : launchBrowser(config);
   const [cachedContent, timings] = await Promise.all([
     buildCachedContent(config, config.htmlPaths),
     config.watch
@@ -234,7 +241,7 @@ export async function run(config: Config): Promise<void> {
 
     process.stdout.write('TAP version 13\n');
     process.stdout.write(
-      `# Running ${allFiles.length} test file${allFiles.length === 1 ? '' : 's'} across ${groupCount} group${groupCount === 1 ? '' : 's'}\n`,
+      `# Running ${allFiles.length} test file${allFiles.length === 1 ? '' : 's'} across ${groupCount} group${groupCount === 1 ? '' : 's'}${config._daemonMode ? ' (daemon)' : ''}\n`,
     );
 
     // Build all group bundles and write static files while the browser is starting up.
@@ -359,6 +366,22 @@ export async function run(config: Config): Promise<void> {
 
     if (config.after) {
       await runUserModule(`${process.cwd()}/${config.after}`, config.COUNTER, 'after');
+    }
+
+    // Daemon mode: close the per-run shared server (if any) but never the browser
+    // (the daemon owns it across runs). Throw DaemonRunError so the daemon's run
+    // handler captures the exit code instead of hitting process.exit.
+    if (config._daemonMode) {
+      clearInterval(keepAlive);
+      await closeWithGrace([
+        sharedServer
+          ?.close()
+          .catch(
+            (err: Error) =>
+              config.debug && process.stderr.write(`# [qunitx] server.close: ${err.message}\n`),
+          ),
+      ]);
+      throw new DaemonRunError(exitCode);
     }
 
     // Flush stdout, shut down Chrome cleanly, then exit.

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -106,6 +106,19 @@ export function formatBuildErrors(error: unknown): string {
 }
 
 /**
+ * Cache key for the daemon/watch incremental esbuild context. Single source of truth
+ * for what makes two builds interchangeable: file set + every BuildOption that varies
+ * between runs. Items intentionally NOT keyed: `plugins` (daemon shuts down on
+ * package.json mtime change), `nodePaths` (cwd-bound, daemon stays in cwd), and the
+ * hardcoded literals (`bundle`, `keepNames`, `legalComments`, `jsx`, `sourcemap`,
+ * `footer`, `logLevel`). When adding a new variable BuildOption, extend this function
+ * — that is the contract enforced by the unit suite.
+ */
+export function bundleCacheKey(opts: esbuild.BuildOptions, files: string[]): string {
+  return JSON.stringify({ files, outfile: opts.outfile, target: opts.target });
+}
+
+/**
  * Pre-builds the esbuild bundle for all test files and caches the result in `cachedContent`.
  * @returns {Promise<void>}
  */
@@ -165,10 +178,16 @@ export async function buildTestBundle(config: Config, cachedContent: CachedConte
   cachedContent._buildError = null;
   cachedContent._noTestsWarning = null;
 
+  // Cache holder: daemon's persistent state slot for daemon-mode runs (so the
+  // incremental context survives across runs); the per-process cachedContent for
+  // watch mode (lives for the life of the watch process).
+  const cacheHolder = config._daemonEsbuildCache ?? cachedContent;
+  const fileKey = bundleCacheKey(buildOptions, allTestFilePaths);
+
   try {
     const [allTestCode] = await Promise.all([
-      config.watch
-        ? buildIncrementally(buildOptions, allTestFilePaths.join('\0'), cachedContent, needsDisk)
+      config.watch || config._daemonMode
+        ? buildIncrementally(buildOptions, fileKey, cacheHolder, needsDisk)
         : buildWithOverlayfsRetry(buildOptions, needsDisk),
       Promise.all(
         cachedContent.htmlPathsToRunTests.map(async (htmlPath) => {
@@ -638,26 +657,28 @@ function buildWithOverlayfsRetry(
   }, needsDisk);
 }
 
-// Uses an esbuild incremental context so the module graph stays warm between watch-mode
-// rebuilds. context.rebuild() re-reads changed files but skips re-parsing unchanged
-// modules, shaving ~80% off rebuild time vs a fresh esbuild.build() call.
-// The context is invalidated (disposed + replaced) whenever the set of test files changes
-// (file added or removed in watch mode), since the entry-point stdin content changes.
+// Uses an esbuild incremental context so the module graph stays warm between rebuilds.
+// context.rebuild() re-reads changed files but skips re-parsing unchanged modules, shaving
+// ~80% off rebuild time vs a fresh esbuild.build() call. The cache is single-source: when
+// the file-set changes (different `fileKey`), the old context is disposed and replaced.
+// Storage holder is whichever object owns the live cache: the per-process CachedContent in
+// watch mode, or the daemon's persistent state slot via `config._daemonEsbuildCache` in
+// daemon mode. Both expose the same `_esbuildContext` / `_esbuildContextKey` field shape.
 async function buildIncrementally(
   options: esbuild.BuildOptions,
   fileKey: string,
-  cachedContent: CachedContent,
+  cache: { _esbuildContext?: esbuild.BuildContext | null; _esbuildContextKey?: string },
   needsDisk: boolean,
 ): Promise<Buffer> {
   const buildOpts: esbuild.BuildOptions = { ...options, write: false };
 
-  if (!cachedContent._esbuildContext || cachedContent._esbuildContextKey !== fileKey) {
-    cachedContent._esbuildContext?.dispose().catch(() => {});
-    cachedContent._esbuildContext = await esbuild.context(buildOpts);
-    cachedContent._esbuildContextKey = fileKey;
+  if (!cache._esbuildContext || cache._esbuildContextKey !== fileKey) {
+    cache._esbuildContext?.dispose().catch(() => {});
+    cache._esbuildContext = await esbuild.context(buildOpts);
+    cache._esbuildContextKey = fileKey;
   }
 
-  const ctx = cachedContent._esbuildContext;
+  const ctx = cache._esbuildContext!;
   return runWithOverlayfsRetry(async () => {
     const result = await ctx.rebuild();
     const jsFile = result.outputFiles!.find((f) => !f.path.endsWith('.map'))!;

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -307,6 +307,12 @@ export async function runTestsInBrowser(
 
       if (!config.watch) {
         await flushConsoleHandlers(config._pendingConsoleHandlers);
+        // Daemon mode: the daemon owns the browser and server lifetimes, so we
+        // must not close them here. Throw instead so the daemon's run handler
+        // captures the exit code and keeps the process alive for the next run.
+        if (config._daemonMode) {
+          throw new DaemonRunError(config.COUNTER.failCount > 0 ? 1 : 0);
+        }
         await closeWithGrace([
           connections.server?.close(),
           connections.browser?.close(),
@@ -316,6 +322,9 @@ export async function runTestsInBrowser(
       }
     }
   } catch (error) {
+    // DaemonRunError signals normal completion in daemon mode (replaces process.exit);
+    // pass it through unchanged so the daemon's run handler can capture the exit code.
+    if (error instanceof DaemonRunError) throw error;
     cachedContent._activeRebuild = null;
     config.lastFailedTestFiles = config.lastRanTestFiles;
     const exception = new BundleError(error);
@@ -803,6 +812,7 @@ async function runTestInsideHTMLFile(
       { server, browser },
       config._groupMode,
       config._pendingConsoleHandlers,
+      config._daemonMode,
     );
   } else if (QUNIT_RESULT.totalTests === 0) {
     // QUnit ran but no tests were registered (or QUnit was not present in the bundle).
@@ -820,6 +830,7 @@ async function runTestInsideHTMLFile(
       { server, browser },
       config._groupMode,
       config._pendingConsoleHandlers,
+      config._daemonMode,
     );
   } else if (QUNIT_RESULT.failedTests > config.COUNTER.failCount) {
     // Safety net: browser tracked failures that WebSocket events never delivered to Node.js
@@ -833,20 +844,24 @@ async function failOnNonWatchMode(
   connections: { server?: HTTPServer; browser?: { close(): Promise<void> } } = {},
   groupMode: boolean = false,
   pendingHandlers?: Set<Promise<void>> | null,
+  daemonMode: boolean = false,
 ): Promise<void> {
-  if (!watchMode) {
-    if (groupMode) {
-      // Parent orchestrator handles cleanup and exit; signal failure via throw.
-      throw new Error('Browser test run failed');
-    }
-    await flushConsoleHandlers(pendingHandlers);
-    await closeWithGrace([
-      connections.server?.close(),
-      connections.browser?.close(),
-      shutdownPrelaunch(),
-    ]);
-    process.exit(1);
+  if (watchMode) return;
+  if (groupMode) {
+    // Parent orchestrator handles cleanup and exit; signal failure via throw.
+    throw new Error('Browser test run failed');
   }
+  await flushConsoleHandlers(pendingHandlers);
+  if (daemonMode) {
+    // Daemon owns browser/server lifetimes — throw so its run handler captures the code.
+    throw new DaemonRunError(1);
+  }
+  await closeWithGrace([
+    connections.server?.close(),
+    connections.browser?.close(),
+    shutdownPrelaunch(),
+  ]);
+  process.exit(1);
 }
 
 // Converts an absolute file path to a relative import path esbuild can resolve from
@@ -864,6 +879,22 @@ class BundleError extends Error {
     super(message);
     this.name = 'BundleError';
     this.message = `esbuild Bundle Error: ${message}`.split('\n').join('\n# ');
+  }
+}
+
+/**
+ * Thrown in daemon mode in place of `process.exit(code)` so the caller (the daemon
+ * server's run handler) can capture the exit code, restore stdout interception, and
+ * keep the daemon process alive for the next run.
+ */
+export class DaemonRunError extends Error {
+  /** The exit code that the run would have passed to `process.exit()` outside of daemon mode. */
+  exitCode: number;
+  /** Constructs a DaemonRunError carrying the run's exit code. */
+  constructor(exitCode: number) {
+    super(`daemon run finished with exit code ${exitCode}`);
+    this.name = 'DaemonRunError';
+    this.exitCode = exitCode;
   }
 }
 

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -9,6 +9,7 @@ import { runUserModule } from '../../utils/run-user-module.ts';
 import { TAPDisplayFinalResult } from '../../tap/display-final-result.ts';
 import { buildErrorHTML, buildNoTestsHTML } from '../../setup/web-server.ts';
 import { extractInlineSourceMap } from '../../utils/source-map-decoder.ts';
+import type { Page } from 'playwright-core';
 import type { Config, CachedContent, Connections } from '../../types.ts';
 import type { HTTPServer } from '../../servers/web.ts';
 
@@ -330,7 +331,7 @@ export async function runTestsInBrowser(
       }
 
       if (!config.watch) {
-        await flushConsoleHandlers(config._pendingConsoleHandlers);
+        await flushConsoleHandlers(config._pendingConsoleHandlers, connections.page);
         // Daemon mode: the daemon owns the browser and server lifetimes, so we
         // must not close them here. Throw instead so the daemon's run handler
         // captures the exit code and keeps the process alive for the next run.
@@ -387,20 +388,31 @@ export async function runTestsInBrowser(
  * Awaits all in-flight console handler promises until the Set is stably empty,
  * recursing to catch handlers added by Firefox BiDi events that arrive during each
  * await. The deadline (default 2 s) guards against infinite recursion.
+ *
+ * Pass `page` whenever the caller is about to close the page/browser. The handlers
+ * Set can otherwise look empty here only because Chrome's `Runtime.consoleAPICalled`
+ * events are still in flight on the CDP WebSocket (a separate channel from QUnit's
+ * `done` WebSocket). A no-op `page.evaluate` request enforces FIFO drain on that
+ * CDP socket: its response cannot arrive before any earlier-queued events have been
+ * read by Playwright and dispatched to `page.on('console')`, so by the time it
+ * resolves every pending handler is in the Set. Without this, late console.log()
+ * output is lost when the page closes mid-flight under concurrent CI load.
  * @returns {Promise<void>}
  */
 export async function flushConsoleHandlers(
   handlers?: Set<Promise<void>> | null,
+  page?: Page | null,
   deadline = Date.now() + CONSOLE_FLUSH_TIMEOUT_MS,
 ): Promise<void> {
   if (!handlers || Date.now() >= deadline) return;
-  // Yield one event-loop cycle so any in-flight CDP console events (which arrive on
-  // a separate TCP connection from the WebSocket 'done' event) can be processed by
-  // the I/O poll phase and register their handlers before we check the Set size.
+  // Force CDP queue drain (page may be closed already — swallow the rejection).
+  if (page) await page.evaluate(() => 0).catch(() => {});
+  // Yield once more so Promise.resolve continuations queued by the dispatch above
+  // run before we observe the Set.
   await new Promise<void>((resolve) => setImmediate(resolve));
   if (handlers.size === 0) return;
   await Promise.allSettled([...handlers]);
-  return flushConsoleHandlers(handlers, deadline);
+  return flushConsoleHandlers(handlers, page, deadline);
 }
 
 /**
@@ -835,7 +847,7 @@ async function runTestInsideHTMLFile(
     console.error('BROWSER: runtime error thrown during executing tests');
     await failOnNonWatchMode(
       config.watch,
-      { server, browser },
+      { server, browser, page },
       config._groupMode,
       config._pendingConsoleHandlers,
       config._daemonMode,
@@ -853,7 +865,7 @@ async function runTestInsideHTMLFile(
     console.error(`BROWSER: TEST TIMED OUT: ${QUNIT_RESULT.currentTest}`);
     await failOnNonWatchMode(
       config.watch,
-      { server, browser },
+      { server, browser, page },
       config._groupMode,
       config._pendingConsoleHandlers,
       config._daemonMode,
@@ -867,7 +879,7 @@ async function runTestInsideHTMLFile(
 
 async function failOnNonWatchMode(
   watchMode: boolean = false,
-  connections: { server?: HTTPServer; browser?: { close(): Promise<void> } } = {},
+  connections: { server?: HTTPServer; browser?: { close(): Promise<void> }; page?: Page } = {},
   groupMode: boolean = false,
   pendingHandlers?: Set<Promise<void>> | null,
   daemonMode: boolean = false,
@@ -877,7 +889,7 @@ async function failOnNonWatchMode(
     // Parent orchestrator handles cleanup and exit; signal failure via throw.
     throw new Error('Browser test run failed');
   }
-  await flushConsoleHandlers(pendingHandlers);
+  await flushConsoleHandlers(pendingHandlers, connections.page);
   if (daemonMode) {
     // Daemon owns browser/server lifetimes — throw so its run handler captures the code.
     throw new DaemonRunError(1);

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -36,10 +36,15 @@ const EMPTY_BUNDLE_THRESHOLD = 500;
 // Extra ms added on top of config.timeout to give Playwright time to commit the navigation
 // before the test-race timers even start. Floors startupMs/testsJsMs for tiny --timeout values.
 const NAV_GRACE_MS = 10_000;
-// Hard floor for the page.goto timeout, regardless of config.timeout. Without this, small
-// --timeout values (e.g. --timeout=500 used in timeout-feature tests) produce a navMs of only
-// 10.5s, which is not enough for Firefox on Windows CI to navigate a localhost page under load.
-const MIN_NAV_MS = 30_000;
+// Max tolerated slowdown over NAV_GRACE_MS before declaring the navigation broken.
+// 6× covers the Firefox/Windows CI tail under 3-way concurrent-group load; the prior
+// 3× floor (30_000) had zero headroom over default config.timeout + NAV_GRACE_MS
+// (20s + 10s = 30s). Chromium never approaches 5s for the same op so this is no-op.
+const MAX_NAV_SLOWDOWN_FACTOR = 6;
+// Floor for page.goto, derived from NAV_GRACE_MS not config.timeout: navigation is
+// environment-bound (browser launch + OS scheduling + port setup) and must not shrink
+// when the user passes a small --timeout.
+const MIN_NAV_MS = NAV_GRACE_MS * MAX_NAV_SLOWDOWN_FACTOR;
 // Startup safety-net: Chrome WS 'open' must arrive within 3× config.timeout.
 const STARTUP_TIMEOUT_FACTOR = 3;
 // tests.js compile safety-net: V8 compilation must finish within 4× config.timeout from serve.

--- a/lib/setup/browser.ts
+++ b/lib/setup/browser.ts
@@ -22,16 +22,20 @@ perfLog('browser.js: playwright-core import started');
  * For chromium: connects via CDP to the pre-launched Chrome (fast path) or falls
  * back to chromium.launch() if pre-launch failed.
  * For firefox/webkit: uses playwright's standard launch (requires `npx playwright install [browser]`).
+ *
+ * @param skipPrelaunch When true, bypasses the prelaunch CDP path entirely and goes
+ * straight to a fresh chromium.launch(). Used by the daemon's crash-recovery path —
+ * prelaunch is a one-shot startup optimization and recovery needs a fresh browser.
  * @returns {Promise<object>}
  */
-export async function launchBrowser(config: Config): Promise<Browser> {
+export async function launchBrowser(config: Config, skipPrelaunch = false): Promise<Browser> {
   const browserName = config.browser || 'chromium';
 
   if (browserName === 'chromium') {
     const waitStart = Date.now();
     const [playwrightCore, prelaunch] = await Promise.all([
       playwrightCorePromise,
-      prelaunchPromise,
+      skipPrelaunch ? Promise.resolve(null) : prelaunchPromise,
     ]);
     perfLog(
       `browser.js: playwright-core + prelaunch resolved in ${Date.now() - waitStart}ms, prelaunch:`,

--- a/lib/setup/web-server.ts
+++ b/lib/setup/web-server.ts
@@ -91,7 +91,9 @@ export function setupWebServer(config: Config, cachedContent: CachedContent): HT
         config._onWsOpen?.();
       } else if (event === 'connection') {
         config._phase = 'running';
-        if (!config._groupMode) process.stdout.write('TAP version 13\n');
+        // In daemon mode the daemon emits one TAP version 13 header per run before the
+        // run starts; suppressing here keeps the stream parser-clean across runs.
+        if (!config._groupMode && !config._daemonMode) process.stdout.write('TAP version 13\n');
         if (config.debug && config._groupMode) debugGroupHeader(config);
         config._resetTestTimeout?.();
       } else if (event === 'testEnd' && !abort) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -142,6 +142,13 @@ export interface Config {
   _onTestsJsServed: (() => void) | null;
   /** `true` while running a grouped (multi-file) test invocation. */
   _groupMode?: boolean;
+  /**
+   * `true` when running inside the persistent daemon process. Disables `process.exit`
+   * paths in the run pipeline (replaced with `DaemonRunError` throws), suppresses the
+   * per-WS-connection TAP version 13 header, and prevents the daemon's shared browser
+   * from being closed at the end of a run.
+   */
+  _daemonMode?: boolean;
   /** Index within the concurrent group array; set when a shared HTTP server is used. */
   _groupId?: number;
   /** Current lifecycle phase of the test run. */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -155,6 +155,15 @@ export interface Config {
    * passes its own browser here so concurrent group runs share one warm Chrome.
    */
   _daemonBrowser?: import('playwright-core').Browser;
+  /**
+   * The daemon's persistent esbuild incremental-context slot. Single source of truth
+   * for the warm module graph across daemon runs; replaced (dispose+recreate) when
+   * `bundleCacheKey()` changes — same correctness behavior as the cache-less path.
+   */
+  _daemonEsbuildCache?: {
+    _esbuildContext?: import('esbuild').BuildContext | null;
+    _esbuildContextKey?: string;
+  };
   /** Index within the concurrent group array; set when a shared HTTP server is used. */
   _groupId?: number;
   /** Current lifecycle phase of the test run. */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -149,6 +149,12 @@ export interface Config {
    * from being closed at the end of a run.
    */
   _daemonMode?: boolean;
+  /**
+   * The daemon's persistent Browser instance. When set, `run()` reuses it instead of
+   * calling `launchBrowser()`, and skips closing it at the end of the run. The daemon
+   * passes its own browser here so concurrent group runs share one warm Chrome.
+   */
+  _daemonBrowser?: import('playwright-core').Browser;
   /** Index within the concurrent group array; set when a shared HTTP server is used. */
   _groupId?: number;
   /** Current lifecycle phase of the test run. */

--- a/lib/utils/chrome-prelaunch.ts
+++ b/lib/utils/chrome-prelaunch.ts
@@ -33,9 +33,9 @@ const { browserFromArgv, openFromArgv, watchFromArgv } = process.argv.reduce(
     watchFromArgv: false,
   },
 );
-// If the daemon is reachable for this cwd and the run is daemon-eligible (not watch,
-// not open, not CI, not opted out), the run will be dispatched over the socket and
-// no local Chrome is needed. Skipping the prelaunch saves the ~150ms spawn cost.
+// If the run will go through the daemon (existing socket OR QUNITX_DAEMON=1
+// auto-spawn) and the invocation is daemon-eligible, no local Chrome is needed —
+// skipping the prelaunch saves the ~150ms spawn cost.
 const isDaemonClientRun =
   isRunCommand &&
   cmd !== 'daemon' &&
@@ -44,7 +44,7 @@ const isDaemonClientRun =
   !process.env.CI &&
   !process.env.QUNITX_NO_DAEMON &&
   !process.argv.includes('--no-daemon') &&
-  existsSync(daemonSocketPath());
+  (Boolean(process.env.QUNITX_DAEMON) || existsSync(daemonSocketPath()));
 // With --open --watch, Chrome is left alive after qunitx exits so the visible browser window persists.
 // With --open alone, qunitx exits after tests complete; the detached browser is opened separately.
 const openWatchMode = openFromArgv && watchFromArgv;

--- a/lib/utils/chrome-prelaunch.ts
+++ b/lib/utils/chrome-prelaunch.ts
@@ -1,8 +1,10 @@
+import { existsSync } from 'node:fs';
 import { findChrome } from './find-chrome.ts';
 import { preLaunchChrome } from './pre-launch-chrome.ts';
 import { killProcessGroup } from './kill-process-group.ts';
 import { CHROMIUM_ARGS } from './chromium-args.ts';
 import { perfLog } from './perf-logger.ts';
+import { daemonSocketPath } from './daemon-socket-path.ts';
 
 // This module is statically imported by cli.ts so its module-level code runs
 // at the very start of the process — before the IIFE, before playwright-core loads.
@@ -11,7 +13,11 @@ import { perfLog } from './perf-logger.ts';
 // For help/init/generate, nothing is spawned and this module costs ~0ms.
 
 const NON_RUN_COMMANDS = new Set(['help', 'h', 'p', 'print', 'new', 'n', 'g', 'generate', 'init']);
-const isRunCommand = Boolean(process.argv[2]) && !NON_RUN_COMMANDS.has(process.argv[2]);
+const cmd = process.argv[2];
+// `daemon _serve` is the daemon's own process — it DOES need Chrome. Other daemon
+// subcommands (start/stop/status) are pure client ops and never need Chrome.
+const isDaemonControlCmd = cmd === 'daemon' && process.argv[3] !== '_serve';
+const isRunCommand = Boolean(cmd) && !NON_RUN_COMMANDS.has(cmd) && !isDaemonControlCmd;
 const { browserFromArgv, openFromArgv, watchFromArgv } = process.argv.reduce(
   (flags, arg) => {
     if (arg.startsWith('--browser=')) flags.browserFromArgv = arg.slice(10);
@@ -27,6 +33,18 @@ const { browserFromArgv, openFromArgv, watchFromArgv } = process.argv.reduce(
     watchFromArgv: false,
   },
 );
+// If the daemon is reachable for this cwd and the run is daemon-eligible (not watch,
+// not open, not CI, not opted out), the run will be dispatched over the socket and
+// no local Chrome is needed. Skipping the prelaunch saves the ~150ms spawn cost.
+const isDaemonClientRun =
+  isRunCommand &&
+  cmd !== 'daemon' &&
+  !watchFromArgv &&
+  !openFromArgv &&
+  !process.env.CI &&
+  !process.env.QUNITX_NO_DAEMON &&
+  !process.argv.includes('--no-daemon') &&
+  existsSync(daemonSocketPath());
 // With --open --watch, Chrome is left alive after qunitx exits so the visible browser window persists.
 // With --open alone, qunitx exits after tests complete; the detached browser is opened separately.
 const openWatchMode = openFromArgv && watchFromArgv;
@@ -70,7 +88,10 @@ export async function shutdownPrelaunch(): Promise<void> {
  * the binary correctly and is used directly in browser.ts.
  */
 export const prelaunchPromise =
-  isRunCommand && browserFromArgv === 'chromium' && process.platform !== 'darwin'
+  isRunCommand &&
+  !isDaemonClientRun &&
+  browserFromArgv === 'chromium' &&
+  process.platform !== 'darwin'
     ? findChrome()
         .then((chromePath) => {
           perfLog('chrome-prelaunch.ts: findChrome resolved', chromePath);

--- a/lib/utils/chrome-prelaunch.ts
+++ b/lib/utils/chrome-prelaunch.ts
@@ -35,15 +35,16 @@ const { browserFromArgv, openFromArgv, watchFromArgv } = process.argv.reduce(
 );
 // If the run will go through the daemon (existing socket OR QUNITX_DAEMON=1
 // auto-spawn) and the invocation is daemon-eligible, no local Chrome is needed —
-// skipping the prelaunch saves the ~150ms spawn cost.
+// skipping the prelaunch saves the ~150ms spawn cost. CI is bypassed by default
+// but QUNITX_DAEMON=1 overrides (mirrors the precedence in client.ts).
 const isDaemonClientRun =
   isRunCommand &&
   cmd !== 'daemon' &&
   !watchFromArgv &&
   !openFromArgv &&
-  !process.env.CI &&
   !process.env.QUNITX_NO_DAEMON &&
   !process.argv.includes('--no-daemon') &&
+  (!process.env.CI || Boolean(process.env.QUNITX_DAEMON)) &&
   // Check the info file rather than the socket path: on Windows the socket is a named
   // pipe (\\.\pipe\...), which existsSync cannot see. The info file is always a regular
   // file in os.tmpdir() and is created/removed in lockstep with the daemon's lifetime.

--- a/lib/utils/chrome-prelaunch.ts
+++ b/lib/utils/chrome-prelaunch.ts
@@ -4,7 +4,7 @@ import { preLaunchChrome } from './pre-launch-chrome.ts';
 import { killProcessGroup } from './kill-process-group.ts';
 import { CHROMIUM_ARGS } from './chromium-args.ts';
 import { perfLog } from './perf-logger.ts';
-import { daemonSocketPath } from './daemon-socket-path.ts';
+import { daemonInfoPath } from './daemon-socket-path.ts';
 
 // This module is statically imported by cli.ts so its module-level code runs
 // at the very start of the process — before the IIFE, before playwright-core loads.
@@ -44,7 +44,10 @@ const isDaemonClientRun =
   !process.env.CI &&
   !process.env.QUNITX_NO_DAEMON &&
   !process.argv.includes('--no-daemon') &&
-  (Boolean(process.env.QUNITX_DAEMON) || existsSync(daemonSocketPath()));
+  // Check the info file rather than the socket path: on Windows the socket is a named
+  // pipe (\\.\pipe\...), which existsSync cannot see. The info file is always a regular
+  // file in os.tmpdir() and is created/removed in lockstep with the daemon's lifetime.
+  (Boolean(process.env.QUNITX_DAEMON) || existsSync(daemonInfoPath()));
 // With --open --watch, Chrome is left alive after qunitx exits so the visible browser window persists.
 // With --open alone, qunitx exits after tests complete; the detached browser is opened separately.
 const openWatchMode = openFromArgv && watchFromArgv;

--- a/lib/utils/daemon-hint.ts
+++ b/lib/utils/daemon-hint.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+// Runs faster than this don't benefit enough from the daemon to justify the nag.
+const FAST_RUN_THRESHOLD_MS = 500;
+
+const HINT_TEXT =
+  '\n\x1b[34mℹ\x1b[39m Tip: export QUNITX_DAEMON=1 for ~2× faster repeated runs ' +
+  '(qunitx daemon --help)\n';
+
+const DEFAULT_SENTINEL = path.join(os.homedir(), '.cache', 'qunitx', 'hint-shown');
+
+/** Run context consumed by the daemon-hint eligibility check. */
+export interface HintContext {
+  /** Total wall-clock the run took, in ms. Used against the fast-run threshold. */
+  durationMs: number;
+  /** True if the run is `--watch` mode (manages its own browser lifecycle — bypass). */
+  watch?: boolean;
+  /** True if this is the daemon process itself running the work — never hint. */
+  daemonMode?: boolean;
+  /** Environment to inspect for opt-outs. Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Override TTY detection (defaults to `process.stderr.isTTY`). Used in tests. */
+  isTTY?: boolean;
+}
+
+/** Side-effect injection points for `maybePrintDaemonHint` — testing seams. */
+export interface PrintOpts {
+  /** Sentinel-file path (defaults to `~/.cache/qunitx/hint-shown`). */
+  sentinelPath?: string;
+  /** Writer function (defaults to `process.stderr.write`). */
+  write?: (text: string) => void;
+}
+
+/**
+ * Pure check: returns true iff the run context permits the hint. Covers env-var
+ * opt-outs, watch / daemon modes (own browser lifecycle), CI (auto-bypassed),
+ * the fast-run threshold, and TTY presence. No filesystem access.
+ */
+export function shouldShowDaemonHint(ctx: HintContext): boolean {
+  const env = ctx.env ?? process.env;
+  if (ctx.watch) return false;
+  if (ctx.daemonMode) return false;
+  if (env.CI) return false;
+  if (env.QUNITX_DAEMON) return false;
+  if (env.QUNITX_NO_DAEMON) return false;
+  if (env.QUNITX_HINT_SHOWN) return false;
+  if (ctx.durationMs < FAST_RUN_THRESHOLD_MS) return false;
+  if (ctx.isTTY === false) return false;
+  if (ctx.isTTY === undefined && !process.stderr.isTTY) return false;
+  return true;
+}
+
+/**
+ * Prints the daemon-mode tip to stderr and creates a sentinel file so the tip is
+ * shown at most once per machine — users who already know about the daemon
+ * shouldn't be nagged. All filesystem I/O is best-effort: a sentinel-write
+ * failure just means the hint shows again on the next eligible run.
+ */
+export async function maybePrintDaemonHint(ctx: HintContext, opts: PrintOpts = {}): Promise<void> {
+  if (!shouldShowDaemonHint(ctx)) return;
+  const sentinel = opts.sentinelPath ?? DEFAULT_SENTINEL;
+  try {
+    await fs.access(sentinel);
+    return;
+  } catch {
+    // Sentinel not present — proceed with show + create.
+  }
+  (opts.write ?? ((t) => process.stderr.write(t)))(HINT_TEXT);
+  try {
+    await fs.mkdir(path.dirname(sentinel), { recursive: true });
+    await fs.writeFile(sentinel, new Date().toISOString());
+  } catch {
+    // Best-effort.
+  }
+}

--- a/lib/utils/daemon-socket-path.ts
+++ b/lib/utils/daemon-socket-path.ts
@@ -1,0 +1,27 @@
+import { createHash } from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+
+// Socket path is derived from the cwd hash so each project gets its own daemon.
+// Hash truncated to 12 hex chars: 48 bits, collision-resistant for the small set
+// of cwds a developer machine ever uses simultaneously.
+function cwdHash(cwd: string): string {
+  return createHash('sha256').update(cwd).digest('hex').slice(0, 12);
+}
+
+/**
+ * Returns the per-cwd Unix socket path the daemon listens on. Same cwd → same path,
+ * so any project gets at most one daemon regardless of how it is invoked.
+ */
+export function daemonSocketPath(cwd: string = process.cwd()): string {
+  return path.join(os.tmpdir(), `qunitx-daemon-${cwdHash(cwd)}.sock`);
+}
+
+/**
+ * Returns the per-cwd sidecar JSON path that mirrors the daemon's socket. Lets
+ * `daemon status` introspect daemon identity (pid, node version, uptime) without
+ * an IPC roundtrip.
+ */
+export function daemonInfoPath(cwd: string = process.cwd()): string {
+  return path.join(os.tmpdir(), `qunitx-daemon-${cwdHash(cwd)}.json`);
+}

--- a/lib/utils/daemon-socket-path.ts
+++ b/lib/utils/daemon-socket-path.ts
@@ -10,17 +10,29 @@ function cwdHash(cwd: string): string {
 }
 
 /**
- * Returns the per-cwd Unix socket path the daemon listens on. Same cwd → same path,
- * so any project gets at most one daemon regardless of how it is invoked.
+ * Returns the per-cwd path the daemon listens on. Platform-specific:
+ *
+ * - POSIX: a Unix domain socket file under `os.tmpdir()` (`/tmp/qunitx-daemon-<hash>.sock`).
+ * - Windows: a named pipe under the special `\\.\pipe\` namespace
+ *   (`\\.\pipe\qunitx-daemon-<hash>`). Node maps `net.Server.listen(pipePath)` to a
+ *   Win32 named pipe; a regular tmpdir filesystem path silently fails to bind.
+ *
+ * `platform` is parameterized for testability; it defaults to `process.platform`.
  */
-export function daemonSocketPath(cwd: string = process.cwd()): string {
-  return path.join(os.tmpdir(), `qunitx-daemon-${cwdHash(cwd)}.sock`);
+export function daemonSocketPath(
+  cwd: string = process.cwd(),
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const name = `qunitx-daemon-${cwdHash(cwd)}`;
+  if (platform === 'win32') return `\\\\.\\pipe\\${name}`;
+  return path.join(os.tmpdir(), `${name}.sock`);
 }
 
 /**
  * Returns the per-cwd sidecar JSON path that mirrors the daemon's socket. Lets
  * `daemon status` introspect daemon identity (pid, node version, uptime) without
- * an IPC roundtrip.
+ * an IPC roundtrip, and serves as the cross-platform "is a daemon present?" sentinel
+ * since Windows named pipes are not visible on the regular filesystem.
  */
 export function daemonInfoPath(cwd: string = process.cwd()): string {
   return path.join(os.tmpdir(), `qunitx-daemon-${cwdHash(cwd)}.json`);

--- a/test/commands/build-test.ts
+++ b/test/commands/build-test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { buildTestBundle } from '../../lib/commands/run/tests-in-browser.ts';
+import { buildTestBundle, bundleCacheKey } from '../../lib/commands/run/tests-in-browser.ts';
 import type { Config, CachedContent } from '../../lib/types.ts';
 
 const CWD = process.cwd();
@@ -63,10 +63,9 @@ module(
         await buildTestBundle(config, cached);
 
         assert.ok(cached._esbuildContext, 'esbuild context is created');
-        assert.strictEqual(
-          cached._esbuildContextKey,
-          FILE_A,
-          'context key equals the single test file path',
+        assert.ok(
+          cached._esbuildContextKey?.includes(FILE_A),
+          'context key encodes the single test file path',
         );
         assert.ok(cached.allTestCode, 'allTestCode is populated');
         assert.ok(
@@ -119,10 +118,10 @@ module(
           firstContext,
           'a new context is created when the file set changes',
         );
-        assert.strictEqual(
-          cached._esbuildContextKey,
-          [FILE_A, FILE_B].join('\0'),
-          'context key reflects both files',
+        const newKey = cached._esbuildContextKey ?? '';
+        assert.ok(
+          newKey.includes(FILE_A) && newKey.includes(FILE_B),
+          'context key encodes both files',
         );
       } finally {
         await disposeCached(cached);
@@ -375,3 +374,39 @@ async function disposeCached(cached: CachedContent): Promise<void> {
     cached._esbuildContext = null;
   }
 }
+
+module('Commands | bundleCacheKey', { concurrency: true }, () => {
+  // Regression contract: every BuildOption that varies between runs MUST be in the key.
+  // If someone adds a new variable option (e.g. a future --debug toggle wiring through
+  // to `sourcemap`) without updating bundleCacheKey, one of these tests should catch it.
+  const baseOpts = { outfile: '/tmp/a/tests.js', target: ['chrome120'] };
+  const baseFiles = ['/proj/a.ts', '/proj/b.ts'];
+
+  test('same inputs produce the same key', (assert) => {
+    assert.equal(bundleCacheKey(baseOpts, baseFiles), bundleCacheKey(baseOpts, baseFiles));
+  });
+
+  test('outfile change → different key (covers --output between daemon runs)', (assert) => {
+    const k1 = bundleCacheKey({ ...baseOpts, outfile: '/tmp/a/tests.js' }, baseFiles);
+    const k2 = bundleCacheKey({ ...baseOpts, outfile: '/tmp/b/tests.js' }, baseFiles);
+    assert.notEqual(k1, k2);
+  });
+
+  test('target change → different key (covers --browser between daemon runs)', (assert) => {
+    const k1 = bundleCacheKey({ ...baseOpts, target: ['chrome120'] }, baseFiles);
+    const k2 = bundleCacheKey({ ...baseOpts, target: ['firefox115'] }, baseFiles);
+    assert.notEqual(k1, k2);
+  });
+
+  test('test-file set change → different key (file added)', (assert) => {
+    const k1 = bundleCacheKey(baseOpts, ['/proj/a.ts']);
+    const k2 = bundleCacheKey(baseOpts, ['/proj/a.ts', '/proj/b.ts']);
+    assert.notEqual(k1, k2);
+  });
+
+  test('test-file order change → different key (intentional — order affects bundle output)', (assert) => {
+    const k1 = bundleCacheKey(baseOpts, ['/proj/a.ts', '/proj/b.ts']);
+    const k2 = bundleCacheKey(baseOpts, ['/proj/b.ts', '/proj/a.ts']);
+    assert.notEqual(k1, k2);
+  });
+});

--- a/test/commands/build-test.ts
+++ b/test/commands/build-test.ts
@@ -63,8 +63,12 @@ module(
         await buildTestBundle(config, cached);
 
         assert.ok(cached._esbuildContext, 'esbuild context is created');
+        // Parse the key rather than substring-checking — the JSON encoding escapes
+        // backslashes on Windows, which makes substring assertions implicitly
+        // platform-specific. The contract is "files are encoded in the key".
+        const parsedKey = JSON.parse(cached._esbuildContextKey ?? '{}') as { files?: string[] };
         assert.ok(
-          cached._esbuildContextKey?.includes(FILE_A),
+          parsedKey.files?.includes(FILE_A),
           'context key encodes the single test file path',
         );
         assert.ok(cached.allTestCode, 'allTestCode is populated');
@@ -118,9 +122,9 @@ module(
           firstContext,
           'a new context is created when the file set changes',
         );
-        const newKey = cached._esbuildContextKey ?? '';
+        const newKey = JSON.parse(cached._esbuildContextKey ?? '{}') as { files?: string[] };
         assert.ok(
-          newKey.includes(FILE_A) && newKey.includes(FILE_B),
+          newKey.files?.includes(FILE_A) && newKey.files?.includes(FILE_B),
           'context key encodes both files',
         );
       } finally {

--- a/test/commands/daemon-test.ts
+++ b/test/commands/daemon-test.ts
@@ -1,0 +1,285 @@
+import { module, test } from 'qunitx';
+import process from 'node:process';
+import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { promisify } from 'node:util';
+import { exec } from 'node:child_process';
+import { daemonSocketPath, daemonInfoPath } from '../../lib/utils/daemon-socket-path.ts';
+import '../helpers/custom-asserts.ts';
+
+const CWD = process.cwd();
+const shellExec = promisify(exec);
+
+// Each daemon test removes QUNITX_NO_DAEMON from the env so its own `node cli.ts <test>`
+// invocations actually route through the daemon. The runner sets QUNITX_NO_DAEMON=1
+// globally so other test files don't accidentally route through this test's daemon
+// while it's alive (the socket path is per-cwd and there is one project cwd in the suite).
+const CLI_ENV = (() => {
+  const env = { ...process.env, FORCE_COLOR: '0' };
+  delete env.QUNITX_NO_DAEMON;
+  return env;
+})();
+
+interface CliResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+const cli = (
+  args: string,
+  opts: { failOk?: boolean; env?: NodeJS.ProcessEnv } = {},
+): Promise<CliResult> =>
+  shellExec(`node ${CWD}/cli.ts ${args}`, { env: opts.env ?? CLI_ENV }).then(
+    ({ stdout, stderr }) => ({ stdout, stderr, code: 0 }),
+    (err: NodeJS.ErrnoException & { stdout: string; stderr: string }) => {
+      if (opts.failOk)
+        return { stdout: err.stdout, stderr: err.stderr, code: err.code as unknown as number };
+      throw err;
+    },
+  );
+
+const SOCKET_PATH = daemonSocketPath(CWD);
+const INFO_PATH = daemonInfoPath(CWD);
+
+async function ensureDaemonStopped(): Promise<void> {
+  // Best-effort cleanup — tolerates a missing daemon (`stop` is idempotent).
+  await cli('daemon stop').catch(() => {});
+  // Defensive: drop a stale socket file that a crashed daemon may have left behind.
+  await fs.unlink(SOCKET_PATH).catch(() => {});
+  await fs.unlink(INFO_PATH).catch(() => {});
+}
+
+const FIXTURE_PASS = 'test/fixtures/passing-tests.ts';
+const FIXTURE_FAIL = 'test/fixtures/failing-tests.ts';
+
+// Daemon tests must run serially: they share a single per-cwd socket path. Concurrent
+// tests would step on each other's daemon state.
+module('Commands | Daemon | usage', { concurrency: false }, () => {
+  test('$ qunitx daemon -> prints usage and exits 0', async (assert) => {
+    const result = await cli('daemon');
+
+    assert.exitCode(result, 0);
+    const text = result.stdout + result.stderr;
+    assert.includes(text, 'Usage: qunitx daemon');
+    assert.includes(text, 'start');
+    assert.includes(text, 'stop');
+    assert.includes(text, 'status');
+  });
+
+  test('$ qunitx daemon foobar -> prints usage and exits 1', async (assert) => {
+    const result = await cli('daemon foobar', { failOk: true });
+
+    assert.exitCode(result, 1);
+    assert.includes(result.stderr, 'Usage: qunitx daemon');
+  });
+});
+
+module('Commands | Daemon | lifecycle', { concurrency: false }, () => {
+  test('status with no daemon running -> exit 1, "No daemon running"', async (assert) => {
+    await ensureDaemonStopped();
+    const result = await cli('daemon status', { failOk: true });
+
+    assert.exitCode(result, 1);
+    assert.includes(result, 'No daemon running');
+  });
+
+  test('stop with no daemon running -> exit 0, "No daemon was running"', async (assert) => {
+    await ensureDaemonStopped();
+    const result = await cli('daemon stop');
+
+    assert.exitCode(result, 0);
+    assert.includes(result, 'No daemon was running');
+  });
+
+  test('start -> exit 0, "Daemon started", socket + info files exist', async (assert) => {
+    await ensureDaemonStopped();
+    try {
+      const result = await cli('daemon start');
+
+      assert.exitCode(result, 0);
+      assert.includes(result, 'Daemon started');
+      assert.regex(result, /pid \d+/);
+      assert.ok(existsSync(SOCKET_PATH), 'socket file exists');
+      assert.ok(existsSync(INFO_PATH), 'info file exists');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('status with daemon running -> exit 0 with full details', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const result = await cli('daemon status');
+
+      assert.exitCode(result, 0);
+      assert.includes(result, 'Daemon running');
+      assert.regex(result, /pid:\s+\d+/);
+      assert.includes(result, `cwd:     ${CWD}`);
+      assert.regex(result, /node:\s+v\d+/);
+      assert.includes(result, `socket:  ${SOCKET_PATH}`);
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('start when already running -> exit 0, "already running"', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const result = await cli('daemon start');
+
+      assert.exitCode(result, 0);
+      assert.includes(result, 'already running');
+      assert.regex(result, /pid \d+/);
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('stop while running -> exit 0, removes socket + info files', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    assert.ok(existsSync(SOCKET_PATH), 'socket exists pre-stop');
+
+    const result = await cli('daemon stop');
+
+    assert.exitCode(result, 0);
+    assert.includes(result, 'Daemon stopped');
+    assert.notOk(existsSync(SOCKET_PATH), 'socket file removed');
+    assert.notOk(existsSync(INFO_PATH), 'info file removed');
+  });
+
+  test('start cleans up a stale socket file from a crashed daemon', async (assert) => {
+    await ensureDaemonStopped();
+    // Simulate a stale socket from a crashed daemon — file exists but no listener.
+    // The daemon's `isLiveSocket` probe returns false; it `unlink`s and re-listens.
+    await fs.writeFile(SOCKET_PATH, '');
+    assert.ok(existsSync(SOCKET_PATH), 'stale socket file present pre-start');
+
+    try {
+      const result = await cli('daemon start');
+
+      assert.exitCode(result, 0);
+      assert.includes(result, 'Daemon started');
+      const stats = await fs.stat(SOCKET_PATH);
+      assert.ok(stats.isSocket(), 'socket file is a live socket post-start');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+});
+
+module('Commands | Daemon | run routing', { concurrency: false }, () => {
+  test('passing test through daemon -> exit 0 and TAP marks "(daemon)"', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const result = await cli(FIXTURE_PASS);
+
+      assert.exitCode(result, 0);
+      assert.includes(result, 'TAP version 13');
+      assert.includes(result, '(daemon)');
+      assert.includes(result, '# pass 3');
+      assert.includes(result, '# fail 0');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('failing test through daemon -> exit 1, TAP shows failures', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const result = await cli(FIXTURE_FAIL, { failOk: true });
+
+      assert.exitCode(result, 1);
+      assert.includes(result, '(daemon)');
+      assert.regex(result, /# fail [1-9]/);
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('two consecutive daemon-routed runs both succeed (warm context reuse)', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const r1 = await cli(FIXTURE_PASS);
+      const r2 = await cli(FIXTURE_PASS);
+
+      assert.exitCode(r1, 0);
+      assert.exitCode(r2, 0);
+      assert.includes(r1, '# pass 3');
+      assert.includes(r2, '# pass 3');
+      assert.includes(r1, '(daemon)');
+      assert.includes(r2, '(daemon)');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('TAP version 13 header appears exactly once per daemon-routed run', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const result = await cli(FIXTURE_PASS);
+      const matches = result.stdout.match(/^TAP version 13\b/gm) || [];
+
+      assert.strictEqual(
+        matches.length,
+        1,
+        `expected exactly one TAP version header, got ${matches.length}`,
+      );
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+});
+
+module('Commands | Daemon | bypass', { concurrency: false }, () => {
+  test('--no-daemon bypasses a running daemon (no "(daemon)" suffix)', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const result = await cli(`--no-daemon ${FIXTURE_PASS}`);
+
+      assert.exitCode(result, 0);
+      assert.includes(result, '# pass 3');
+      assert.notIncludes(result, '(daemon)');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('QUNITX_NO_DAEMON env var bypasses a running daemon', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const result = await cli(FIXTURE_PASS, {
+        env: { ...CLI_ENV, QUNITX_NO_DAEMON: '1' },
+      });
+
+      assert.exitCode(result, 0);
+      assert.includes(result, '# pass 3');
+      assert.notIncludes(result, '(daemon)');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('CI env var bypasses a running daemon', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const result = await cli(FIXTURE_PASS, { env: { ...CLI_ENV, CI: '1' } });
+
+      assert.exitCode(result, 0);
+      assert.includes(result, '# pass 3');
+      assert.notIncludes(result, '(daemon)');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+});

--- a/test/commands/daemon-test.ts
+++ b/test/commands/daemon-test.ts
@@ -160,6 +160,51 @@ module('Commands | Daemon | lifecycle', { concurrency: false }, () => {
     }
   });
 
+  test('concurrent daemon start invocations converge on a single live daemon', async (assert) => {
+    // Two simultaneous starts exercise THREE invariants in one test:
+    //
+    // 1. Atomic claim: listen() is the only at-most-one operation; whichever
+    //    process binds first wins. The loser hits EADDRINUSE.
+    // 2. Listen-failure cleanup correctness: the loser's shutdown must NOT unlink
+    //    the winner's socket/info files. Without the `listenSucceeded` gate this
+    //    silently corrupts the winner — info file vanishes, POSIX socket dirent
+    //    is removed, the running daemon becomes unreachable to new clients while
+    //    its own fds keep working. Catastrophic and silent.
+    // 3. Convergent client view: both clients' polls — which require BOTH info
+    //    file presence AND a live ping — must report the SAME surviving daemon's
+    //    pid. A pid mismatch would mean one client returned during a brief
+    //    inconsistent window.
+    //
+    // The single-iteration "info file exists at start return" lifecycle test
+    // covers the basic startup contract. This test is the strictly stronger
+    // regression — it would catch every race the lifecycle test catches, plus
+    // listen-failure corruption that single-process tests can't reach.
+    await ensureDaemonStopped();
+    const [r1, r2] = await Promise.all([cli('daemon start'), cli('daemon start')]);
+    try {
+      assert.exitCode(r1, 0, 'first start exited 0');
+      assert.exitCode(r2, 0, 'second start exited 0');
+
+      // Both "Daemon started (pid N)" and "Daemon already running (pid N)" carry
+      // the surviving pid; either match shape is acceptable.
+      const pid1 = Number(/pid (\d+)/.exec(r1.stdout)?.[1]);
+      const pid2 = Number(/pid (\d+)/.exec(r2.stdout)?.[1]);
+      assert.ok(Number.isInteger(pid1) && pid1 > 0, `client 1 reported pid (got ${pid1})`);
+      assert.ok(Number.isInteger(pid2) && pid2 > 0, `client 2 reported pid (got ${pid2})`);
+      assert.equal(pid1, pid2, 'both clients converge on the same surviving daemon pid');
+
+      // Loser's listen-failure path must NOT have unlinked the winner's files.
+      assert.ok(existsSync(INFO_PATH), 'winner info file intact after concurrent race');
+
+      const status = await cli('daemon status');
+      assert.exitCode(status, 0);
+      const statusPid = Number(/pid:\s+(\d+)/.exec(status.stdout)?.[1]);
+      assert.equal(statusPid, pid1, 'status reports the surviving daemon pid');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
   test('start cleans up a stale socket file from a crashed daemon', async (assert) => {
     // POSIX-only: simulating a stale socket requires writing a regular file at the
     // socket path. Windows sockets are named pipes (\\.\pipe\...) — fs.writeFile to

--- a/test/commands/daemon-test.ts
+++ b/test/commands/daemon-test.ts
@@ -51,6 +51,7 @@ async function ensureDaemonStopped(): Promise<void> {
 }
 
 const FIXTURE_PASS = 'test/fixtures/passing-tests.ts';
+const FIXTURE_PASS_JS = 'test/fixtures/passing-tests.js';
 const FIXTURE_FAIL = 'test/fixtures/failing-tests.ts';
 
 // Daemon tests must run serially: they share a single per-cwd socket path. Concurrent
@@ -232,6 +233,43 @@ module('Commands | Daemon | run routing', { concurrency: false }, () => {
         1,
         `expected exactly one TAP version header, got ${matches.length}`,
       );
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('multi-file run uses concurrent groups inside the daemon', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const result = await cli(`${FIXTURE_PASS} ${FIXTURE_PASS_JS}`);
+
+      assert.exitCode(result, 0);
+      // 2 files × 3 passing tests each = 6 total
+      assert.includes(result, '# pass 6');
+      assert.includes(result, '# fail 0');
+      // The "(daemon)" tag rides on the same `# Running ...` line as group count.
+      assert.regex(result, /# Running 2 test files across \d+ groups? \(daemon\)/);
+      // Exactly one TAP header even though each group's web-server fires its own
+      // 'connection' event — the suppress-in-daemon-mode check must hold.
+      const headers = result.stdout.match(/^TAP version 13\b/gm) || [];
+      assert.strictEqual(headers.length, 1, 'one TAP version header for the whole run');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('multi-file run with one failing file -> exit 1, fails counted', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const result = await cli(`${FIXTURE_PASS} ${FIXTURE_FAIL}`, { failOk: true });
+
+      assert.exitCode(result, 1);
+      // Passing fixture contributes 3 passes, failing fixture has at least one fail.
+      assert.regex(result, /# pass [3-9]/);
+      assert.regex(result, /# fail [1-9]/);
+      assert.includes(result, '(daemon)');
     } finally {
       await ensureDaemonStopped();
     }

--- a/test/commands/daemon-test.ts
+++ b/test/commands/daemon-test.ts
@@ -283,3 +283,140 @@ module('Commands | Daemon | bypass', { concurrency: false }, () => {
     }
   });
 });
+
+module('Commands | Daemon | crash recovery', { concurrency: false }, () => {
+  // Linux-only: relies on /proc/<pid>/task/<pid>/children to find the daemon's Chrome.
+  // macOS/Windows lack a portable equivalent; the recovery code path itself is the same.
+  const isLinux = process.platform === 'linux';
+
+  test('daemon relaunches Chrome after it is SIGKILLed', async (assert) => {
+    if (!isLinux) return assert.ok(true, 'skipped on non-linux');
+
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const before = await cli(FIXTURE_PASS);
+      assert.includes(before, '# pass 3');
+
+      const daemonPid = await readDaemonPid();
+      const killed = await killDaemonChrome(daemonPid);
+      assert.ok(killed, "killed daemon's Chrome process");
+      // Give Playwright's CDP transport a moment to flag the connection dead.
+      await new Promise((r) => setTimeout(r, 200));
+
+      const after = await cli(FIXTURE_PASS);
+      assert.exitCode(after, 0);
+      assert.includes(after, '# pass 3');
+      assert.includes(after, '(daemon)');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('successful run resets the crash counter (consecutive crashes survive)', async (assert) => {
+    if (!isLinux) return assert.ok(true, 'skipped on non-linux');
+
+    // Two back-to-back kill+run cycles. If the counter were not reset by the successful
+    // run between, the second cycle would push the daemon past MAX_CONSECUTIVE_CRASHES
+    // and the third invocation (status check) would fail.
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const startupPid = await readDaemonPid();
+
+      // Cycle 1
+      const cycle1Killed = await killDaemonChrome(startupPid);
+      assert.ok(cycle1Killed, 'cycle 1: killed Chrome');
+      await new Promise((r) => setTimeout(r, 200));
+      const cycle1 = await cli(FIXTURE_PASS);
+      assert.exitCode(cycle1, 0);
+      assert.includes(cycle1, '# pass 3');
+
+      // Cycle 2
+      const cycle2Killed = await killDaemonChrome(startupPid);
+      assert.ok(cycle2Killed, 'cycle 2: killed Chrome');
+      await new Promise((r) => setTimeout(r, 200));
+      const cycle2 = await cli(FIXTURE_PASS);
+      assert.exitCode(cycle2, 0);
+      assert.includes(cycle2, '# pass 3');
+
+      // Daemon must still be the same process (not restarted, not dead).
+      const status = await cli('daemon status');
+      assert.exitCode(status, 0);
+      const stillAlivePid = Number(/pid:\s+(\d+)/.exec(status.stdout)?.[1]);
+      assert.strictEqual(stillAlivePid, startupPid, 'daemon process survived both crash cycles');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('post-run check recovers when Chrome dies during the run', async (assert) => {
+    if (!isLinux) return assert.ok(true, 'skipped on non-linux');
+
+    // Race condition: kill Chrome while a run is in flight. That run will fail (browser
+    // mid-test died), but the daemon's post-run check must detect the disconnected
+    // browser and relaunch so the *next* run succeeds.
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      await cli(FIXTURE_PASS); // warm-up: ensures daemon is ready
+
+      const daemonPid = await readDaemonPid();
+      // Schedule the kill ~150ms in. The fixture takes ~140ms; the kill almost always
+      // lands while page.goto / WS handshake / first test is in flight.
+      const killTimer = setTimeout(() => {
+        void killDaemonChrome(daemonPid);
+      }, 150);
+
+      const inFlight = await cli(FIXTURE_PASS, { failOk: true });
+      clearTimeout(killTimer);
+
+      // The in-flight run may either complete (kill landed too late) or fail (kill
+      // killed Chrome mid-run). Either is acceptable — what matters is that the next
+      // run succeeds, proving the daemon recovered rather than getting stuck.
+      assert.ok(
+        inFlight.code === 0 || inFlight.code === 1,
+        `in-flight run produced an exit code (got ${inFlight.code})`,
+      );
+
+      const next = await cli(FIXTURE_PASS);
+      assert.exitCode(next, 0);
+      assert.includes(next, '# pass 3');
+      assert.includes(next, '(daemon)');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+});
+
+async function readDaemonPid(): Promise<number> {
+  const status = await cli('daemon status');
+  const pid = Number(/pid:\s+(\d+)/.exec(status.stdout)?.[1]);
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error(`daemon status did not report a valid pid:\n${status.stdout}`);
+  }
+  return pid;
+}
+
+/**
+ * Kills only the daemon's direct Chrome child (filters by `chrome` in cmdline so the
+ * esbuild service child stays alive). Returns true if at least one Chrome was killed.
+ */
+async function killDaemonChrome(daemonPid: number): Promise<boolean> {
+  const childrenRaw = await fs
+    .readFile(`/proc/${daemonPid}/task/${daemonPid}/children`, 'utf8')
+    .catch(() => '');
+  const childPids = childrenRaw.trim().split(/\s+/).filter(Boolean).map(Number);
+  let killedAny = false;
+  for (const pid of childPids) {
+    const cmdline = await fs.readFile(`/proc/${pid}/cmdline`, 'utf8').catch(() => '');
+    if (!/chrome/i.test(cmdline)) continue;
+    try {
+      process.kill(pid, 'SIGKILL');
+      killedAny = true;
+    } catch {
+      /* already dead */
+    }
+  }
+  return killedAny;
+}

--- a/test/commands/daemon-test.ts
+++ b/test/commands/daemon-test.ts
@@ -97,7 +97,7 @@ module('Commands | Daemon | lifecycle', { concurrency: false }, () => {
     assert.includes(result, 'No daemon was running');
   });
 
-  test('start -> exit 0, "Daemon started", socket + info files exist', async (assert) => {
+  test('start -> exit 0, "Daemon started", info file exists', async (assert) => {
     await ensureDaemonStopped();
     try {
       const result = await cli('daemon start');
@@ -105,7 +105,8 @@ module('Commands | Daemon | lifecycle', { concurrency: false }, () => {
       assert.exitCode(result, 0);
       assert.includes(result, 'Daemon started');
       assert.regex(result, /pid \d+/);
-      assert.ok(existsSync(SOCKET_PATH), 'socket file exists');
+      // Info file is the cross-platform presence sentinel — on Windows the socket is
+      // a named pipe and existsSync(SOCKET_PATH) cannot see it.
       assert.ok(existsSync(INFO_PATH), 'info file exists');
     } finally {
       await ensureDaemonStopped();
@@ -143,20 +144,28 @@ module('Commands | Daemon | lifecycle', { concurrency: false }, () => {
     }
   });
 
-  test('stop while running -> exit 0, removes socket + info files', async (assert) => {
+  test('stop while running -> exit 0, removes info file', async (assert) => {
     await ensureDaemonStopped();
     await cli('daemon start');
-    assert.ok(existsSync(SOCKET_PATH), 'socket exists pre-stop');
+    assert.ok(existsSync(INFO_PATH), 'info file exists pre-stop');
 
     const result = await cli('daemon stop');
 
     assert.exitCode(result, 0);
     assert.includes(result, 'Daemon stopped');
-    assert.notOk(existsSync(SOCKET_PATH), 'socket file removed');
     assert.notOk(existsSync(INFO_PATH), 'info file removed');
+    // Socket is a named pipe on Windows (no fs entry) — only assert on POSIX.
+    if (process.platform !== 'win32') {
+      assert.notOk(existsSync(SOCKET_PATH), 'socket file removed');
+    }
   });
 
   test('start cleans up a stale socket file from a crashed daemon', async (assert) => {
+    // POSIX-only: simulating a stale socket requires writing a regular file at the
+    // socket path. Windows sockets are named pipes (\\.\pipe\...) — fs.writeFile to
+    // that path is not a valid operation, and stale named pipes auto-recycle anyway.
+    if (process.platform === 'win32') return assert.ok(true, 'skipped on win32');
+
     await ensureDaemonStopped();
     // Simulate a stale socket from a crashed daemon — file exists but no listener.
     // The daemon's `isLiveSocket` probe returns false; it `unlink`s and re-listens.

--- a/test/commands/daemon-test.ts
+++ b/test/commands/daemon-test.ts
@@ -10,13 +10,17 @@ import '../helpers/custom-asserts.ts';
 const CWD = process.cwd();
 const shellExec = promisify(exec);
 
-// Each daemon test removes QUNITX_NO_DAEMON from the env so its own `node cli.ts <test>`
-// invocations actually route through the daemon. The runner sets QUNITX_NO_DAEMON=1
-// globally so other test files don't accidentally route through this test's daemon
-// while it's alive (the socket path is per-cwd and there is one project cwd in the suite).
+// Strip every env var that would cause `shouldUseDaemon` or `shouldAutoSpawnDaemon`
+// to short-circuit, so this file's `node cli.ts <test>` invocations actually route
+// through the daemon. The runner sets QUNITX_NO_DAEMON=1 globally; GitHub Actions sets
+// CI=true. Both short-circuit the daemon dispatch and would silently turn every daemon
+// test into a local run, dropping the "(daemon)" marker that several assertions rely on.
+// Bypass tests below explicitly re-add CI / QUNITX_NO_DAEMON / --no-daemon to verify
+// they win over the daemon path.
 const CLI_ENV = (() => {
   const env = { ...process.env, FORCE_COLOR: '0' };
   delete env.QUNITX_NO_DAEMON;
+  delete env.CI;
   return env;
 })();
 

--- a/test/commands/daemon-test.ts
+++ b/test/commands/daemon-test.ts
@@ -322,6 +322,79 @@ module('Commands | Daemon | bypass', { concurrency: false }, () => {
   });
 });
 
+module('Commands | Daemon | auto-spawn', { concurrency: false }, () => {
+  test('QUNITX_DAEMON=1 with no daemon -> auto-spawns and routes', async (assert) => {
+    await ensureDaemonStopped();
+    try {
+      const result = await cli(FIXTURE_PASS, {
+        env: { ...CLI_ENV, QUNITX_DAEMON: '1' },
+      });
+
+      assert.exitCode(result, 0);
+      assert.includes(result, '# pass 3');
+      assert.includes(result, '(daemon)');
+
+      // Daemon must still be running for subsequent invocations to reuse.
+      const status = await cli('daemon status');
+      assert.exitCode(status, 0);
+      assert.includes(status, 'Daemon running');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('without QUNITX_DAEMON, no daemon is spawned and run is local', async (assert) => {
+    await ensureDaemonStopped();
+    const result = await cli(FIXTURE_PASS);
+
+    assert.exitCode(result, 0);
+    assert.includes(result, '# pass 3');
+    assert.notIncludes(result, '(daemon)');
+
+    const status = await cli('daemon status', { failOk: true });
+    assert.exitCode(status, 1);
+    assert.includes(status, 'No daemon running');
+  });
+
+  test('QUNITX_DAEMON=1 with daemon already running -> reuses it', async (assert) => {
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const startupPid = await readDaemonPid();
+
+      const result = await cli(FIXTURE_PASS, {
+        env: { ...CLI_ENV, QUNITX_DAEMON: '1' },
+      });
+      assert.exitCode(result, 0);
+      assert.includes(result, '(daemon)');
+
+      // Same daemon instance — no double-spawn.
+      const samePid = await readDaemonPid();
+      assert.strictEqual(samePid, startupPid, 'daemon process unchanged');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+
+  test('QUNITX_DAEMON=1 + --no-daemon -> bypass wins, runs locally', async (assert) => {
+    await ensureDaemonStopped();
+    try {
+      const result = await cli(`--no-daemon ${FIXTURE_PASS}`, {
+        env: { ...CLI_ENV, QUNITX_DAEMON: '1' },
+      });
+      assert.exitCode(result, 0);
+      assert.includes(result, '# pass 3');
+      assert.notIncludes(result, '(daemon)');
+
+      // No daemon spawned because --no-daemon vetoes auto-spawn.
+      const status = await cli('daemon status', { failOk: true });
+      assert.exitCode(status, 1);
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
+});
+
 module('Commands | Daemon | crash recovery', { concurrency: false }, () => {
   // Linux-only: relies on /proc/<pid>/task/<pid>/children to find the daemon's Chrome.
   // macOS/Windows lack a portable equivalent; the recovery code path itself is the same.

--- a/test/commands/daemon-test.ts
+++ b/test/commands/daemon-test.ts
@@ -78,6 +78,23 @@ module('Commands | Daemon | usage', { concurrency: false }, () => {
     assert.exitCode(result, 1);
     assert.includes(result.stderr, 'Usage: qunitx daemon');
   });
+
+  test('$ qunitx daemon --help / -h / help -> usage on stdout, exits 0', async (assert) => {
+    for (const flag of ['--help', '-h', 'help']) {
+      const result = await cli(`daemon ${flag}`);
+      assert.exitCode(result, 0, `daemon ${flag} exits 0`);
+      assert.includes(
+        result.stdout,
+        'Usage: qunitx daemon',
+        `daemon ${flag} prints usage to stdout`,
+      );
+      assert.includes(
+        result.stdout,
+        'QUNITX_DAEMON=1',
+        `daemon ${flag} mentions auto-spawn env var`,
+      );
+    }
+  });
 });
 
 module('Commands | Daemon | lifecycle', { concurrency: false }, () => {

--- a/test/commands/daemon-test.ts
+++ b/test/commands/daemon-test.ts
@@ -160,6 +160,24 @@ module('Commands | Daemon | lifecycle', { concurrency: false }, () => {
     }
   });
 
+  test('rapid stop+start cycles do not race the daemon resource teardown', async (assert) => {
+    // Regression test: the dispatch handler used to ack 'done' to the client BEFORE
+    // the daemon's async cleanup (server.close, browser.close, process.exit) ran.
+    // A fast follow-up `daemon start` could race the dying daemon's socket/named-
+    // pipe handle and hit EADDRINUSE — the new daemon exited, the parent timed out
+    // polling for the info file, and the cli reported "Daemon did not start within
+    // 10s". Especially reliable on Windows where named-pipe handle release lags
+    // process exit. Three cycles back-to-back makes the race detectable on any
+    // platform if the wait-for-pid-exit fix in client.ts ever regresses.
+    await ensureDaemonStopped();
+    for (let i = 0; i < 3; i++) {
+      const start = await cli('daemon start');
+      assert.exitCode(start, 0, `iteration ${i}: start succeeded`);
+      const stop = await cli('daemon stop');
+      assert.exitCode(stop, 0, `iteration ${i}: stop succeeded`);
+    }
+  });
+
   test('concurrent daemon start invocations converge on a single live daemon', async (assert) => {
     // Two simultaneous starts exercise THREE invariants in one test:
     //

--- a/test/commands/daemon-test.ts
+++ b/test/commands/daemon-test.ts
@@ -378,6 +378,26 @@ module('Commands | Daemon | bypass', { concurrency: false }, () => {
       await ensureDaemonStopped();
     }
   });
+
+  test('QUNITX_DAEMON=1 overrides CI=1 (multi-invocation CI opt-in)', async (assert) => {
+    // Default: CI=1 bypasses the daemon for single-invocation jobs (most CI). When
+    // both CI=1 and QUNITX_DAEMON=1 are set, the explicit opt-in wins — multi-
+    // invocation CI flows (monorepos, pre-commit hooks doing N qunitx calls) need
+    // to be able to share the warm daemon across calls.
+    await ensureDaemonStopped();
+    await cli('daemon start');
+    try {
+      const result = await cli(FIXTURE_PASS, {
+        env: { ...CLI_ENV, CI: '1', QUNITX_DAEMON: '1' },
+      });
+
+      assert.exitCode(result, 0);
+      assert.includes(result, '# pass 3');
+      assert.includes(result, '(daemon)');
+    } finally {
+      await ensureDaemonStopped();
+    }
+  });
 });
 
 module('Commands | Daemon | auto-spawn', { concurrency: false }, () => {

--- a/test/commands/help-test.ts
+++ b/test/commands/help-test.ts
@@ -39,12 +39,18 @@ Optional flags:
 --browser : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
 --before : run a script before the tests(i.e start a new web server before tests)
 --after : run a script after the tests(i.e save test results to a file)
+--no-daemon : don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn
 
 Example: $ qunitx test/foo.ts app/e2e --debug --watch --before=scripts/start-new-webserver.js --after=scripts/write-test-results.js
 
 Commands:
-$ qunitx init               # Bootstraps qunitx base html and add qunitx config to package.json if needed
-$ qunitx new $testFileName  # Creates a qunitx test file`;
+$ qunitx init                            # Bootstraps qunitx base html and add qunitx config to package.json if needed
+$ qunitx new $testFileName               # Creates a qunitx test file
+$ qunitx daemon <start|stop|status>      # Optional persistent daemon — ~2× faster repeated runs
+
+Environment:
+QUNITX_DAEMON=1     : auto-spawn the daemon on the first qunitx run; reuse it on every run after (overrides the CI=1 bypass)
+QUNITX_NO_DAEMON=1  : never use the daemon for this run`;
 
 module('Commands | Version tests', { concurrency: true }, () => {
   test('$ qunitx --version -> prints only the version number', async (assert) => {

--- a/test/commands/run-cleanup-test.ts
+++ b/test/commands/run-cleanup-test.ts
@@ -21,9 +21,9 @@ module('Commands | run | closeWithGrace', { concurrency: true }, () => {
   test('returns within graceMs when a close never resolves', async (assert) => {
     // Reproduces the Firefox+Windows browser.close() deadlock — an unresolved promise stands
     // in for the stuck Playwright call. Without closeWithGrace, this would block forever.
-    const start = Date.now();
+    const start = performance.now();
     await closeWithGrace([new Promise<void>(() => {})], HANG_GRACE_MS);
-    const elapsed = Date.now() - start;
+    const elapsed = performance.now() - start;
 
     assert.ok(
       elapsed >= HANG_GRACE_MS && elapsed < HANG_GRACE_UPPER_BOUND_MS,
@@ -32,9 +32,9 @@ module('Commands | run | closeWithGrace', { concurrency: true }, () => {
   });
 
   test('returns immediately when every close has already settled', async (assert) => {
-    const start = Date.now();
+    const start = performance.now();
     await closeWithGrace([Promise.resolve(), Promise.resolve()], 5_000);
-    const elapsed = Date.now() - start;
+    const elapsed = performance.now() - start;
 
     assert.ok(
       elapsed < 50,
@@ -67,9 +67,9 @@ module('Commands | run | closeWithGrace', { concurrency: true }, () => {
   test('returns immediately when the close list is empty', async (assert) => {
     // Defensive: caller might filter all closers away (e.g. no sharedServer), and the helper
     // must not block on an empty Promise.allSettled.
-    const start = Date.now();
+    const start = performance.now();
     await closeWithGrace([], 5_000);
-    const elapsed = Date.now() - start;
+    const elapsed = performance.now() - start;
 
     assert.ok(elapsed < 50, `empty fast path: ${elapsed} ms`);
   });

--- a/test/commands/run-cleanup-test.ts
+++ b/test/commands/run-cleanup-test.ts
@@ -16,6 +16,12 @@ const HANG_GRACE_MS = 100;
 // without indicating any real bug. A hanging close that returns within ~3× HANG_GRACE_MS
 // still proves the helper is bounded — which is the only contract that matters here.
 const HANG_GRACE_UPPER_BOUND_MS = 300;
+// Lower-bound slack absorbs libuv timer jitter. setTimeout(N) can fire up to a few ms
+// before N elapses in wall-clock terms because libuv computes the deadline against its
+// per-loop-iteration cached `uv_now`, not a live monotonic read. Local sampling shows
+// min ≈ N − 1ms; CI hit N − 0.26ms (run 25088492776). 10ms tolerance is ~10× the worst
+// observed, comfortably absorbing jitter without admitting a 0-ms "did we wait?" bug.
+const HANG_GRACE_LOWER_BOUND_MS = HANG_GRACE_MS - 10;
 
 module('Commands | run | closeWithGrace', { concurrency: true }, () => {
   test('returns within graceMs when a close never resolves', async (assert) => {
@@ -26,8 +32,8 @@ module('Commands | run | closeWithGrace', { concurrency: true }, () => {
     const elapsed = performance.now() - start;
 
     assert.ok(
-      elapsed >= HANG_GRACE_MS && elapsed < HANG_GRACE_UPPER_BOUND_MS,
-      `returned within bounded grace: got ${elapsed} ms, expected ${HANG_GRACE_MS}–${HANG_GRACE_UPPER_BOUND_MS} ms`,
+      elapsed >= HANG_GRACE_LOWER_BOUND_MS && elapsed < HANG_GRACE_UPPER_BOUND_MS,
+      `returned within bounded grace: got ${elapsed} ms, expected ${HANG_GRACE_LOWER_BOUND_MS}–${HANG_GRACE_UPPER_BOUND_MS} ms`,
     );
   });
 

--- a/test/helpers/shell.ts
+++ b/test/helpers/shell.ts
@@ -143,7 +143,13 @@ export async function spawnCapture(
       clearTimeout(timer);
       reject(err);
     });
-    child.once('exit', (code, signal) => {
+    // Resolve on 'close', not 'exit'. Per Node docs, 'exit' fires when the process has
+    // terminated but child stdio streams may still be open — buffered 'data' events
+    // arriving after 'exit' are then missed by the resolved promise. 'close' fires only
+    // after every stdio stream has fully drained, so we capture the entire stdout/stderr.
+    // This was reproducing as truncated CI captures on Windows: process exit at 7.68 s,
+    // last captured stdout at 1.4 s, the intervening test+after-script output dropped.
+    child.once('close', (code, signal) => {
       clearTimeout(timer);
       const result: CapturedResult = {
         stdout,

--- a/test/runner.ts
+++ b/test/runner.ts
@@ -82,7 +82,16 @@ function spawnTests(files: string[]): Promise<number> {
       watchMode ? ['--test', '--watch', ...files] : ['--test', '--test-force-exit', ...files],
       {
         stdio: 'inherit',
-        env: { ...process.env, FORCE_COLOR: '0', QUNITX_SEMAPHORE_PORT: String(semaphore.port) },
+        env: {
+          ...process.env,
+          FORCE_COLOR: '0',
+          QUNITX_SEMAPHORE_PORT: String(semaphore.port),
+          // Block accidental daemon routing during the suite: a daemon running for this
+          // project's cwd would be picked up by every `node cli.ts` invocation and
+          // silently change behavior (TAP "(daemon)" suffix, single warm browser shared
+          // across tests). The daemon test file deletes this var for its own client invocations.
+          QUNITX_NO_DAEMON: '1',
+        },
       },
     );
     child.once('exit', (code) => resolve(code ?? 0));

--- a/test/utils/daemon-hint-test.ts
+++ b/test/utils/daemon-hint-test.ts
@@ -1,0 +1,144 @@
+import { module, test } from 'qunitx';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { shouldShowDaemonHint, maybePrintDaemonHint } from '../../lib/utils/daemon-hint.ts';
+import '../helpers/custom-asserts.ts';
+
+interface BaseCtx {
+  durationMs: number;
+  watch: boolean;
+  daemonMode: boolean;
+  env: NodeJS.ProcessEnv;
+  isTTY: boolean;
+}
+
+const BASE_CTX: BaseCtx = {
+  durationMs: 1_000,
+  watch: false,
+  daemonMode: false,
+  env: {},
+  isTTY: true,
+};
+
+const tmpSentinel = (): string => path.join(os.tmpdir(), `qunitx-hint-${randomUUID()}`);
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+module('Utils | DaemonHint | shouldShowDaemonHint', { concurrency: true }, () => {
+  test('shows on slow non-CI TTY run with empty env', (assert) => {
+    assert.true(shouldShowDaemonHint(BASE_CTX));
+  });
+
+  test('suppresses when CI is set', (assert) => {
+    assert.false(shouldShowDaemonHint({ ...BASE_CTX, env: { CI: 'true' } }));
+    assert.false(shouldShowDaemonHint({ ...BASE_CTX, env: { CI: '1' } }));
+  });
+
+  test('suppresses when QUNITX_DAEMON is set (already opted in)', (assert) => {
+    assert.false(shouldShowDaemonHint({ ...BASE_CTX, env: { QUNITX_DAEMON: '1' } }));
+  });
+
+  test('suppresses when QUNITX_NO_DAEMON is set (explicit opt-out)', (assert) => {
+    assert.false(shouldShowDaemonHint({ ...BASE_CTX, env: { QUNITX_NO_DAEMON: '1' } }));
+  });
+
+  test('suppresses when QUNITX_HINT_SHOWN is set (per-session override)', (assert) => {
+    assert.false(shouldShowDaemonHint({ ...BASE_CTX, env: { QUNITX_HINT_SHOWN: '1' } }));
+  });
+
+  test('suppresses in --watch mode (own browser lifecycle)', (assert) => {
+    assert.false(shouldShowDaemonHint({ ...BASE_CTX, watch: true }));
+  });
+
+  test('suppresses inside the daemon process itself', (assert) => {
+    assert.false(shouldShowDaemonHint({ ...BASE_CTX, daemonMode: true }));
+  });
+
+  test('threshold: shows at 500ms, suppresses at 499ms', (assert) => {
+    assert.false(shouldShowDaemonHint({ ...BASE_CTX, durationMs: 499 }));
+    assert.true(shouldShowDaemonHint({ ...BASE_CTX, durationMs: 500 }));
+    assert.true(shouldShowDaemonHint({ ...BASE_CTX, durationMs: 1_500 }));
+  });
+
+  test('suppresses when stderr is not a TTY', (assert) => {
+    assert.false(shouldShowDaemonHint({ ...BASE_CTX, isTTY: false }));
+  });
+});
+
+module('Utils | DaemonHint | maybePrintDaemonHint', { concurrency: true }, () => {
+  test('writes hint and creates sentinel on first call', async (assert) => {
+    const sentinel = tmpSentinel();
+    const writes: string[] = [];
+    try {
+      await maybePrintDaemonHint(BASE_CTX, {
+        sentinelPath: sentinel,
+        write: (t) => writes.push(t),
+      });
+      assert.equal(writes.length, 1, 'exactly one write');
+      assert.includes(writes[0], 'QUNITX_DAEMON=1');
+      assert.includes(writes[0], 'qunitx daemon --help');
+      assert.true(await pathExists(sentinel), 'sentinel file created');
+    } finally {
+      await fs.unlink(sentinel).catch(() => {});
+    }
+  });
+
+  test('skips print when sentinel already exists', async (assert) => {
+    const sentinel = tmpSentinel();
+    try {
+      await fs.writeFile(sentinel, 'pre-existing');
+      const writes: string[] = [];
+      await maybePrintDaemonHint(BASE_CTX, {
+        sentinelPath: sentinel,
+        write: (t) => writes.push(t),
+      });
+      assert.equal(writes.length, 0, 'nothing written when sentinel exists');
+    } finally {
+      await fs.unlink(sentinel).catch(() => {});
+    }
+  });
+
+  test('skips print and sentinel creation when env disqualifies', async (assert) => {
+    const sentinel = tmpSentinel();
+    const writes: string[] = [];
+    await maybePrintDaemonHint(
+      { ...BASE_CTX, env: { CI: 'true' } },
+      { sentinelPath: sentinel, write: (t) => writes.push(t) },
+    );
+    assert.equal(writes.length, 0, 'nothing written under CI');
+    assert.false(await pathExists(sentinel), 'no sentinel when suppressed');
+  });
+
+  test('skips print and sentinel creation when run is fast', async (assert) => {
+    const sentinel = tmpSentinel();
+    const writes: string[] = [];
+    await maybePrintDaemonHint(
+      { ...BASE_CTX, durationMs: 200 },
+      { sentinelPath: sentinel, write: (t) => writes.push(t) },
+    );
+    assert.equal(writes.length, 0, 'nothing written for fast runs');
+    assert.false(await pathExists(sentinel), 'no sentinel for fast runs');
+  });
+
+  test('second call after sentinel exists is silent (one-shot per machine)', async (assert) => {
+    const sentinel = tmpSentinel();
+    try {
+      const writes: string[] = [];
+      const opts = { sentinelPath: sentinel, write: (t: string) => writes.push(t) };
+      await maybePrintDaemonHint(BASE_CTX, opts);
+      await maybePrintDaemonHint(BASE_CTX, opts);
+      assert.equal(writes.length, 1, 'only the first call printed');
+    } finally {
+      await fs.unlink(sentinel).catch(() => {});
+    }
+  });
+});

--- a/test/utils/daemon-socket-path-test.ts
+++ b/test/utils/daemon-socket-path-test.ts
@@ -1,0 +1,62 @@
+import { module, test } from 'qunitx';
+import os from 'node:os';
+import path from 'node:path';
+import { daemonSocketPath, daemonInfoPath } from '../../lib/utils/daemon-socket-path.ts';
+import '../helpers/custom-asserts.ts';
+
+const FIXED_CWD = '/some/test/project';
+
+module('Utils | daemonSocketPath', { concurrency: true }, () => {
+  test('linux: places the socket under os.tmpdir() with .sock suffix', (assert) => {
+    const result = daemonSocketPath(FIXED_CWD, 'linux');
+    assert.equal(path.dirname(result), os.tmpdir());
+    assert.regex(path.basename(result), /^qunitx-daemon-[0-9a-f]{12}\.sock$/);
+  });
+
+  test('darwin: places the socket under os.tmpdir() with .sock suffix', (assert) => {
+    const result = daemonSocketPath(FIXED_CWD, 'darwin');
+    assert.equal(path.dirname(result), os.tmpdir());
+    assert.regex(path.basename(result), /^qunitx-daemon-[0-9a-f]{12}\.sock$/);
+  });
+
+  test('win32: emits a \\\\.\\pipe\\ named-pipe path (no .sock suffix)', (assert) => {
+    const result = daemonSocketPath(FIXED_CWD, 'win32');
+    // node:net on Windows requires named pipes to live in \\.\pipe\ (or \\?\pipe\).
+    assert.regex(result, /^\\\\\.\\pipe\\qunitx-daemon-[0-9a-f]{12}$/);
+  });
+
+  test('same cwd → same path on the same platform (deterministic)', (assert) => {
+    assert.equal(daemonSocketPath(FIXED_CWD, 'linux'), daemonSocketPath(FIXED_CWD, 'linux'));
+    assert.equal(daemonSocketPath(FIXED_CWD, 'win32'), daemonSocketPath(FIXED_CWD, 'win32'));
+  });
+
+  test('different cwds → different paths on the same platform', (assert) => {
+    assert.notEqual(
+      daemonSocketPath('/project/a', 'linux'),
+      daemonSocketPath('/project/b', 'linux'),
+    );
+    assert.notEqual(
+      daemonSocketPath('/project/a', 'win32'),
+      daemonSocketPath('/project/b', 'win32'),
+    );
+  });
+});
+
+module('Utils | daemonInfoPath', { concurrency: true }, () => {
+  test('always under os.tmpdir() with .json suffix (regardless of platform)', (assert) => {
+    // The info file is the cross-platform presence sentinel — it must always live on
+    // the regular filesystem so existsSync() can see it on Windows too.
+    const result = daemonInfoPath(FIXED_CWD);
+    assert.equal(path.dirname(result), os.tmpdir());
+    assert.regex(path.basename(result), /^qunitx-daemon-[0-9a-f]{12}\.json$/);
+  });
+
+  test('shares the cwd hash with daemonSocketPath (same project → paired files)', (assert) => {
+    const sock = daemonSocketPath(FIXED_CWD, 'linux');
+    const info = daemonInfoPath(FIXED_CWD);
+    const sockHash = /-([0-9a-f]{12})\.sock$/.exec(sock)?.[1];
+    const infoHash = /-([0-9a-f]{12})\.json$/.exec(info)?.[1];
+    assert.ok(sockHash && infoHash, 'both paths carry a hash');
+    assert.equal(sockHash, infoHash);
+  });
+});


### PR DESCRIPTION
Adds `qunitx daemon start|stop|status` and a Unix-socket dispatch path that lets subsequent `qunitx <test>` invocations reuse a single warm Chrome and esbuild incremental context. On a single passing fixture the cost drops from ~2.0s (cold local run) to ~0.65s through the daemon — the dominant savings are the eliminated Chrome launch (~800ms) plus the warm esbuild context (~200–400ms). The first run after `daemon start` still pays the cold cost (daemon startup loads modules + launches Chrome); every run after that is fast.

Architecture:
- Per-cwd Unix socket at /tmp/qunitx-daemon-<sha256(cwd)[:12]>.sock so each project gets at most one daemon. Sidecar JSON file mirrors the socket so `daemon status` can show pid/cwd/node/uptime without an IPC roundtrip.
- NDJSON wire protocol: client sends one Request line; daemon streams stdout and stderr chunks ending with a `done` (or `fatal`) message. attachLineParser
  + probeSocket are shared by both sides.
- Serial run queue. The daemon multiplexes runs through a Promise mutex; a single browser is shared across runs, so concurrent runs would step on each other's stdout interception. Serial keeps it simple and correct.
- Per-run: spawn a fresh Playwright page in the daemon's persistent browser, build a per-run web server (so config.output and other run-specific server state stays isolated), drive runTestsInBrowser, then close the page + server. The browser stays alive.
- env + argv snapshot/restore around each run so before-hook env mutations don't bleed across runs.

Lifecycle and safety:
- 30-min idle timeout (unref'd) shuts down the daemon after the last run.
- SIGTERM / SIGINT / unhandledRejection all funnel through one shutdown path.
- Detects package.json mtime change and node version mismatch between client and daemon; both trigger shutdown so the next invocation respawns fresh.
- Race-resolution at startup: if a live daemon already exists for this cwd, the new daemon process exits 0 cleanly (the client's polling reaches the winner). Stale socket files (from crashed daemons) are removed before listen.

Bypass paths (daemon never used):
- `--watch` / `-w` — daemon owns no watcher
- `--open` / `-o` — daemon is headless-only
- `CI=1` — opt out for ephemeral CI runners
- `QUNITX_NO_DAEMON=1` env or `--no-daemon` flag
- chrome-prelaunch.ts also skips the local Chrome spawn for daemon-eligible runs so we don't waste ~150ms launching a Chrome we'll never use.

Code-path changes outside the daemon module:
- web-server.ts suppresses the per-WS-connection `TAP version 13` header in daemon mode; the daemon emits exactly one header per run, keeping the stream parser-clean across multiple runs in one session.
- runTestsInBrowser throws a new `DaemonRunError(exitCode)` instead of process.exit when `_daemonMode` is set, so the daemon's run handler can capture the exit code and keep the process alive. The outer catch re-throws DaemonRunError unchanged so it doesn't get wrapped as BundleError.
- failOnNonWatchMode gained a `daemonMode` parameter with the same semantics.

Tests (test/commands/daemon-test.ts, 16 cases):
- usage: `daemon` (no subcommand) and `daemon foobar` (invalid)
- lifecycle: start/stop/status across all states; stale-socket recovery on start; "already running" idempotence; socket+info file cleanup on stop
- run routing: passing → exit 0 + `(daemon)` tag; failing → exit 1; warm consecutive runs; exactly one TAP version 13 header per run
- bypass: --no-daemon, QUNITX_NO_DAEMON=1, CI=1

test/runner.ts sets QUNITX_NO_DAEMON=1 in the spawn env globally so other test files can't accidentally route through the daemon test's daemon while it's alive (the per-cwd socket is a project-wide singleton). The daemon test deletes that var locally for its own client invocations.

Out of scope for v1 (left for follow-up):
- Browser-crash recovery — daemon currently dies on Playwright exceptions rather than relaunching; the next client invocation respawns it.
- Concurrent multi-group runs through the daemon — always single-group.
- Auto-spawn of the daemon — opt-in via `qunitx daemon start`.