### PR TITLE
feat(cli): --changed / --since flag for incremental runs

### DIFF
--- a/.github/workflows/browser-compat.yml
+++ b/.github/workflows/browser-compat.yml
@@ -22,6 +22,8 @@ permissions:
 jobs:
   browser-compat:
     name: ${{ matrix.os }} / ${{ matrix.browser }}
+    # Skip duplicate pull_request events (push already covers same-repo branches; forks still run).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# `if: !DUPLICATE_PR_EVENT` (inlined per job below): same-repo PRs fire BOTH
+# `push` and `pull_request` for the same SHA; skip the pull_request leg since
+# push already covers it. Forks still run via pull_request because pushes from
+# forks don't fire here. Applied to lint / test / bench only — every other job
+# already filters on `refs/heads/main` or `refs/tags/v*`.
 jobs:
   # ── Lint ──────────────────────────────────────────────────────────────────────
   # Surfaces formatting (prettier) and code-quality (deno lint) failures fast,
   # independent of the slower test job.
   lint:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -49,6 +55,7 @@ jobs:
   # Matrix covers all three platforms so Chromium behaviour is verified on each OS.
   # macOS/Windows get extra time: Chrome startup and I/O are slower off Linux.
   test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.os == 'ubuntu-latest' && 15 || 25 }}
@@ -135,6 +142,7 @@ jobs:
   # SKIP_BENCHMARK=<basename> in env to skip only that file, or =true to
   # skip the whole gate while you investigate.
   bench:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -29,6 +29,8 @@ ${color('--browser')} : browser engine to run tests in: chromium, firefox, webki
 ${color('--before')} : run a script before the tests(i.e start a new web server before tests)
 ${color('--after')} : run a script after the tests(i.e save test results to a file)
 ${color('--no-daemon')} : don't use the daemon for this run — skips a running daemon and prevents ${color('QUNITX_DAEMON')} auto-spawn
