### PR TITLE
feat(cli): --shard=N/M flag for distributed CI matrix runs

### DIFF
--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -31,6 +31,7 @@ ${color('--after')} : run a script after the tests(i.e save test results to a fi
 ${color('--no-daemon')} : don't use the daemon for this run — skips a running daemon and prevents ${color('QUNITX_DAEMON')} auto-spawn
 ${color('--changed')} : run only test files affected by changes since ${color('HEAD')} (requires git; falls back to running all on first use)
 ${color('--since')} : run only test files affected by changes since the given git ref (e.g. ${color('--since=main')}); ${color('--changed')} = ${color('--since=HEAD')}
+${color('--shard')} : run only the Nth shard of M (e.g. ${color('--shard=2/4')}) for distributed CI matrix jobs — every file lands in exactly one shard, deterministically across machines
 ${color('--trace-perf')} : write timestamped startup-perf trace lines to stderr (Chrome pre-launch, module load, browser bind)
 
 ${highlight('Example:')} $ ${color('qunitx test/foo.ts app/e2e --debug --watch --before=scripts/start-new-webserver.js --after=scripts/write-test-results.js')}

--- a/lib/setup/config.ts
+++ b/lib/setup/config.ts
@@ -6,6 +6,7 @@ import { findProjectRoot } from '../utils/find-project-root.ts';
 import { buildFSTree } from './fs-tree.ts';
 import { setupTestFilePaths } from './test-file-paths.ts';
 import { getChangedFsTree } from './get-changed-fs-tree.ts';
+import { shardFsTree } from '../utils/shard-fs-tree.ts';
 import { parseCliFlags } from '../utils/parse-cli-flags.ts';
 import type { Config } from '../types.ts';
 import type { Plugin as EsbuildPlugin } from 'esbuild';
@@ -61,6 +62,23 @@ export async function setupConfig(): Promise<Config> {
   // on every save, not "what does my working tree affect" semantics.
   if (config.changedSince && !config.watch) {
     config.fsTree = await getChangedFsTree(config.fsTree, config.projectRoot, config.changedSince);
+  }
+
+  // --shard=N/M: keep only files in this shard. Stacks after --changed so the
+  // same shard always claims the same affected-tests subset on every CI worker.
+  // Watch mode skips: sharding is a CI distribution feature, not a dev loop one.
+  if (config.shardIndex !== undefined && config.shardTotal !== undefined && !config.watch) {
+    const before = Object.keys(config.fsTree).length;
+    config.fsTree = shardFsTree(
+      config.fsTree,
+      config.projectRoot,
+      config.shardIndex,
+      config.shardTotal,
+    );
+    const after = Object.keys(config.fsTree).length;
+    process.stdout.write(
+      `# --shard: ${after} of ${before} test files in shard ${config.shardIndex + 1}/${config.shardTotal}\n`,
+    );
   }
 
   return config as Config;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -132,6 +132,15 @@ export interface Config {
    * Falls back to running all tests on git failure or missing metafile cache.
    */
   changedSince?: string;
+  /**
+   * 0-indexed shard number; set by `--shard=N/M` (parser converts the
+   * human-facing 1-indexed N to 0-indexed). Files are partitioned by stable
+   * SHA-1 hash of their projectRoot-relative path, so every shard returns a
+   * disjoint slice and the union of all M shards equals the input set.
+   */
+  shardIndex?: number;
+  /** Total shard count, paired with `shardIndex`. */
+  shardTotal?: number;
   /** Mutable test-outcome counters updated as TAP events arrive. */
   COUNTER: Counter;
   /** Test files that failed on the previous run (drives re-run filtering). */

--- a/lib/utils/parse-cli-flags.ts
+++ b/lib/utils/parse-cli-flags.ts
@@ -20,6 +20,8 @@ interface ParsedFlags {
   before?: string | false;
   after?: string | false;
   changedSince?: string;
+  shardIndex?: number;
+  shardTotal?: number;
 }
 
 /**
@@ -85,6 +87,19 @@ export function parseCliFlags(projectRoot: string): ParsedFlags {
           process.exit(1);
         }
         return Object.assign(result, { changedSince: ref });
+      } else if (arg.startsWith('--shard')) {
+        const value = arg.split('=')[1] ?? '';
+        const match = /^(\d+)\/(\d+)$/.exec(value);
+        const n = match ? Number(match[1]) : NaN;
+        const m = match ? Number(match[2]) : NaN;
+        if (!match || n < 1 || m < 1 || n > m) {
+          console.error(
+            `Invalid --shard value: "${value}". Expected N/M with 1 ≤ N ≤ M (e.g. --shard=1/4).`,
+          );
+          process.exit(1);
+        }
+        // Store 0-indexed for consistent modulo math; humans pass 1-indexed.
+        return Object.assign(result, { shardIndex: n - 1, shardTotal: m });
       } else if (arg === '--trace-perf') {
         return result; // consumed by perf-logger.js at module load time, not stored in config
       }

--- a/lib/utils/shard-fs-tree.ts
+++ b/lib/utils/shard-fs-tree.ts
@@ -1,0 +1,37 @@
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import type { FSTree } from '../types.ts';
+
+/**
+ * Returns the subset of `fsTree` whose entries fall in shard `shardIndex` of
+ * `shardTotal`. Used by `--shard=N/M` for distributed-CI matrix jobs: every
+ * shard number returns a disjoint slice of the input tree, and across all M
+ * shards every input file appears in exactly one shard.
+ *
+ * Files are partitioned by SHA-1 of their projectRoot-relative path normalized
+ * to forward slashes (so the same file on Windows and POSIX hashes to the same
+ * shard). SHA-1 → uniform distribution; modulo `shardTotal` is exact under the
+ * assumption shardTotal ≪ 2³². The cost is ~1 µs per file even on tens-of-
+ * thousands-of-files repos — a non-factor next to the test runtime saved by
+ * sharding.
+ */
+export function shardFsTree(
+  fsTree: FSTree,
+  projectRoot: string,
+  shardIndex: number,
+  shardTotal: number,
+): FSTree {
+  return Object.fromEntries(
+    Object.entries(fsTree).filter(
+      ([abs]) => shardOf(relForHashing(projectRoot, abs), shardTotal) === shardIndex,
+    ),
+  );
+}
+
+function relForHashing(projectRoot: string, abs: string): string {
+  return path.relative(projectRoot, abs).split(path.sep).join('/');
+}
+
+function shardOf(rel: string, shardTotal: number): number {
+  return createHash('sha1').update(rel).digest().readUInt32BE(0) % shardTotal;
+}

--- a/test/commands/help-test.ts
+++ b/test/commands/help-test.ts
@@ -42,6 +42,7 @@ Optional flags:
 --no-daemon : don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn
 --changed : run only test files affected by changes since HEAD (requires git; falls back to running all on first use)
 --since : run only test files affected by changes since the given git ref (e.g. --since=main); --changed = --since=HEAD
+--shard : run only the Nth shard of M (e.g. --shard=2/4) for distributed CI matrix jobs — every file lands in exactly one shard, deterministically across machines
 --trace-perf : write timestamped startup-perf trace lines to stderr (Chrome pre-launch, module load, browser bind)
 
 Example: $ qunitx test/foo.ts app/e2e --debug --watch --before=scripts/start-new-webserver.js --after=scripts/write-test-results.js

--- a/test/flags/shard-test.ts
+++ b/test/flags/shard-test.ts
@@ -1,0 +1,141 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { module, test } from 'qunitx';
+import '../helpers/custom-asserts.ts';
+import { spawnCapture } from '../helpers/shell.ts';
+import { acquireBrowser } from '../helpers/browser-semaphore-queue.ts';
+
+const CWD = process.cwd();
+
+interface ShardProject {
+  cwd: string;
+  testCount: number;
+}
+
+// Build a self-contained project with N independently-passing test files,
+// symlinking node_modules so qunitx + esbuild resolve. Each test logs a unique
+// id so the total can be reconstructed from stdout across all shards.
+async function makeShardProject(testCount: number): Promise<ShardProject> {
+  const id = crypto.randomUUID();
+  const cwd = path.join(CWD, 'tmp', `shard-${id}`);
+  await fs.mkdir(cwd, { recursive: true });
+  const writes = Array.from({ length: testCount }, (_, i) => {
+    const filePath = path.join(cwd, 'test', `file-${i}-test.ts`);
+    const content =
+      [
+        `import { module, test } from 'qunitx';`,
+        `module('Shard | file-${i}', () => {`,
+        `  test('file-${i} ok', (assert) => assert.equal(${i}, ${i}));`,
+        `});`,
+      ].join('\n') + '\n';
+    return writeWithMkdir(filePath, content);
+  });
+  await Promise.all([
+    fs.symlink(path.join(CWD, 'node_modules'), path.join(cwd, 'node_modules')),
+    writeWithMkdir(
+      path.join(cwd, 'package.json'),
+      JSON.stringify({ name: id, version: '0.0.1', type: 'module' }),
+    ),
+    ...writes,
+  ]);
+  return { cwd, testCount };
+}
+
+async function writeWithMkdir(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+}
+
+async function runCli(project: ShardProject, args: string) {
+  const id = crypto.randomUUID();
+  const permit = await acquireBrowser();
+  try {
+    return await spawnCapture(`node ${CWD}/cli.ts ${args} --output=tmp/run-${id} --no-daemon`, {
+      env: { ...process.env, FORCE_COLOR: '0' },
+      cwd: project.cwd,
+    });
+  } finally {
+    permit.release();
+  }
+}
+
+// Sums every `# pass N` line in the run's stdout — one per HTML file (1 here),
+// summed gives the total tests that actually executed.
+function countPasses(stdout: string): number {
+  return [...stdout.matchAll(/^# pass (\d+)$/gm)].reduce((sum, m) => sum + Number(m[1]), 0);
+}
+
+module('--shard flag', { concurrency: true }, () => {
+  test('--shard=1/2 + --shard=2/2 partition the input exhaustively and disjointly', async (assert) => {
+    // Eight test files give SHA-1 ≈ 50/50 odds of both shards being non-empty,
+    // and even an unlucky 8/0 split still validates union coverage.
+    const project = await makeShardProject(8);
+
+    const [a, b] = await Promise.all([
+      runCli(project, 'test/ --shard=1/2'),
+      runCli(project, 'test/ --shard=2/2'),
+    ]);
+
+    assert.exitCode(a, 0);
+    assert.exitCode(b, 0);
+
+    // Every input file appears in exactly one shard's run.
+    const aPasses = countPasses(a.stdout);
+    const bPasses = countPasses(b.stdout);
+    assert.equal(
+      aPasses + bPasses,
+      project.testCount,
+      `union covers all ${project.testCount} files (a=${aPasses}, b=${bPasses})`,
+    );
+
+    // Diagnostic line confirms the filter ran.
+    assert.regex(a, /# --shard: \d+ of \d+ test files in shard 1\/2/);
+    assert.regex(b, /# --shard: \d+ of \d+ test files in shard 2\/2/);
+  });
+
+  test('--shard=1/1 is a no-op (every file runs)', async (assert) => {
+    const project = await makeShardProject(3);
+    const result = await runCli(project, 'test/ --shard=1/1');
+    assert.exitCode(result, 0);
+    assert.equal(countPasses(result.stdout), project.testCount);
+  });
+
+  test('--shard with more shards than files: most shards are empty, union still covers all', async (assert) => {
+    const project = await makeShardProject(2);
+    const results = await Promise.all([
+      runCli(project, 'test/ --shard=1/5'),
+      runCli(project, 'test/ --shard=2/5'),
+      runCli(project, 'test/ --shard=3/5'),
+      runCli(project, 'test/ --shard=4/5'),
+      runCli(project, 'test/ --shard=5/5'),
+    ]);
+    results.forEach((r, i) => assert.exitCode(r, 0, `shard ${i + 1}/5 exited 0`));
+    const total = results.reduce((sum, r) => sum + countPasses(r.stdout), 0);
+    assert.equal(
+      total,
+      project.testCount,
+      `union of all 5 shards covers ${project.testCount} files`,
+    );
+  });
+
+  test('invalid --shard value exits 1 with a clear error', async (assert) => {
+    // Fails early in parseCliFlags — no project setup needed; pin against a
+    // throwaway cwd so we don't bother with the symlink dance.
+    const dir = path.join(CWD, 'tmp', `shard-invalid-${crypto.randomUUID()}`);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'package.json'), '{"name":"x","type":"module"}');
+    let captured: { code: number | null; stderr: string } | null = null;
+    try {
+      await spawnCapture(`node ${CWD}/cli.ts --shard=abc`, {
+        env: { ...process.env, FORCE_COLOR: '0' },
+        cwd: dir,
+      });
+    } catch (err) {
+      captured = err as { code: number | null; stderr: string };
+    }
+    assert.ok(captured, 'cli should reject and exit non-zero');
+    assert.equal(captured!.code, 1);
+    assert.ok(captured!.stderr.includes('Invalid --shard value'), 'stderr explains the bad value');
+  });
+});

--- a/test/setup/parse-cli-flags-test.ts
+++ b/test/setup/parse-cli-flags-test.ts
@@ -131,6 +131,26 @@ module('Setup | parseCliFlags | --changed / --since', { concurrency: true }, () 
   });
 });
 
+module('Setup | parseCliFlags | --shard', { concurrency: true }, () => {
+  test('--shard=2/4 parses to 0-indexed shardIndex + shardTotal', (assert) => {
+    const flags = withArgv(['--shard=2/4'], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.shardIndex, 1, 'human-facing 2 → 0-indexed 1');
+    assert.strictEqual(flags.shardTotal, 4);
+  });
+
+  test('--shard=1/1 is a valid no-op partition (every file in shard 0 of 1)', (assert) => {
+    const flags = withArgv(['--shard=1/1'], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.shardIndex, 0);
+    assert.strictEqual(flags.shardTotal, 1);
+  });
+
+  test('shardIndex/shardTotal are undefined when --shard is not provided', (assert) => {
+    const flags = withArgv([], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.shardIndex, undefined);
+    assert.strictEqual(flags.shardTotal, undefined);
+  });
+});
+
 module('Setup | parseCliFlags | --timeout', { concurrency: true }, () => {
   test('--timeout value is parsed as a number, not a string', (assert) => {
     const flags = withArgv(['--timeout=5000'], () => parseCliFlags(PROJECT_ROOT));

--- a/test/utils/shard-fs-tree-test.ts
+++ b/test/utils/shard-fs-tree-test.ts
@@ -1,0 +1,102 @@
+import path from 'node:path';
+import { module, test } from 'qunitx';
+import { shardFsTree } from '../../lib/utils/shard-fs-tree.ts';
+import type { FSTree } from '../../lib/types.ts';
+
+// Pure-function tests — no I/O, no spawning. Each module runs in <2 ms locally.
+
+const PROJECT_ROOT = '/proj';
+const abs = (rel: string) => path.resolve(PROJECT_ROOT, rel);
+
+function fsTreeOf(rels: string[]): FSTree {
+  return Object.fromEntries(rels.map((r) => [abs(r), null]));
+}
+
+module('Utils | shardFsTree | partition properties', { concurrency: true }, () => {
+  test('union of every shard equals the input set (no file dropped, none duplicated)', (assert) => {
+    const files = Array.from({ length: 50 }, (_, i) => `test/file-${i}.ts`);
+    const tree = fsTreeOf(files);
+    const M = 4;
+    const allShards = Array.from({ length: M }, (_, n) =>
+      Object.keys(shardFsTree(tree, PROJECT_ROOT, n, M)),
+    );
+    const flattened = allShards.flat();
+    assert.equal(flattened.length, files.length, 'every file lands in exactly one shard');
+    assert.deepEqual(flattened.sort(), files.map(abs).sort(), 'union covers every input file');
+    // No duplicates — `Set` size equals array size when partitioning is exact.
+    assert.equal(new Set(flattened).size, flattened.length, 'no file appears in two shards');
+  });
+
+  test('shards are disjoint pairwise', (assert) => {
+    const files = Array.from({ length: 50 }, (_, i) => `test/file-${i}.ts`);
+    const tree = fsTreeOf(files);
+    const M = 4;
+    const shards = Array.from(
+      { length: M },
+      (_, n) => new Set(Object.keys(shardFsTree(tree, PROJECT_ROOT, n, M))),
+    );
+    for (let a = 0; a < M; a++) {
+      for (let b = a + 1; b < M; b++) {
+        const overlap = [...shards[a]].filter((f) => shards[b].has(f));
+        assert.equal(overlap.length, 0, `shard ${a} and shard ${b} are disjoint`);
+      }
+    }
+  });
+
+  test('distribution is reasonably uniform across shards', (assert) => {
+    // 100 files / 4 shards → expected 25 per shard. SHA-1 should keep every
+    // shard within a tight band (10..40) for this size; this guards against
+    // a hash-input regression that would suddenly cluster everything in one shard.
+    const files = Array.from({ length: 100 }, (_, i) => `test/file-${i}.ts`);
+    const tree = fsTreeOf(files);
+    const M = 4;
+    const counts = Array.from(
+      { length: M },
+      (_, n) => Object.keys(shardFsTree(tree, PROJECT_ROOT, n, M)).length,
+    );
+    counts.forEach((c, n) => {
+      assert.ok(c >= 10 && c <= 40, `shard ${n} has ${c} files (expected ~25, allowed 10–40)`);
+    });
+  });
+});
+
+module('Utils | shardFsTree | determinism', { concurrency: true }, () => {
+  test('same input → same shard assignment (deterministic across calls)', (assert) => {
+    const tree = fsTreeOf(['test/a.ts', 'test/b.ts', 'test/c.ts']);
+    const a = shardFsTree(tree, PROJECT_ROOT, 0, 3);
+    const b = shardFsTree(tree, PROJECT_ROOT, 0, 3);
+    assert.deepEqual(Object.keys(a), Object.keys(b));
+  });
+
+  // Cross-platform stability of the hash input (path.sep → '/' normalisation
+  // before SHA-1) is verified by the OS matrix in CI rather than here:
+  // path.resolve / path.relative behave per-platform, so a single-OS test
+  // can't faithfully simulate the other's separator. The integration test
+  // in test/flags/shard-test.ts hits the real path code on whichever OS
+  // it runs.
+});
+
+module('Utils | shardFsTree | edge cases', { concurrency: true }, () => {
+  test('empty fsTree returns empty for every shard', (assert) => {
+    for (const M of [1, 4]) {
+      for (let n = 0; n < M; n++) {
+        assert.equal(Object.keys(shardFsTree({}, PROJECT_ROOT, n, M)).length, 0);
+      }
+    }
+  });
+
+  test('shardTotal=1 returns the full tree on shard 0', (assert) => {
+    const tree = fsTreeOf(['test/a.ts', 'test/b.ts']);
+    const result = shardFsTree(tree, PROJECT_ROOT, 0, 1);
+    assert.deepEqual(Object.keys(result).sort(), Object.keys(tree).sort());
+  });
+
+  test('more shards than files: some shards are empty, every file still lands once', (assert) => {
+    const tree = fsTreeOf(['test/a.ts', 'test/b.ts']);
+    const M = 10;
+    const allFiles = Array.from({ length: M }, (_, n) =>
+      Object.keys(shardFsTree(tree, PROJECT_ROOT, n, M)),
+    ).flat();
+    assert.deepEqual(allFiles.sort(), Object.keys(tree).sort());
+  });
+});


### PR DESCRIPTION
Adds a stable hash-based file partitioning flag:

  qunitx test/ --shard=1/4    # worker 1 of 4
  qunitx test/ --shard=2/4    # worker 2 of 4
  ...

Files are partitioned by SHA-1 of their projectRoot-relative path normalised to forward slashes (so the same file on Windows and POSIX hashes to the same shard). Every input file lands in exactly one shard, the union of all M shards covers the input set, and the assignment is deterministic across machines — the three properties a CI matrix needs to split a suite across N workers.

Stacks after --changed so a sharded incremental run claims the same affected-tests slice on every worker. Watch mode skips sharding (it's a CI feature, not a dev-loop one). Invalid values fail fast in parseCliFlags with a clear error.

Tests: 7 pure-fn partition properties (union, disjointness, distribution, determinism, edge cases including shardTotal > file count) + 3 parser tests
+ 4 end-to-end integration tests verifying the wiring from cli through setupConfig. Total ~8.5s wall clock with cross-file concurrency.