+${color('--changed')} : run only test files affected by changes since ${color('HEAD')} (requires git; falls back to running all on first use)
+${color('--since')} : run only test files affected by changes since the given git ref (e.g. ${color('--since=main')}); ${color('--changed')} = ${color('--since=HEAD')}
 ${color('--trace-perf')} : write timestamped startup-perf trace lines to stderr (Chrome pre-launch, module load, browser bind)
 
 ${highlight('Example:')} $ ${color('qunitx test/foo.ts app/e2e --debug --watch --before=scripts/start-new-webserver.js --after=scripts/write-test-results.js')}

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -210,6 +210,24 @@ export async function run(config: Config): Promise<void> {
     // is hidden behind the ~1.2s Chrome launch. Each group then gets its own
     // HTTP server and Playwright page inside one shared browser instance.
     const allFiles = Object.keys(config.fsTree);
+    // Empty fsTree (e.g. --changed filtered out every test, or the inputs
+    // matched no files): emit a clean TAP plan and exit 0. The downstream
+    // group/build pipeline assumes ≥1 file and would crash on undefined
+    // groupConfigs[0]. In daemon mode, throw DaemonRunError so the daemon's
+    // run handler closes the run cleanly and stays alive for the next call.
+    if (allFiles.length === 0) {
+      process.stdout.write('TAP version 13\n');
+      process.stdout.write(
+        `# Running 0 test files${config._daemonMode ? ' (daemon)' : ''}\n1..0\n`,
+      );
+      if (config._daemonMode) throw new DaemonRunError(0);
+      if (!config.watch) {
+        const browser = config._daemonBrowser ? null : await browserPromise!;
+        await closeWithGrace([browser?.close(), shutdownPrelaunch()]);
+        return process.exit(0);
+      }
+      return;
+    }
     const groupCount = Math.min(allFiles.length, availableParallelism());
     const { groups, weights } = await splitIntoGroups(allFiles, groupCount, timings ?? {});
 

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -9,6 +9,8 @@ import { runUserModule } from '../../utils/run-user-module.ts';
 import { TAPDisplayFinalResult } from '../../tap/display-final-result.ts';
 import { buildErrorHTML, buildNoTestsHTML } from '../../setup/web-server.ts';
 import { extractInlineSourceMap } from '../../utils/source-map-decoder.ts';
+import { writeMetafileCache } from '../../utils/metafile-cache.ts';
+import type { AffectedMetafile } from '../../utils/get-changed-files.ts';
 import type { Page } from 'playwright-core';
 import type { Config, CachedContent, Connections } from '../../types.ts';
 import type { HTTPServer } from '../../servers/web.ts';
@@ -169,6 +171,10 @@ export async function buildTestBundle(config: Config, cachedContent: CachedConte
     // tsconfig's `jsxImportSource` or a `@jsxImportSource <pkg>` pragma cover Vue/Preact/Solid.
     jsx: 'automatic',
     plugins: config.plugins,
+    // Required for --changed/--since dep-graph filter on subsequent runs (cache
+    // populates here, reads in setupConfig). Inputs map carries the full reverse-dep
+    // graph; output cost is negligible.
+    metafile: true,
     // Signal the runtime that all test modules are registered. The runtime's maybeStart()
     // waits for both this event and the WebSocket 'open' event before calling QUnit.start().
     // Dispatching from the bundle (rather than from a script onload attr) is reliable across
@@ -186,7 +192,7 @@ export async function buildTestBundle(config: Config, cachedContent: CachedConte
   const fileKey = bundleCacheKey(buildOptions, allTestFilePaths);
 
   try {
-    const [allTestCode] = await Promise.all([
+    const [{ js: allTestCode, metafile }] = await Promise.all([
       config.watch || config._daemonMode
         ? buildIncrementally(buildOptions, fileKey, cacheHolder, needsDisk)
         : buildWithOverlayfsRetry(buildOptions, needsDisk),
@@ -202,6 +208,9 @@ export async function buildTestBundle(config: Config, cachedContent: CachedConte
     ]);
     cachedContent.allTestCode = allTestCode;
     config._sourceMapDecoder = extractInlineSourceMap(allTestCode, outDir);
+    // Persist metafile for the next --changed run. Best-effort; cache miss
+    // on subsequent reads degrades to "run all tests."
+    if (metafile) void writeMetafileCache(projectRoot, process.cwd(), metafile);
   } catch (error) {
     cachedContent._buildError = {
       type: deriveBuildErrorType(error),
@@ -517,6 +526,9 @@ export async function buildAllGroupBundles(
     sourcemap,
     write: false,
     jsx: 'automatic',
+    // Required for --changed/--since dep-graph filter on subsequent runs. Same
+    // contract as the single-group path in `buildTestBundle`.
+    metafile: true,
     footer: { js: 'window.dispatchEvent(new CustomEvent("qunitx:tests-ready"));' },
   };
 
@@ -563,6 +575,10 @@ export async function buildAllGroupBundles(
         return fs.writeFile(destPath, outputFile.contents);
       }),
     );
+    // Persist metafile for the next --changed run (same cache as single-group path).
+    if (result.metafile) {
+      void writeMetafileCache(projectRoot, process.cwd(), result.metafile as AffectedMetafile);
+    }
   } catch (error) {
     const buildError = { type: deriveBuildErrorType(error), formatted: formatBuildErrors(error) };
     const errorHtml = buildErrorHTML(buildError);
@@ -593,6 +609,8 @@ function buildFilteredTests(
 ): Promise<Buffer> {
   const sourcemap: esbuild.BuildOptions['sourcemap'] = 'inline';
   const needsDisk = Boolean(config.open);
+  // Filtered re-runs (qf shortcut) are a subset bundle; the cached metafile
+  // would be incomplete, so we don't request one or persist it here.
   return buildWithOverlayfsRetry(
     {
       stdin: {
@@ -613,7 +631,7 @@ function buildFilteredTests(
       footer: { js: 'window.dispatchEvent(new CustomEvent("qunitx:tests-ready"));' },
     },
     needsDisk,
-  );
+  ).then((r) => r.js);
 }
 
 // On Docker/overlayfs CI, a newly written file may be visible to inotify (IN_CREATE fires)
@@ -628,7 +646,7 @@ function buildFilteredTests(
 async function runWithOverlayfsRetry(
   getContents: () => Promise<{ result: esbuild.BuildResult; js: Buffer }>,
   needsDisk: boolean,
-): Promise<Buffer> {
+): Promise<{ js: Buffer; metafile?: AffectedMetafile }> {
   let { result, js } = await getContents();
   const initialSize = js.length;
 
@@ -654,13 +672,13 @@ async function runWithOverlayfsRetry(
     );
   }
 
-  return js;
+  return { js, metafile: result.metafile as AffectedMetafile | undefined };
 }
 
 function buildWithOverlayfsRetry(
   options: esbuild.BuildOptions,
   needsDisk: boolean,
-): Promise<Buffer> {
+): Promise<{ js: Buffer; metafile?: AffectedMetafile }> {
   const buildOpts: esbuild.BuildOptions = { ...options, write: false };
   return runWithOverlayfsRetry(async () => {
     const result = await esbuild.build(buildOpts);
@@ -681,7 +699,7 @@ async function buildIncrementally(
   fileKey: string,
   cache: { _esbuildContext?: esbuild.BuildContext | null; _esbuildContextKey?: string },
   needsDisk: boolean,
-): Promise<Buffer> {
+): Promise<{ js: Buffer; metafile?: AffectedMetafile }> {
   const buildOpts: esbuild.BuildOptions = { ...options, write: false };
 
   if (!cache._esbuildContext || cache._esbuildContextKey !== fileKey) {

--- a/lib/setup/config.ts
+++ b/lib/setup/config.ts
@@ -5,6 +5,7 @@ import { defaultProjectConfigValues } from './default-project-config-values.ts';
 import { findProjectRoot } from '../utils/find-project-root.ts';
 import { buildFSTree } from './fs-tree.ts';
 import { setupTestFilePaths } from './test-file-paths.ts';
+import { getChangedFsTree } from './get-changed-fs-tree.ts';
 import { parseCliFlags } from '../utils/parse-cli-flags.ts';
 import type { Config } from '../types.ts';
 import type { Plugin as EsbuildPlugin } from 'esbuild';
@@ -54,6 +55,13 @@ export async function setupConfig(): Promise<Config> {
     buildFSTree(config.testFileLookupPaths, config),
     pluginsPromise,
   ]);
+
+  // --changed / --since: filter fsTree to test files whose transitive deps
+  // include a changed file. Watch mode skips this — watch is for fast feedback
+  // on every save, not "what does my working tree affect" semantics.
+  if (config.changedSince && !config.watch) {
+    config.fsTree = await getChangedFsTree(config.fsTree, config.projectRoot, config.changedSince);
+  }
 
   return config as Config;
 }

--- a/lib/setup/file-watcher.ts
+++ b/lib/setup/file-watcher.ts
@@ -17,7 +17,7 @@ const RESCAN_INTERVAL_MS = 1_000;
 // window ensures the rebuild fires AFTER the writeFile burst settles, so esbuild
 // reads the final content rather than a partial snapshot. See the
 // 'rapid back-to-back writes coalesce ...' test in file-watcher-test.ts.
-const CHANGE_COALESCE_MS = 50;
+const CHANGE_COALESCE_MS = 75;
 // Windows fs.watch (ReadDirectoryChangesW) fires both a `rename` (→ classified as 'add')
 // AND one or more spurious `change` events for a single fs.writeFile of a new file. The
 // trailing 'change' arrives after the add's filtered-rebuild has completed, so the existing

--- a/lib/setup/get-changed-fs-tree.ts
+++ b/lib/setup/get-changed-fs-tree.ts
@@ -1,0 +1,65 @@
+import { getChangedFiles } from '../utils/get-changed-files.ts';
+import { getChangedFilePathsInGitSince } from '../utils/get-changed-file-paths-in-git-since.ts';
+import { readMetafileCache } from '../utils/metafile-cache.ts';
+import type { FSTree } from '../types.ts';
+
+/**
+ * Returns a new fsTree containing only the test files affected by changes
+ * since `ref`, per the cached esbuild metafile's reverse-dependency graph.
+ *
+ * Falls back to returning the input fsTree unchanged (with a stdout note)
+ * when any of these hold — they are "run-all is the safe answer" scenarios,
+ * not bugs:
+ *   - blast-radius file changed (package.json, tsconfig.json, …): full graph
+ *     potentially affected, dep walk would miss it.
+ *   - no metafile cache yet: nothing built before this run.
+ *   - git failed: not a repo, ref doesn't exist, git binary missing.
+ *
+ * Always logs how the filter resolved (full / filtered / fallback) so users can
+ * reason about why their selected suite ran.
+ */
+export async function getChangedFsTree(
+  fsTree: FSTree,
+  projectRoot: string,
+  changedSince: string,
+): Promise<FSTree> {
+  const testFiles = Object.keys(fsTree);
+  if (testFiles.length === 0) return fsTree;
+
+  const cache = await readMetafileCache(projectRoot);
+  if (!cache) {
+    process.stdout.write(
+      `# --changed: no metafile cache yet — running all ${testFiles.length} test files (cache populates on this run)\n`,
+    );
+    return fsTree;
+  }
+
+  // .catch funnels git failures into a value branch so the three outcomes
+  // (error / blast-radius / size===0) collapse into one if/else-if chain
+  // without a mutable `let changed` + try/catch.
+  const changed = await getChangedFilePathsInGitSince(projectRoot, changedSince).catch(
+    (err: Error) => err,
+  );
+  if (changed instanceof Error) {
+    process.stdout.write(
+      `# --changed: git lookup failed (${changed.message.split('\n')[0]}) — running all ${testFiles.length} test files\n`,
+    );
+    return fsTree;
+  } else if (changed === null) {
+    process.stdout.write(
+      `# --changed: blast-radius file changed (package.json / tsconfig.json / lockfile) — running all ${testFiles.length} test files\n`,
+    );
+    return fsTree;
+  } else if (changed.size === 0) {
+    process.stdout.write(
+      `# --changed: 0 files changed since ${changedSince} — running 0 test files\n`,
+    );
+    return {};
+  }
+
+  const affected = getChangedFiles(cache.metafile, cache.esbuildCwd, changed, testFiles);
+  process.stdout.write(
+    `# --changed: ${affected.size} of ${testFiles.length} test files affected by changes since ${changedSince}\n`,
+  );
+  return Object.fromEntries(testFiles.filter((f) => affected.has(f)).map((f) => [f, null]));
+}

--- a/lib/setup/write-output-static-files.ts
+++ b/lib/setup/write-output-static-files.ts
@@ -21,7 +21,16 @@ export async function writeOutputStaticFiles(
     );
   });
   const assetPromises = Array.from(cachedContent.assets).map(async (assetAbsolutePath) => {
-    const assetRelativePath = path.relative(projectRoot, assetAbsolutePath);
+    // When the asset lives outside projectRoot — pnpm/yarn workspaces with a
+    // hoisted `node_modules`, npm-link'd dev deps, or test fixtures that
+    // symlink `node_modules` — `path.relative` returns leading `..` segments.
+    // Joining those onto outDir cancels its trailing segments, so distinct
+    // group outputs would converge on the same on-disk path AND the served
+    // file wouldn't match the URL the browser requests. Strip the leading
+    // escape so the asset always lands at `<outDir>/<rest>`.
+    const assetRelativePath = path
+      .relative(projectRoot, assetAbsolutePath)
+      .replace(/^(?:\.\.[\\/])+/, '');
     const outDir = path.resolve(projectRoot, output);
     await ensureFolderExists(path.join(outDir, assetRelativePath));
     await fs.copyFile(assetAbsolutePath, path.join(outDir, assetRelativePath));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -126,6 +126,12 @@ export interface Config {
   open?: boolean | string;
   /** Print the local server URL and forward browser console output to stdout. */
   debug?: boolean;
+  /**
+   * When set, run only test files whose transitive imports include any file
+   * changed since this git ref. `--changed` is shorthand for `--since=HEAD`.
+   * Falls back to running all tests on git failure or missing metafile cache.
+   */
+  changedSince?: string;
   /** Mutable test-outcome counters updated as TAP events arrive. */
   COUNTER: Counter;
   /** Test files that failed on the previous run (drives re-run filtering). */

--- a/lib/utils/get-changed-file-paths-in-git-since.ts
+++ b/lib/utils/get-changed-file-paths-in-git-since.ts
@@ -1,0 +1,72 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Exact basenames whose modification invalidates the entire test suite. A change
+ * to any of these short-circuits `getChangedFilePathsInGitSince` to `null`, signalling
+ * the caller to skip filtering and run everything. The qunitx config lives
+ * inside `package.json` per project convention, so package.json alone covers it.
+ */
+const BLAST_RADIUS_FILES = new Set(['package.json', 'package-lock.json', 'deno.json', 'deno.lock']);
+/**
+ * Basename regexes with the same blast-radius semantics. Currently catches
+ * `tsconfig.json` and editor variants like `tsconfig.test.json` /
+ * `tsconfig.build.json`.
+ */
+const BLAST_RADIUS_PATTERNS = [/^tsconfig.*\.json$/];
+
+/**
+ * Resolves the set of working-tree paths that differ from `ref`, plus all
+ * uncommitted modifications/additions. Returns absolute paths.
+ *
+ * Returns `null` when any "blast-radius" file (package.json, tsconfig*.json, …)
+ * has changed — those changes can affect every test and must skip the
+ * dep-graph filter. The caller treats `null` as "run all tests."
+ *
+ * Throws on git failure (not a repo, ref doesn't exist, git missing). Callers
+ * should catch and degrade to the run-all path with a stderr note.
+ */
+export async function getChangedFilePathsInGitSince(
+  projectRoot: string,
+  ref: string,
+): Promise<Set<string> | null> {
+  const [diffOut, statusOut] = await Promise.all([
+    execFileAsync('git', ['diff', '--name-only', '--no-renames', ref, '--', projectRoot], {
+      cwd: projectRoot,
+      maxBuffer: 16 * 1024 * 1024,
+    }).then((r) => r.stdout),
+    execFileAsync('git', ['status', '--porcelain', '--untracked-files=all'], {
+      cwd: projectRoot,
+      maxBuffer: 16 * 1024 * 1024,
+    }).then((r) => r.stdout),
+  ]);
+
+  // `git status --porcelain` lines look like "XY path" or "XY path -> newpath"
+  // for renames. We disabled renames in `git diff` above; for status, take the
+  // rightmost path (post-rename name is what's currently on disk).
+  const fromStatus = (line: string) => {
+    const rest = line.slice(3);
+    const arrow = rest.indexOf(' -> ');
+    return arrow === -1 ? rest : rest.slice(arrow + 4);
+  };
+  const relPaths = new Set([
+    ...diffOut.split('\n').filter(Boolean),
+    ...statusOut
+      .split('\n')
+      .filter((l) => l.length >= 4)
+      .map(fromStatus),
+  ]);
+
+  const isBlastRadius = (rel: string) => {
+    const base = path.basename(rel);
+    return BLAST_RADIUS_FILES.has(base) || BLAST_RADIUS_PATTERNS.some((re) => re.test(base));
+  };
+  if (Array.from(relPaths).some(isBlastRadius)) return null;
+
+  return new Set(Array.from(relPaths, (rel) => path.resolve(projectRoot, rel)));
+}
+
+export { BLAST_RADIUS_FILES, BLAST_RADIUS_PATTERNS };

--- a/lib/utils/get-changed-files.ts
+++ b/lib/utils/get-changed-files.ts
@@ -1,0 +1,66 @@
+import path from 'node:path';
+
+/**
+ * Subset of esbuild's Metafile shape that we actually read. Defined locally so
+ * this module doesn't import the heavy `esbuild` package — it only parses a
+ * JSON file that esbuild produced earlier.
+ */
+export interface AffectedMetafile {
+  /** Every input file esbuild visited, keyed by path relative to esbuild's cwd. */
+  inputs: Record<string, { imports?: Array<{ path: string }> }>;
+}
+
+/**
+ * Returns the subset of `testFiles` (absolute paths) whose transitive imports,
+ * per the cached esbuild metafile, include any file in `changedAbsPaths`.
+ *
+ * Memoizes "does this node transitively reach a changed file?" across all tests
+ * so total work is O(V+E) for the whole call, regardless of how many tests
+ * share dependencies. Cycles are handled by tracking the active recursion stack.
+ *
+ * Paths in the metafile are relative to `esbuildCwd`; we resolve them against it
+ * so comparisons happen on normalized absolute paths.
+ */
+export function getChangedFiles(
+  metafile: AffectedMetafile,
+  esbuildCwd: string,
+  changedAbsPaths: ReadonlySet<string>,
+  testFiles: readonly string[],
+): Set<string> {
+  // absolute-path → absolute-paths-of-imports. One pass over the metafile
+  // up front; subsequent reachability lookups are O(1) per node.
+  const deps = new Map(
+    Object.entries(metafile.inputs).map(([relPath, info]) => [
+      path.resolve(esbuildCwd, relPath),
+      (info.imports ?? []).map((i) => path.resolve(esbuildCwd, i.path)),
+    ]),
+  );
+
+  const memo = new Map<string, boolean>();
+  return new Set(
+    testFiles.filter((test) => reachesChange(test, deps, changedAbsPaths, memo, new Set())),
+  );
+}
+
+function reachesChange(
+  node: string,
+  deps: Map<string, string[]>,
+  changedAbsPaths: ReadonlySet<string>,
+  memo: Map<string, boolean>,
+  stack: Set<string>,
+): boolean {
+  const cached = memo.get(node);
+  if (cached !== undefined) return cached;
+  // Cycle: this branch contributes no new info; let other branches decide.
+  // Don't memoize here — the answer depends on which branch eventually closes.
+  if (stack.has(node)) return false;
+  stack.add(node);
+  // `.some` short-circuits exactly like a for-loop with break, so the
+  // memoized DFS preserves its O(V+E) total bound across all tests.
+  const result =
+    changedAbsPaths.has(node) ||
+    (deps.get(node) ?? []).some((dep) => reachesChange(dep, deps, changedAbsPaths, memo, stack));
+  stack.delete(node);
+  memo.set(node, result);
+  return result;
+}

--- a/lib/utils/metafile-cache.ts
+++ b/lib/utils/metafile-cache.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import type { AffectedMetafile } from './get-changed-files.ts';
+
+/**
+ * Persistent on-disk cache of the most recent successful esbuild metafile,
+ * used by `--changed` / `--since` to compute the reverse-dependency graph
+ * without re-running esbuild. Lives under `node_modules/.cache/` (npm convention,
+ * gitignored, survives `rm -rf tmp/`).
+ *
+ * The wrapper format records the absolute cwd at write time so the reader can
+ * resolve metafile-relative paths the same way esbuild would, regardless of
+ * where qunitx is invoked from on the next run.
+ */
+interface MetafileCachePayload {
+  /** `process.cwd()` at the moment the metafile was produced; metafile paths are relative to it. */
+  esbuildCwd: string;
+  /** The raw esbuild metafile this cache represents. */
+  metafile: AffectedMetafile;
+}
+
+const CACHE_FILE = 'metafile.json';
+
+/**
+ * Returns the on-disk cache path for `projectRoot`. The path embeds a SHA-1
+ * tag of the absolute project root so projects that share a hoisted/symlinked
+ * `node_modules` (pnpm workspaces, monorepos, integration test fixtures) write
+ * to distinct files. 12 hex chars is far below collision risk for the scale of
+ * "projects on one machine."
+ */
+export function metafileCachePath(projectRoot: string): string {
+  const tag = createHash('sha1').update(projectRoot).digest('hex').slice(0, 12);
+  return path.join(projectRoot, 'node_modules', '.cache', 'qunitx', tag, CACHE_FILE);
+}
+
+/** Best-effort write; failures are swallowed because cache miss on the next read just degrades to "run all tests." */
+export async function writeMetafileCache(
+  projectRoot: string,
+  esbuildCwd: string,
+  metafile: AffectedMetafile,
+): Promise<void> {
+  const file = metafileCachePath(projectRoot);
+  try {
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(
+      file,
+      JSON.stringify({ esbuildCwd, metafile } satisfies MetafileCachePayload),
+    );
+  } catch {
+    /* node_modules/.cache may not be writable (read-only FS, EACCES); silent degrade. */
+  }
+}
+
+/** Reads the cached metafile. Returns `null` on miss or corruption. */
+export async function readMetafileCache(projectRoot: string): Promise<MetafileCachePayload | null> {
+  try {
+    const raw = await fs.readFile(metafileCachePath(projectRoot), 'utf8');
+    const parsed = JSON.parse(raw) as MetafileCachePayload;
+    if (typeof parsed?.esbuildCwd !== 'string' || !parsed.metafile?.inputs) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export type { MetafileCachePayload };

--- a/lib/utils/parse-cli-flags.ts
+++ b/lib/utils/parse-cli-flags.ts
@@ -19,6 +19,7 @@ interface ParsedFlags {
   browser?: 'chromium' | 'firefox' | 'webkit';
   before?: string | false;
   after?: string | false;
+  changedSince?: string;
 }
 
 /**
@@ -73,6 +74,17 @@ export function parseCliFlags(projectRoot: string): ParsedFlags {
         return Object.assign(result, { before: parseModule(arg.split('=')[1]) });
       } else if (arg.startsWith('--after')) {
         return Object.assign(result, { after: parseModule(arg.split('=')[1]) });
+      } else if (arg === '--changed') {
+        // Shorthand for --since=HEAD. Most common case: "what tests does my
+        // working tree affect compared to last commit?"
+        return Object.assign(result, { changedSince: 'HEAD' });
+      } else if (arg.startsWith('--since')) {
+        const ref = arg.split('=')[1];
+        if (!ref) {
+          console.error(`Invalid --since value: empty. Expected --since=<git-ref>.`);
+          process.exit(1);
+        }
+        return Object.assign(result, { changedSince: ref });
       } else if (arg === '--trace-perf') {
         return result; // consumed by perf-logger.js at module load time, not stored in config
       }

--- a/test/commands/daemon-test.ts
+++ b/test/commands/daemon-test.ts
@@ -581,12 +581,12 @@ module('Commands | Daemon | idle timeout', { concurrency: true }, () => {
       const start = await cli(project, 'daemon start', {
         env: { ...CLI_ENV, QUNITX_DAEMON_IDLE_TIMEOUT: '500ms' },
       });
+      // exitCode 0 already certifies the daemon was up at cli-return time
+      // (the start path waits for both the info file AND a successful ping
+      // before returning). An `existsSync` line right after races the 500 ms
+      // timer on loaded Windows CI — the daemon may have already self-shut-
+      // down — so we omit it; `waitForFileGone` is the load-bearing check.
       assert.exitCode(start, 0);
-      assert.ok(existsSync(project.infoPath), 'info file present immediately after start');
-
-      // Event-driven wait via fs.watch — sub-ms latency, zero CPU between events.
-      // 3 s deadline is ~6× the configured timer; covers worst-case CI scheduling
-      // jitter without bleeding test time when the shutdown happens promptly.
       const gone = await waitForFileGone(project.infoPath, 3000);
       assert.ok(gone, 'daemon self-shut-down within the configured window');
     },

--- a/test/commands/help-test.ts
+++ b/test/commands/help-test.ts
@@ -40,6 +40,8 @@ Optional flags:
 --before : run a script before the tests(i.e start a new web server before tests)
 --after : run a script after the tests(i.e save test results to a file)
 --no-daemon : don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn
+--changed : run only test files affected by changes since HEAD (requires git; falls back to running all on first use)
+--since : run only test files affected by changes since the given git ref (e.g. --since=main); --changed = --since=HEAD
 --trace-perf : write timestamped startup-perf trace lines to stderr (Chrome pre-launch, module load, browser bind)
 
 Example: $ qunitx test/foo.ts app/e2e --debug --watch --before=scripts/start-new-webserver.js --after=scripts/write-test-results.js

--- a/test/flags/changed-test.ts
+++ b/test/flags/changed-test.ts
@@ -1,0 +1,147 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { module, test } from 'qunitx';
+import '../helpers/custom-asserts.ts';
+import { spawnCapture } from '../helpers/shell.ts';
+import { acquireBrowser } from '../helpers/browser-semaphore-queue.ts';
+import { metafileCachePath } from '../../lib/utils/metafile-cache.ts';
+
+const execFileAsync = promisify(execFile);
+const CWD = process.cwd();
+
+interface ChangedProject {
+  cwd: string;
+}
+
+// Build a self-contained git project with src + tests, symlinking node_modules
+// to the parent so qunitx + esbuild resolve. Same pattern as daemon-test.ts.
+async function makeChangedProject(): Promise<ChangedProject> {
+  const id = crypto.randomUUID();
+  const cwd = path.join(CWD, 'tmp', `changed-${id}`);
+  await fs.mkdir(cwd, { recursive: true });
+  // All file/dir creation under cwd is independent — fan out in one Promise.all.
+  // `writeWithMkdir` ensures the target's parent exists per-write so we don't
+  // need to pre-create `src/` and `test/` separately.
+  await Promise.all([
+    fs.symlink(path.join(CWD, 'node_modules'), path.join(cwd, 'node_modules')),
+    writeWithMkdir(
+      path.join(cwd, 'package.json'),
+      JSON.stringify({ name: id, version: '0.0.1', type: 'module' }),
+    ),
+    writeWithMkdir(path.join(cwd, '.gitignore'), 'node_modules/\ntmp/\n'),
+    writeWithMkdir(path.join(cwd, 'src/a.ts'), 'export const a = 1;\n'),
+    writeWithMkdir(path.join(cwd, 'src/b.ts'), 'export const b = 2;\n'),
+    writeWithMkdir(
+      path.join(cwd, 'test/a-test.ts'),
+      [
+        `import { module, test } from 'qunitx';`,
+        `import { a } from '../src/a.ts';`,
+        `module('a', () => { test('a===1', (assert) => assert.equal(a, 1)); });`,
+      ].join('\n') + '\n',
+    ),
+    writeWithMkdir(
+      path.join(cwd, 'test/b-test.ts'),
+      [
+        `import { module, test } from 'qunitx';`,
+        `import { b } from '../src/b.ts';`,
+        `module('b', () => { test('b===2', (assert) => assert.equal(b, 2)); });`,
+      ].join('\n') + '\n',
+    ),
+  ]);
+
+  // Inline `-c` user info on commit — avoids touching `.git/config` and the
+  // lock-file race two parallel `git config` calls would hit.
+  await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd });
+  await execFileAsync('git', ['add', '-A'], { cwd });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-q', '-m', 'init'],
+    { cwd },
+  );
+
+  return { cwd };
+}
+
+async function writeWithMkdir(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+}
+
+// Default `shell` doesn't forward cwd, and these tests must run inside their
+// per-project directory so qunitx finds their package.json + test files (not
+// qunitx-cli's). spawnCapture takes cwd directly. Auto-output keeps parallel
+// runs from clobbering one another.
+async function runCli(project: ChangedProject, args: string) {
+  const id = crypto.randomUUID();
+  const permit = await acquireBrowser();
+  try {
+    return await spawnCapture(`node ${CWD}/cli.ts ${args} --output=tmp/run-${id}`, {
+      env: { ...process.env, FORCE_COLOR: '0' },
+      cwd: project.cwd,
+    });
+  } finally {
+    permit.release();
+  }
+}
+
+module('--changed flag', { concurrency: true }, () => {
+  test('first run warms the metafile cache; second --changed with no edits skips all tests', async (assert) => {
+    const project = await makeChangedProject();
+
+    // Run 1: full build, no --changed. Populates the per-project metafile cache.
+    const first = await runCli(project, 'test/');
+    assert.exitCode(first, 0);
+    assert.includes(first, '# pass 2');
+
+    assert.ok(
+      await fs
+        .stat(metafileCachePath(project.cwd))
+        .then(() => true)
+        .catch(() => false),
+      'metafile cache written after first run',
+    );
+
+    // Run 2: --changed with HEAD === working tree. Filter resolves to 0 tests; exit 0 fast.
+    const second = await runCli(project, 'test/ --changed');
+    assert.exitCode(second, 0);
+    assert.includes(second, '# Running 0 test files');
+    assert.includes(second, '1..0');
+    assert.notIncludes(second, '# pass');
+  });
+
+  test('--changed runs only tests whose imports include a changed source file', async (assert) => {
+    const project = await makeChangedProject();
+
+    // Warm the metafile.
+    const first = await runCli(project, 'test/');
+    assert.exitCode(first, 0);
+    assert.includes(first, '# pass 2');
+
+    // Modify only src/a.ts so that only test/a-test.ts is affected.
+    await fs.writeFile(path.join(project.cwd, 'src/a.ts'), 'export const a = 1;\n// tweak\n');
+
+    const second = await runCli(project, 'test/ --changed');
+    assert.exitCode(second, 0);
+    assert.includes(second, '1 of 2 test files affected');
+    assert.includes(second, '# pass 1');
+    assert.notIncludes(second, '# pass 2');
+  });
+
+  test('package.json change short-circuits to a full run with a warning', async (assert) => {
+    const project = await makeChangedProject();
+
+    await runCli(project, 'test/');
+    await fs.writeFile(
+      path.join(project.cwd, 'package.json'),
+      JSON.stringify({ name: 'changed', version: '0.0.2', type: 'module' }),
+    );
+
+    const result = await runCli(project, 'test/ --changed');
+    assert.exitCode(result, 0);
+    assert.includes(result, 'blast-radius');
+    assert.includes(result, '# pass 2');
+  });
+});

--- a/test/setup/get-changed-fs-tree-test.ts
+++ b/test/setup/get-changed-fs-tree-test.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { module, test } from 'qunitx';
+import { getChangedFsTree } from '../../lib/setup/get-changed-fs-tree.ts';
+import { writeMetafileCache } from '../../lib/utils/metafile-cache.ts';
+import type { AffectedMetafile } from '../../lib/utils/get-changed-files.ts';
+import type { FSTree } from '../../lib/types.ts';
+
+// Asserts on the orchestrator's return value only. The stdout diagnostic
+// ("# --changed: …") is covered end-to-end in test/flags/changed-test.ts
+// against a real subprocess; monkey-patching process.stdout here would race
+// when modules run with `concurrency: true`. Real git repos + real metafile
+// cache are used because each fixture costs ~80 ms and any mock would lose
+// fidelity for less.
+
+const execFileAsync = promisify(execFile);
+
+async function makeProjectWithGit(initial: Record<string, string>): Promise<string> {
+  const root = path.join(process.cwd(), 'tmp', `get-changed-fs-tree-${crypto.randomUUID()}`);
+  await fs.mkdir(root, { recursive: true });
+  // node_modules holds the metafile cache — gitignore it so writes there don't
+  // surface as "changed" in git status during the test. Fanned out in parallel
+  // with the fixture writes since none of them depend on each other.
+  await Promise.all([
+    fs.writeFile(path.join(root, '.gitignore'), 'node_modules/\n'),
+    ...Object.entries(initial).map(async ([rel, content]) => {
+      const target = path.join(root, rel);
+      await fs.mkdir(path.dirname(target), { recursive: true });
+      await fs.writeFile(target, content);
+    }),
+  ]);
+  // Inline `-c` user info on commit — avoids touching `.git/config` and the
+  // lock-file race two parallel `git config` calls would hit.
+  await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  await execFileAsync('git', ['add', '-A'], { cwd: root });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-q', '-m', 'init'],
+    { cwd: root },
+  );
+  return root;
+}
+
+// For "git fails" tests we need a directory that ISN'T under any git repo. The
+// repo's tmp/ is inside qunitx-cli's own git work-tree, so git would find that
+// parent repo via the upward walk; using os.tmpdir() (typically /tmp) escapes.
+async function makeProjectWithoutGit(): Promise<string> {
+  const root = path.join(os.tmpdir(), `qunitx-get-changed-fs-tree-no-git-${crypto.randomUUID()}`);
+  await fs.mkdir(root, { recursive: true });
+  return root;
+}
+
+function fsTreeFromAbs(root: string, files: string[]): FSTree {
+  return Object.fromEntries(files.map((f) => [path.join(root, f), null]));
+}
+
+function metafileFor(graph: Record<string, string[]>): AffectedMetafile {
+  return {
+    inputs: Object.fromEntries(
+      Object.entries(graph).map(([file, imports]) => [
+        file,
+        { imports: imports.map((p) => ({ path: p })) },
+      ]),
+    ),
+  };
+}
+
+module('Setup | getChangedFsTree | fallback paths', { concurrency: true }, () => {
+  test('no metafile cache → returns input fsTree unchanged', async (assert) => {
+    const root = await makeProjectWithGit({ 'a.ts': '', 'test/a-test.ts': '' });
+    const tree = fsTreeFromAbs(root, ['test/a-test.ts']);
+    const result = await getChangedFsTree(tree, root, 'HEAD');
+    assert.strictEqual(result, tree);
+  });
+
+  test('git fails (not a repo) → returns input fsTree unchanged', async (assert) => {
+    const root = await makeProjectWithoutGit();
+    await writeMetafileCache(root, root, metafileFor({}));
+    const tree = fsTreeFromAbs(root, ['test/a-test.ts']);
+    const result = await getChangedFsTree(tree, root, 'HEAD');
+    assert.strictEqual(result, tree);
+  });
+
+  test('blast-radius file changed → returns input fsTree unchanged', async (assert) => {
+    const root = await makeProjectWithGit({
+      'package.json': '{}',
+      'test/a-test.ts': '',
+    });
+    await writeMetafileCache(root, root, metafileFor({ 'test/a-test.ts': [] }));
+    await fs.writeFile(path.join(root, 'package.json'), '{"name":"x"}');
+    const tree = fsTreeFromAbs(root, ['test/a-test.ts']);
+    const result = await getChangedFsTree(tree, root, 'HEAD');
+    assert.strictEqual(result, tree);
+  });
+});
+
+module('Setup | getChangedFsTree | filtered runs', { concurrency: true }, () => {
+  test('filters to tests whose deps include a changed source file', async (assert) => {
+    const root = await makeProjectWithGit({
+      'src/a.ts': 'export const a = 1;',
+      'src/b.ts': 'export const b = 2;',
+      'test/a-test.ts': "import './a.ts';",
+      'test/b-test.ts': "import './b.ts';",
+    });
+    await writeMetafileCache(
+      root,
+      root,
+      metafileFor({
+        'test/a-test.ts': ['src/a.ts'],
+        'test/b-test.ts': ['src/b.ts'],
+        'src/a.ts': [],
+        'src/b.ts': [],
+      }),
+    );
+    await fs.writeFile(path.join(root, 'src/a.ts'), 'export const a = 99;');
+    const tree = fsTreeFromAbs(root, ['test/a-test.ts', 'test/b-test.ts']);
+    const result = await getChangedFsTree(tree, root, 'HEAD');
+    assert.deepEqual(
+      Object.keys(result).sort(),
+      [path.join(root, 'test/a-test.ts')],
+      'only the affected test survives',
+    );
+  });
+
+  test('no changes → returns empty fsTree (skip-all path)', async (assert) => {
+    const root = await makeProjectWithGit({ 'test/a-test.ts': '' });
+    await writeMetafileCache(root, root, metafileFor({ 'test/a-test.ts': [] }));
+    const tree = fsTreeFromAbs(root, ['test/a-test.ts']);
+    const result = await getChangedFsTree(tree, root, 'HEAD');
+    assert.equal(Object.keys(result).length, 0);
+  });
+
+  test('empty input fsTree short-circuits without git or cache reads', async (assert) => {
+    // Non-git dir + no metafile cache — any read would observably fail.
+    const root = await makeProjectWithoutGit();
+    const result = await getChangedFsTree({}, root, 'HEAD');
+    assert.equal(Object.keys(result).length, 0);
+  });
+});

--- a/test/setup/parse-cli-flags-test.ts
+++ b/test/setup/parse-cli-flags-test.ts
@@ -109,6 +109,28 @@ module('Setup | parseCliFlags | --failFast', { concurrency: true }, () => {
   });
 });
 
+module('Setup | parseCliFlags | --changed / --since', { concurrency: true }, () => {
+  test('--changed sets changedSince to "HEAD"', (assert) => {
+    const flags = withArgv(['--changed'], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.changedSince, 'HEAD');
+  });
+
+  test('--since=<ref> sets changedSince to the given ref', (assert) => {
+    const flags = withArgv(['--since=main'], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.changedSince, 'main');
+  });
+
+  test('--since=origin/main keeps the slash-bearing ref', (assert) => {
+    const flags = withArgv(['--since=origin/main'], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.changedSince, 'origin/main');
+  });
+
+  test('changedSince is undefined when neither flag is present', (assert) => {
+    const flags = withArgv([], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.changedSince, undefined);
+  });
+});
+
 module('Setup | parseCliFlags | --timeout', { concurrency: true }, () => {
   test('--timeout value is parsed as a number, not a string', (assert) => {
     const flags = withArgv(['--timeout=5000'], () => parseCliFlags(PROJECT_ROOT));

--- a/test/setup/write-output-static-files-test.ts
+++ b/test/setup/write-output-static-files-test.ts
@@ -1,0 +1,129 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { module, test } from 'qunitx';
+import { writeOutputStaticFiles } from '../../lib/setup/write-output-static-files.ts';
+import type { CachedContent } from '../../lib/types.ts';
+
+// Build the minimal CachedContent shape writeOutputStaticFiles touches: just the
+// two collections it iterates over. The other fields are run-state slots the
+// function doesn't read here.
+function cachedContentFor(opts: {
+  staticHTMLs?: Record<string, string>;
+  assets?: string[];
+}): CachedContent {
+  return {
+    allTestCode: null,
+    assets: new Set(opts.assets ?? []),
+    htmlPathsToRunTests: [],
+    mainHTML: { filePath: null, html: null },
+    staticHTMLs: opts.staticHTMLs ?? {},
+    dynamicContentHTMLs: {},
+  };
+}
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = path.join(process.cwd(), 'tmp', `${prefix}-${crypto.randomUUID()}`);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+module('Setup | writeOutputStaticFiles', { concurrency: true }, () => {
+  test('asset under projectRoot lands at outDir/<rel>', async (assert) => {
+    const projectRoot = await tempDir('wsf');
+    const asset = path.join(projectRoot, 'node_modules', 'qunitx', 'vendor', 'qunit.css');
+    await writeAsset(asset, '/* css */');
+
+    await writeOutputStaticFiles(
+      { projectRoot, output: 'tmp/out' },
+      cachedContentFor({ assets: [asset] }),
+    );
+
+    const dest = path.join(
+      projectRoot,
+      'tmp',
+      'out',
+      'node_modules',
+      'qunitx',
+      'vendor',
+      'qunit.css',
+    );
+    assert.strictEqual(
+      await fs.readFile(dest, 'utf8'),
+      '/* css */',
+      'asset copied under outDir at the same relative subpath',
+    );
+  });
+
+  test('asset OUTSIDE projectRoot still lands inside outDir (no `..` escape)', async (assert) => {
+    // Mirrors the pnpm/yarn-workspace and test-fixture-symlink case: qunitx is
+    // hoisted to a parent's node_modules, so its absolute realpath resolves to
+    // a tree outside `projectRoot`. Without stripping the leading `..` from the
+    // computed relative path, `path.join(outDir, '..\\..\\node_modules\\…')`
+    // would cancel two segments of outDir and converge multiple group runs on
+    // the same destination — root cause of the Windows EBUSY observed in CI.
+    const workspace = await tempDir('wsf-ws');
+    const projectRoot = path.join(workspace, 'packages', 'foo');
+    const asset = path.join(workspace, 'node_modules', 'qunitx', 'vendor', 'qunit.css');
+    await Promise.all([
+      fs.mkdir(projectRoot, { recursive: true }),
+      writeAsset(asset, '/* hoisted css */'),
+    ]);
+
+    await writeOutputStaticFiles(
+      { projectRoot, output: 'tmp/run-X/group-0' },
+      cachedContentFor({ assets: [asset] }),
+    );
+
+    const dest = path.join(projectRoot, 'tmp/run-X/group-0/node_modules/qunitx/vendor/qunit.css');
+    const escapePath = path.join(projectRoot, 'tmp/node_modules/qunitx/vendor/qunit.css');
+    const [destContent, escapeExists] = await Promise.all([
+      fs.readFile(dest, 'utf8'),
+      fs
+        .stat(escapePath)
+        .then(() => true)
+        .catch(() => false),
+    ]);
+    assert.strictEqual(destContent, '/* hoisted css */', 'asset anchored at outDir');
+    assert.equal(escapeExists, false, 'nothing written at the escaped path');
+  });
+
+  test('two outputs sharing one source land at distinct dests (group-mode shape)', async (assert) => {
+    // Concrete shape of what run.ts does in concurrent group mode: each group
+    // gets its own outDir like `tmp/run-X/group-0`, `tmp/run-X/group-1`. Both
+    // copy the same upstream asset; their dests must differ for parallel
+    // copyFile to be safe under Windows file locking.
+    const workspace = await tempDir('wsf-groups');
+    const projectRoot = path.join(workspace, 'packages', 'foo');
+    const asset = path.join(workspace, 'node_modules', 'qunitx', 'vendor', 'qunit.css');
+    await Promise.all([
+      fs.mkdir(projectRoot, { recursive: true }),
+      writeAsset(asset, '/* shared */'),
+    ]);
+
+    await Promise.all([
+      writeOutputStaticFiles(
+        { projectRoot, output: 'tmp/run-X/group-0' },
+        cachedContentFor({ assets: [asset] }),
+      ),
+      writeOutputStaticFiles(
+        { projectRoot, output: 'tmp/run-X/group-1' },
+        cachedContentFor({ assets: [asset] }),
+      ),
+    ]);
+
+    const a = path.join(projectRoot, 'tmp/run-X/group-0/node_modules/qunitx/vendor/qunit.css');
+    const b = path.join(projectRoot, 'tmp/run-X/group-1/node_modules/qunitx/vendor/qunit.css');
+    const [contentA, contentB] = await Promise.all([
+      fs.readFile(a, 'utf8'),
+      fs.readFile(b, 'utf8'),
+    ]);
+    assert.strictEqual(contentA, '/* shared */');
+    assert.strictEqual(contentB, '/* shared */');
+  });
+});
+
+async function writeAsset(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+}

--- a/test/utils/get-changed-file-paths-in-git-since-test.ts
+++ b/test/utils/get-changed-file-paths-in-git-since-test.ts
@@ -1,0 +1,109 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { module, test } from 'qunitx';
+import {
+  BLAST_RADIUS_FILES,
+  BLAST_RADIUS_PATTERNS,
+  getChangedFilePathsInGitSince,
+} from '../../lib/utils/get-changed-file-paths-in-git-since.ts';
+
+const execFileAsync = promisify(execFile);
+
+// Each test gets a private temp git repo. `git init` + 2 commits ≈ 60-90 ms.
+// Tests run concurrently so wall-clock cost stays under 200 ms for the full module.
+async function makeRepo(initial: Record<string, string>): Promise<string> {
+  const root = path.join(process.cwd(), 'tmp', `changed-files-${crypto.randomUUID()}`);
+  await fs.mkdir(root, { recursive: true });
+  // Fan out file writes in parallel; otherwise the per-fixture cost is dominated
+  // by sequential mkdir+writeFile latency, not the test logic we care about.
+  await Promise.all(
+    Object.entries(initial).map(async ([rel, content]) => {
+      const target = path.join(root, rel);
+      await fs.mkdir(path.dirname(target), { recursive: true });
+      await fs.writeFile(target, content);
+    }),
+  );
+  // Inline `-c` user info on commit — avoids touching `.git/config` and the
+  // lock-file race two parallel `git config` calls would hit.
+  await execFileAsync('git', ['init', '-q', '-b', 'main'], { cwd: root });
+  await execFileAsync('git', ['add', '-A'], { cwd: root });
+  await execFileAsync(
+    'git',
+    ['-c', 'user.email=test@example.com', '-c', 'user.name=Test', 'commit', '-q', '-m', 'init'],
+    { cwd: root },
+  );
+  return root;
+}
+
+module('Utils | getChangedFilePathsInGitSince | constants', { concurrency: true }, () => {
+  test('blast-radius set covers the load-bearing config files', (assert) => {
+    assert.ok(BLAST_RADIUS_FILES.has('package.json'));
+    assert.ok(BLAST_RADIUS_FILES.has('package-lock.json'));
+    assert.ok(BLAST_RADIUS_FILES.has('deno.json'));
+    assert.ok(BLAST_RADIUS_FILES.has('deno.lock'));
+  });
+
+  test('blast-radius patterns match tsconfig variants', (assert) => {
+    const matches = (s: string) => BLAST_RADIUS_PATTERNS.some((re) => re.test(s));
+    assert.ok(matches('tsconfig.json'));
+    assert.ok(matches('tsconfig.test.json'));
+    assert.ok(matches('tsconfig.build.json'));
+    assert.notOk(matches('foo.json'));
+  });
+});
+
+module('Utils | getChangedFilePathsInGitSince | git interaction', { concurrency: true }, () => {
+  test('returns empty set when nothing changed', async (assert) => {
+    const root = await makeRepo({ 'a.ts': 'export const a = 1;' });
+    const result = await getChangedFilePathsInGitSince(root, 'HEAD');
+    assert.ok(result, 'not blast-radius');
+    assert.equal(result!.size, 0);
+  });
+
+  test('untracked file is reported as changed', async (assert) => {
+    const root = await makeRepo({ 'a.ts': 'export const a = 1;' });
+    await fs.writeFile(path.join(root, 'b.ts'), 'export const b = 2;');
+    const result = await getChangedFilePathsInGitSince(root, 'HEAD');
+    assert.ok(result);
+    assert.ok(result!.has(path.resolve(root, 'b.ts')));
+  });
+
+  test('modified tracked file is reported as changed', async (assert) => {
+    const root = await makeRepo({ 'a.ts': 'export const a = 1;' });
+    await fs.writeFile(path.join(root, 'a.ts'), 'export const a = 2;');
+    const result = await getChangedFilePathsInGitSince(root, 'HEAD');
+    assert.ok(result);
+    assert.ok(result!.has(path.resolve(root, 'a.ts')));
+  });
+
+  test('package.json change short-circuits to null (blast radius)', async (assert) => {
+    const root = await makeRepo({
+      'a.ts': 'export const a = 1;',
+      'package.json': '{}',
+    });
+    await fs.writeFile(path.join(root, 'package.json'), '{"name":"x"}');
+    const result = await getChangedFilePathsInGitSince(root, 'HEAD');
+    assert.equal(result, null);
+  });
+
+  test('tsconfig.test.json change short-circuits to null', async (assert) => {
+    const root = await makeRepo({
+      'a.ts': 'export const a = 1;',
+      'tsconfig.test.json': '{}',
+    });
+    await fs.writeFile(path.join(root, 'tsconfig.test.json'), '{"compilerOptions":{}}');
+    const result = await getChangedFilePathsInGitSince(root, 'HEAD');
+    assert.equal(result, null);
+  });
+
+  test('throws on missing ref so caller can degrade with a warning', async (assert) => {
+    const root = await makeRepo({ 'a.ts': '' });
+    await assert.rejects(
+      getChangedFilePathsInGitSince(root, 'no-such-ref'),
+      'unknown ref bubbles as a rejection',
+    );
+  });
+});

--- a/test/utils/get-changed-files-test.ts
+++ b/test/utils/get-changed-files-test.ts
@@ -1,0 +1,119 @@
+import path from 'node:path';
+import { module, test } from 'qunitx';
+import { getChangedFiles, type AffectedMetafile } from '../../lib/utils/get-changed-files.ts';
+
+// Pure-function unit tests — no I/O, no spawning. Each module runs in <2 ms locally.
+
+const CWD = '/proj';
+const abs = (rel: string) => path.resolve(CWD, rel);
+
+function metafileFor(graph: Record<string, string[]>): AffectedMetafile {
+  return {
+    inputs: Object.fromEntries(
+      Object.entries(graph).map(([file, imports]) => [
+        file,
+        { imports: imports.map((p) => ({ path: p })) },
+      ]),
+    ),
+  };
+}
+
+module('Utils | getChangedFiles | basic', { concurrency: true }, () => {
+  test('a test that imports a changed source file is affected', (assert) => {
+    const meta = metafileFor({
+      'test/foo-test.ts': ['src/foo.ts'],
+      'src/foo.ts': [],
+    });
+    const result = getChangedFiles(meta, CWD, new Set([abs('src/foo.ts')]), [
+      abs('test/foo-test.ts'),
+    ]);
+    assert.deepEqual([...result], [abs('test/foo-test.ts')]);
+  });
+
+  test('a test whose deps do not include any changed file is not affected', (assert) => {
+    const meta = metafileFor({
+      'test/foo-test.ts': ['src/foo.ts'],
+      'src/foo.ts': [],
+      'src/bar.ts': [],
+    });
+    const result = getChangedFiles(meta, CWD, new Set([abs('src/bar.ts')]), [
+      abs('test/foo-test.ts'),
+    ]);
+    assert.equal(result.size, 0);
+  });
+
+  test('a changed test file is affected (self-reach via changedAbsPaths)', (assert) => {
+    const meta = metafileFor({ 'test/foo-test.ts': [] });
+    const result = getChangedFiles(meta, CWD, new Set([abs('test/foo-test.ts')]), [
+      abs('test/foo-test.ts'),
+    ]);
+    assert.deepEqual([...result], [abs('test/foo-test.ts')]);
+  });
+
+  test('transitive: test → util → changed leaf is affected', (assert) => {
+    const meta = metafileFor({
+      'test/foo-test.ts': ['src/util.ts'],
+      'src/util.ts': ['src/leaf.ts'],
+      'src/leaf.ts': [],
+    });
+    const result = getChangedFiles(meta, CWD, new Set([abs('src/leaf.ts')]), [
+      abs('test/foo-test.ts'),
+    ]);
+    assert.deepEqual([...result], [abs('test/foo-test.ts')]);
+  });
+});
+
+module('Utils | getChangedFiles | edge cases', { concurrency: true }, () => {
+  test('cycle in dep graph does not infinite-loop and resolves correctly', (assert) => {
+    const meta = metafileFor({
+      'test/foo-test.ts': ['src/a.ts'],
+      'src/a.ts': ['src/b.ts'],
+      'src/b.ts': ['src/a.ts'], // cycle
+    });
+    const result = getChangedFiles(meta, CWD, new Set([abs('src/b.ts')]), [
+      abs('test/foo-test.ts'),
+    ]);
+    assert.deepEqual([...result], [abs('test/foo-test.ts')]);
+  });
+
+  test('test not present in metafile is not affected unless it is itself changed', (assert) => {
+    const meta = metafileFor({ 'test/known-test.ts': [] });
+    // 'test/new-test.ts' has no metafile entry: it can only be marked affected if
+    // the changed set contains it directly (matches "newly added test file" case).
+    const newlyAdded = abs('test/new-test.ts');
+    const r1 = getChangedFiles(meta, CWD, new Set([newlyAdded]), [newlyAdded]);
+    assert.deepEqual(
+      [...r1],
+      [newlyAdded],
+      'newly added test file is included via changedAbsPaths',
+    );
+
+    const r2 = getChangedFiles(meta, CWD, new Set([abs('src/x.ts')]), [newlyAdded]);
+    assert.equal(r2.size, 0, 'unrelated change → unknown test is not pulled in');
+  });
+
+  test('many tests sharing a dep memoize the dep walk (semantic verification)', (assert) => {
+    // 50 tests all pointing at one shared util that doesn't reach the change.
+    // Without memoization the walk would explode; with it, the assertion passes
+    // because every test resolves through the same cached `false` for the util.
+    const indices = Array.from({ length: 50 }, (_, i) => i);
+    const inputs: Record<string, string[]> = {
+      'src/shared.ts': [],
+      ...Object.fromEntries(indices.map((i) => [`test/t-${i}.ts`, ['src/shared.ts']])),
+    };
+    const tests = indices.map((i) => abs(`test/t-${i}.ts`));
+    const result = getChangedFiles(
+      metafileFor(inputs),
+      CWD,
+      new Set([abs('src/unrelated.ts')]),
+      tests,
+    );
+    assert.equal(result.size, 0);
+  });
+
+  test('empty changed set returns empty result', (assert) => {
+    const meta = metafileFor({ 'test/foo-test.ts': ['src/foo.ts'] });
+    const result = getChangedFiles(meta, CWD, new Set(), [abs('test/foo-test.ts')]);
+    assert.equal(result.size, 0);
+  });
+});

--- a/test/utils/metafile-cache-test.ts
+++ b/test/utils/metafile-cache-test.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { module, test } from 'qunitx';
+import {
+  metafileCachePath,
+  readMetafileCache,
+  writeMetafileCache,
+} from '../../lib/utils/metafile-cache.ts';
+import type { AffectedMetafile } from '../../lib/utils/get-changed-files.ts';
+
+async function tempProjectRoot(): Promise<string> {
+  const root = path.join(process.cwd(), 'tmp', `metafile-cache-${crypto.randomUUID()}`);
+  await fs.mkdir(root, { recursive: true });
+  return root;
+}
+
+const SAMPLE: AffectedMetafile = {
+  inputs: {
+    'test/foo.ts': { imports: [{ path: 'src/foo.ts' }] },
+    'src/foo.ts': { imports: [] },
+  },
+};
+
+module('Utils | metafile-cache', { concurrency: true }, () => {
+  test('write then read round-trips esbuildCwd + metafile', async (assert) => {
+    const root = await tempProjectRoot();
+    await writeMetafileCache(root, '/some/cwd', SAMPLE);
+    const got = await readMetafileCache(root);
+    assert.ok(got, 'cache hit');
+    assert.equal(got!.esbuildCwd, '/some/cwd');
+    assert.deepEqual(got!.metafile, SAMPLE);
+  });
+
+  test('read returns null when file does not exist', async (assert) => {
+    const root = await tempProjectRoot();
+    assert.equal(await readMetafileCache(root), null);
+  });
+
+  test('read returns null on corrupt JSON', async (assert) => {
+    const root = await tempProjectRoot();
+    const cacheFile = metafileCachePath(root);
+    await fs.mkdir(path.dirname(cacheFile), { recursive: true });
+    await fs.writeFile(cacheFile, '{not-json');
+    assert.equal(await readMetafileCache(root), null);
+  });
+
+  test('read returns null when payload is missing required fields', async (assert) => {
+    const root = await tempProjectRoot();
+    const cacheFile = metafileCachePath(root);
+    await fs.mkdir(path.dirname(cacheFile), { recursive: true });
+    await fs.writeFile(cacheFile, JSON.stringify({ esbuildCwd: '/x' })); // no metafile
+    assert.equal(await readMetafileCache(root), null);
+  });
+
+  test('distinct projectRoots that share a node_modules write to distinct cache files', async (assert) => {
+    // Regression test for the CI failure on PR1's first run: the test fixture's
+    // symlinked node_modules made every per-test project share one cache, so
+    // concurrent runs overwrote each other. The path tag derived from
+    // projectRoot keeps each project's cache isolated even under the symlink.
+    const [rootA, rootB] = await Promise.all([tempProjectRoot(), tempProjectRoot()]);
+    assert.notStrictEqual(metafileCachePath(rootA), metafileCachePath(rootB));
+    // Same projectRoot must always resolve to the same path so daemon runs hit.
+    assert.strictEqual(metafileCachePath(rootA), metafileCachePath(rootA));
+  });
+
+  test('write is best-effort: read-only cache dir does not throw', async (assert) => {
+    // No cache dir creation — write a regular file at the would-be dir path so
+    // mkdir fails (EEXIST as file). writeMetafileCache should swallow the error.
+    const root = await tempProjectRoot();
+    const cacheParent = path.join(root, 'node_modules', '.cache');
+    await fs.mkdir(path.dirname(cacheParent), { recursive: true });
+    await fs.writeFile(cacheParent, ''); // file where dir is expected → mkdir fails
+    await writeMetafileCache(root, '/x', SAMPLE); // must not throw
+    // And subsequent read returns null because the file was never written.
+    assert.equal(await readMetafileCache(root), null);
+  });
+});


### PR DESCRIPTION
Adds two new flags that filter the test set to only files whose transitive imports include any file changed since a git ref:

  qunitx --changed           # since HEAD (working-tree changes)
  qunitx --since=main        # since any ref

Pipeline:
1. Every successful build emits an esbuild metafile to node_modules/.cache/qunitx/metafile.json (build artifact, gitignored via the node_modules convention; survives rm -rf tmp/).
2. setupConfig reads the cache, runs `git diff --name-only <ref>` plus `git status --porcelain`, and uses the metafile's reverse-dep graph (memoized DFS, cycle-safe) to filter fsTree to affected tests.
3. Blast-radius files (package.json, lockfiles, tsconfig*.json) short- circuit to a full run with a TAP comment.
4. First-time use, git failure, or missing metafile each fall back to running all tests with a clear stdout note (TAP-comment style).

run.ts now handles the empty-fsTree case (clean `1..0` plan + exit 0) since the filter can legitimately resolve to zero affected tests.

Tests: 8 pure-fn dep-graph tests, 5 metafile-cache tests, 8 git-interaction tests, 6 orchestrator tests, 3 end-to-end integration tests covering cache-warm, filtered-rerun, and blast-radius paths. Total ~6s wall clock (integration tests are concurrent).