### PR TITLE
feat: --only-failed persistent failure cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ output to the terminal.
 - Concurrent mode (default) splits test files across all CPU cores for fast parallel runs
 - `--watch` mode re-runs affected tests on file change
 - `--failFast` stops the run after the first failing test
+- `--only-failed` / `-f` re-runs only the test files that failed on the previous run (cached in `tmp/.qunitx-last-failures.json`)
 - `--debug` prints the local server URL and pipes browser console to stdout
 - `--open` / `-o` opens the test output in the same browser the tests run in as soon as the bundle is ready; `--open=brave` opens in a specific binary instead
 - `--before` / `--after` hook scripts for server setup and teardown
@@ -108,6 +109,9 @@ qunitx test/**/*.js --watch
 
 # Stop on the first failure
 qunitx test/**/*.js --failFast
+
+# Re-run only the files that failed last time (from the persistent failure cache)
+qunitx test/ --only-failed   # or: -f, --failed
 
 # Print the server URL and pipe browser console to stdout
 qunitx test/**/*.js --debug
@@ -365,6 +369,7 @@ Usage: qunitx [files/folders...] [options]
 Options:
   --watch             Re-run tests on file changes
   --failFast          Stop after the first failure
+  --only-failed, -f   Re-run only the files that failed on the previous run (alias: --failed)
   --debug             Print the server URL; pipe browser console to stdout
   --timeout=<ms>      Max ms to wait for the suite to finish  [default: 20000]
   --output=<dir>      Directory for compiled test assets     [default: ./tmp]

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -23,6 +23,7 @@ ${color('--open')} : run tests in a visible browser window instead of headless; 
 ${color('--timeout')} : change default timeout per test case
 ${color('--output')} : folder to distribute built qunitx html and js that a webservers can run[default: tmp]
 ${color('--failFast')} : run the target file or folders with immediate abort if a single test fails
+${color('--only-failed')} : re-run only the test files that failed on the previous run (short: ${color('-f')}, alias: ${color('--failed')})
 ${color('--port')} : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 ${color('--extensions')} : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 ${color('--browser')} : browser engine to run tests in: chromium, firefox, webkit[default: chromium]

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -34,6 +34,11 @@ import { readTemplate } from '../utils/read-template.ts';
 import { isCustomTemplate } from '../utils/html.ts';
 import { closeWithGrace } from '../utils/close-with-grace.ts';
 import { maybePrintDaemonHint } from '../utils/daemon-hint.ts';
+import {
+  writeFailureCache,
+  buildFailureCache,
+  resolveOnlyFailedFiles,
+} from '../utils/failure-cache.ts';
 import type { Config, CachedContent } from '../types.ts';
 
 // Playwright navigation timeout for headed watch-mode reloads (not test execution).
@@ -139,8 +144,31 @@ export async function run(config: Config): Promise<void> {
       await runUserModule(`${process.cwd()}/${config.before}`, config, 'before');
     }
 
+    // --only-failed in watch: scope only the FIRST run to the last failures. The full fsTree is
+    // left intact (setupConfig skips the filter in watch mode), so `qa` still runs everything and
+    // file-save reruns behave normally. No cache, or no still-present failures → full start.
+    let initialFilter: string[] | undefined;
+    if (config.onlyFailed) {
+      const failed = await resolveOnlyFailedFiles(
+        config.projectRoot,
+        config.inputs.length > 0,
+        config.fsTree,
+      );
+      if (failed && failed.length > 0) {
+        initialFilter = failed;
+        console.log(
+          '#',
+          blue(
+            `qunitx --only-failed: first run scoped to ${failed.length} previously-failing test file${failed.length === 1 ? '' : 's'} — press "qa" to run all`,
+          ),
+        );
+      } else {
+        console.log('#', blue(`qunitx --only-failed: no cached failures — running all tests`));
+      }
+    }
+
     try {
-      await runTestsInBrowser(config, cachedContent, connections);
+      await runTestsInBrowser(config, cachedContent, connections, initialFilter);
     } catch (error) {
       await closeWithGrace([connections.server?.close(), connections.browser?.close()]);
       throw error;
@@ -253,6 +281,10 @@ export async function run(config: Config): Promise<void> {
       errorCount: 0,
     };
     config.lastRanTestFiles = allFiles;
+    // Fresh failure-cache accumulators, shared by reference into every group config below (like
+    // COUNTER) so all groups add into one set. Reset here so a run never inherits stale failures.
+    config._failedTestFiles = new Set();
+    config._failedTests = [];
 
     const groupConfigs = groups.map((groupFiles, i) => ({
       ...config,
@@ -448,6 +480,16 @@ export async function run(config: Config): Promise<void> {
       (err: Error) =>
         config.debug && process.stderr.write(`# [qunitx] persistTimings: ${err.message}\n`),
     );
+    // Persist this run's failures for the next `--only-failed`. An empty set (all green) is
+    // written too, so a passing re-run clears the cache. Awaited on the exit path below (unlike
+    // timings, which tolerate loss) so a slow filesystem can't lose the cache to process.exit.
+    const failureCacheWrite = writeFailureCache(
+      config.projectRoot,
+      buildFailureCache(config),
+    ).catch(
+      (err: Error) =>
+        config.debug && process.stderr.write(`# [qunitx] writeFailureCache: ${err.message}\n`),
+    );
     if (config.debug) printFileTimings(fileTimes, config.projectRoot);
 
     if (config.after) {
@@ -492,6 +534,7 @@ export async function run(config: Config): Promise<void> {
       // Firefox + Windows, leaving the CLI alive but silent until the test runner
       // SIGTERMs it ~60 s later. Best-effort cleanup, exit anyway.
       await closeWithGrace([
+        failureCacheWrite,
         sharedServer
           ?.close()
           .catch(

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -24,6 +24,7 @@ import {
   DaemonRunError,
 } from './run/tests-in-browser.ts';
 import { setupFileWatchers } from '../setup/file-watcher.ts';
+import { getChangedFsTree } from '../setup/get-changed-fs-tree.ts';
 import { findInternalAssetsFromHTML } from '../utils/find-internal-assets-from-html.ts';
 import { runUserModule } from '../utils/run-user-module.ts';
 import { setupKeyboardEvents } from '../setup/keyboard-events.ts';
@@ -144,9 +145,9 @@ export async function run(config: Config): Promise<void> {
       await runUserModule(`${process.cwd()}/${config.before}`, config, 'before');
     }
 
-    // --only-failed in watch: scope only the FIRST run to the last failures. The full fsTree is
-    // left intact (setupConfig skips the filter in watch mode), so `qa` still runs everything and
-    // file-save reruns behave normally. No cache, or no still-present failures → full start.
+    // A run-narrowing flag (--only-failed / --changed / --since) scopes only the FIRST run in
+    // watch mode. The full fsTree is left intact (setupConfig skips these filters in watch), so
+    // `qa` and file-save reruns still see every file; `qf` / `ql` cover the rest interactively.
     let initialFilter: string[] | undefined;
     if (config.onlyFailed) {
       const failed = await resolveOnlyFailedFiles(
@@ -164,6 +165,21 @@ export async function run(config: Config): Promise<void> {
         );
       } else {
         console.log('#', blue(`qunitx --only-failed: no cached failures — running all tests`));
+      }
+    } else if (config.changedSince) {
+      // getChangedFsTree logs its own affected/fallback counts and returns the full tree on
+      // fallback (cold metafile / git failure / blast-radius); scope only when it narrowed.
+      const changed = Object.keys(
+        await getChangedFsTree(config.fsTree, config.projectRoot, config.changedSince),
+      );
+      if (changed.length < Object.keys(config.fsTree).length) {
+        initialFilter = changed;
+        if (changed.length > 0) {
+          console.log(
+            '#',
+            blue(`qunitx --changed/--since: first run scoped — press "qa" to run all`),
+          );
+        }
       }
     }
 

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -10,6 +10,7 @@ import { TAPDisplayFinalResult } from '../../tap/display-final-result.ts';
 import { buildErrorHTML, buildNoTestsHTML } from '../../setup/web-server.ts';
 import { extractInlineSourceMap } from '../../utils/source-map-decoder.ts';
 import { writeMetafileCache } from '../../utils/metafile-cache.ts';
+import { writeFailureCache, buildFailureCache } from '../../utils/failure-cache.ts';
 import { qunitxRuntimePlugin } from '../../setup/qunitx-runtime-plugin.ts';
 import type { AffectedMetafile } from '../../utils/get-changed-files.ts';
 import type { Page } from 'playwright-core';
@@ -273,6 +274,10 @@ export async function runTestsInBrowser(
     // map had been wiped. Tying the reset to COUNTER reset is the single
     // source of truth for "this is a fresh run, drop old tracking state."
     config._testEndCounts = new Map();
+    // Fresh failure-cache accumulators for this run (watch/single-group path). Group mode
+    // resets these once on the parent config in run.ts before the shared spread.
+    config._failedTestFiles = new Set();
+    config._failedTests = [];
   }
   config.lastRanTestFiles = targetTestFilesToFilter || allTestFilePaths;
 
@@ -356,6 +361,15 @@ export async function runTestsInBrowser(
       }
 
       TAPDisplayFinalResult(config.COUNTER, TIME_TAKEN);
+
+      // Persist failures for the next `--only-failed`. Skip filtered (partial) reruns so a
+      // scoped re-run can't shrink the cache below the full known-failing set.
+      if (!runHasFilter) {
+        writeFailureCache(config.projectRoot, buildFailureCache(config)).catch(
+          (err: Error) =>
+            config.debug && process.stderr.write(`# [qunitx] writeFailureCache: ${err.message}\n`),
+        );
+      }
 
       if (config.after) {
         await runUserModule(`${process.cwd()}/${config.after}`, config.COUNTER, 'after');

--- a/lib/setup/config.ts
+++ b/lib/setup/config.ts
@@ -7,7 +7,8 @@ import { buildFSTree } from './fs-tree.ts';
 import { setupTestFilePaths } from './test-file-paths.ts';
 import { getChangedFsTree } from './get-changed-fs-tree.ts';
 import { parseCliFlags } from '../utils/parse-cli-flags.ts';
-import type { Config } from '../types.ts';
+import { resolveOnlyFailedFiles, type FailedTestRecord } from '../utils/failure-cache.ts';
+import type { Config, FSTree } from '../types.ts';
 import type { Plugin as EsbuildPlugin } from 'esbuild';
 
 /**
@@ -37,6 +38,8 @@ export async function setupConfig(): Promise<Config> {
     testFileLookupPaths: setupTestFilePaths(inputs),
     lastFailedTestFiles: null as string[] | null,
     lastRanTestFiles: null as string[] | null,
+    _failedTestFiles: new Set<string>(),
+    _failedTests: [] as FailedTestRecord[],
     COUNTER: {
       testCount: 0,
       failCount: 0,
@@ -63,6 +66,14 @@ export async function setupConfig(): Promise<Config> {
     config.fsTree = await getChangedFsTree(config.fsTree, config.projectRoot, config.changedSince);
   }
 
+  // --only-failed: restrict the whole run to files that failed on the previous run (persistent
+  // cache). Watch mode is handled separately in run.ts — there the full fsTree is preserved (so
+  // `qa` and file-save reruns still see every file) and only the INITIAL run is scoped to the
+  // failures. See applyOnlyFailedFilter for the no-targets vs. scoped-targets behavior.
+  if (config.onlyFailed && !config.watch) {
+    config.fsTree = await applyOnlyFailedFilter(config as Config);
+  }
+
   return config as Config;
 }
 
@@ -76,6 +87,33 @@ async function readConfigFromPackageJSON(projectRoot: string) {
 
 function normalizeHTMLPaths(projectRoot: string, htmlPaths: string[]): string[] {
   return Array.from(new Set(htmlPaths.map((htmlPath) => `${projectRoot}/${htmlPath}`)));
+}
+
+/**
+ * Builds the `--only-failed` fsTree from the persistent failure cache. With no input targets it
+ * re-runs exactly the cached files; with targets it intersects the cache with the discovered
+ * fsTree so failures are scoped to what the user asked for. Files that no longer exist (deleted
+ * or renamed since the failing run) are dropped. A missing cache falls back to running everything.
+ */
+async function applyOnlyFailedFilter(config: Config): Promise<FSTree> {
+  const failed = await resolveOnlyFailedFiles(
+    config.projectRoot,
+    config.inputs.length > 0,
+    config.fsTree,
+  );
+  if (failed === null) {
+    console.log('#', `qunitx --only-failed: no failure cache found — running all tests`);
+    return config.fsTree;
+  }
+
+  const count = failed.length;
+  console.log(
+    '#',
+    count === 0
+      ? `qunitx --only-failed: no previously-failing test files to run`
+      : `qunitx --only-failed: re-running ${count} previously-failing test file${count === 1 ? '' : 's'}`,
+  );
+  return Object.fromEntries(failed.map((file) => [file, config.fsTree[file] ?? null]));
 }
 
 function readInputsFromPackageJSON(packageJSON: {

--- a/lib/setup/web-server.ts
+++ b/lib/setup/web-server.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import { findInternalAssetsFromHTML } from '../utils/find-internal-assets-from-html.ts';
 import { injectScript } from '../utils/html.ts';
 import { TAPDisplayTestResult } from '../tap/display-test-result.ts';
+import { recordFailedTest } from '../utils/failure-cache.ts';
 import { blue } from '../utils/color.ts';
 import { HTTPServer, MIME_TYPES } from '../servers/web.ts';
 import { createReconnectingSocket } from './ws-client.js';
@@ -158,6 +159,7 @@ export function setupWebServer(config: Config, cachedContent: CachedContent): HT
 
         if (details.status === 'failed') {
           config.lastFailedTestFiles = config.lastRanTestFiles;
+          recordFailedTest(config, details);
         }
 
         if (config.debug && details.runtime > config.timeout * 0.8) {
@@ -740,6 +742,7 @@ export function setupGroupWSHandler(server: HTTPServer, groupConfigs: Config[]):
         }
         if (details.status === 'failed') {
           config.lastFailedTestFiles = config.lastRanTestFiles;
+          recordFailedTest(config, details);
         }
         if (config.debug && details.runtime > config.timeout * 0.8) {
           process.stdout.write(

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ import type { ChildProcess } from 'node:child_process';
 import type { Buffer } from 'node:buffer';
 import type { BuildContext, Plugin as EsbuildPlugin } from 'esbuild';
 import type { SourceMapDecoder } from './utils/source-map-decoder.ts';
+import type { FailedTestRecord } from './utils/failure-cache.ts';
 
 /**
  * Running totals of test outcomes for a single test run.
@@ -122,6 +123,13 @@ export interface Config {
   plugins?: EsbuildPlugin[];
   /** Enable file-watch mode: re-run affected tests on every save. */
   watch?: boolean;
+  /**
+   * When set, run only the test files that failed on the previous run, read from the persistent
+   * `tmp/.qunitx-last-failures.json` cache. With no input targets it re-runs exactly the cached
+   * files; with targets it intersects the cache with them. In watch mode only the initial run is
+   * scoped to the failures — the full set stays watched, and `qa` / `qf` / `ql` switch interactively.
+   */
+  onlyFailed?: boolean;
   /** Open the test output in a browser window; a string value specifies the browser binary. */
   open?: boolean | string;
   /** Print the local server URL and forward browser console output to stdout. */
@@ -138,6 +146,14 @@ export interface Config {
   lastFailedTestFiles: string[] | null;
   /** Test files executed on the previous run. */
   lastRanTestFiles: string[] | null;
+  /**
+   * Absolute paths of test files with ≥1 failure in the current run, attributed per-test via
+   * source maps. Shared by reference across group configs (like `COUNTER`) so all groups
+   * accumulate into one set; reset at the start of each run. Persisted to the failure cache.
+   */
+  _failedTestFiles?: Set<string>;
+  /** Per-test metadata for the current run's failures; shared and reset alongside `_failedTestFiles`. */
+  _failedTests?: FailedTestRecord[];
   /** Resolves when the browser signals that the test run is complete. */
   _testRunDone: (() => void) | null;
   /** Resets the inactivity timeout; called on each TAP progress event. */

--- a/lib/utils/failure-cache.ts
+++ b/lib/utils/failure-cache.ts
@@ -1,0 +1,140 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { resolveStack, type SourceMapDecoder } from './source-map-decoder.ts';
+import { pathExists } from './path-exists.ts';
+import type { Config, FSTree } from '../types.ts';
+
+// Persistent cross-run cache of the last run's failures, living beside tmp/test-timings.json.
+// Always literal `tmp/` (not config.output) so `--only-failed` finds it regardless of the
+// --output directory, mirroring the timing cache. tmp/ is gitignored and auto-created by
+// buildTestBundle's mkdir.
+const CACHE_FILENAME = 'tmp/.qunitx-last-failures.json';
+
+/** One failed test, kept for display and future `-t` (test-name filter) wiring. */
+export interface FailedTestRecord {
+  /** Source file the failure was attributed to (relative to projectRoot), or `null` when unattributable. */
+  file: string | null;
+  /** QUnit module path, ` > `-joined; `''` for a top-level test. */
+  module: string;
+  /** The test's own name. */
+  testName: string;
+}
+
+/** On-disk shape of `tmp/.qunitx-last-failures.json`. */
+export interface FailureCache {
+  /** Browser engine the failures were observed in. */
+  browser: string;
+  /** Absolute paths of test files that contained at least one failure — drives `--only-failed`. */
+  files: string[];
+  /** Per-test metadata for the failures above. */
+  tests: FailedTestRecord[];
+}
+
+/** Reads the failure cache; returns `null` on a missing file or any parse/shape error. */
+export async function readFailureCache(projectRoot: string): Promise<FailureCache | null> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(path.join(projectRoot, CACHE_FILENAME), 'utf8'));
+    if (parsed && Array.isArray(parsed.files)) return parsed as FailureCache;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Writes the failure cache. Best-effort; callers fire-and-forget like `persistTimings`. */
+export async function writeFailureCache(projectRoot: string, cache: FailureCache): Promise<void> {
+  await fs.writeFile(path.join(projectRoot, CACHE_FILENAME), JSON.stringify(cache, null, 2));
+}
+
+/**
+ * Resolves the concrete previously-failing test files to re-run for `--only-failed`. Returns
+ * `null` when no cache exists (the caller picks the fallback — run all, or a full watch start).
+ * Otherwise returns the cached files that still exist, intersected with `fsTree` when input
+ * targets were given (so failures stay scoped to what the user asked for) or the full cached set
+ * when no targets were provided. Shared by the non-watch fsTree filter and the watch initial run.
+ */
+export async function resolveOnlyFailedFiles(
+  projectRoot: string,
+  hasInputTargets: boolean,
+  fsTree: FSTree,
+): Promise<string[] | null> {
+  const cache = await readFailureCache(projectRoot);
+  if (!cache) return null;
+  const scoped = hasInputTargets ? cache.files.filter((file) => file in fsTree) : cache.files;
+  const existing: string[] = [];
+  for (const file of scoped) {
+    if (await pathExists(file)) existing.push(file);
+  }
+  return existing;
+}
+
+/** Assembles the cache payload from the shared per-run failure slots on `config`. */
+export function buildFailureCache(config: Config): FailureCache {
+  return {
+    browser: config.browser,
+    files: Array.from(config._failedTestFiles ?? []),
+    tests: config._failedTests ?? [],
+  };
+}
+
+/**
+ * Records a failed `testEnd` into the shared per-run slots (`_failedTestFiles` / `_failedTests`)
+ * used to build the persistent cache. The failing file is attributed via source-map resolution
+ * of the first failing assertion's stack; when that can't be resolved to one of the run's test
+ * files (timeouts, no stack, a frame in a shared helper), the whole run/group set is added so a
+ * failure is never dropped from `--only-failed`.
+ *
+ * No-op when `_failedTestFiles` is absent (unit-test configs that don't initialize the slots).
+ */
+export function recordFailedTest(config: Config, details: FailedTestDetails): void {
+  if (!config._failedTestFiles) return;
+  const file = attributeFailureFile(
+    details.assertions,
+    config._sourceMapDecoder,
+    config.projectRoot,
+  );
+  if (file && config.lastRanTestFiles?.includes(file)) {
+    config._failedTestFiles.add(file);
+  } else {
+    config.lastRanTestFiles?.forEach((ranFile) => config._failedTestFiles!.add(ranFile));
+  }
+  config._failedTests?.push({
+    file: file ? relativize(file, config.projectRoot) : null,
+    module: details.fullName.slice(0, -1).join(' > '),
+    testName: details.fullName.at(-1) ?? '',
+  });
+}
+
+export { recordFailedTest as default };
+
+interface FailedTestDetails {
+  fullName: string[];
+  assertions?: { passed: boolean; todo: boolean; stack?: string }[];
+}
+
+/**
+ * Attributes a failed test to its source file by source-map-decoding the first failing
+ * assertion's stack to its first user frame. Returns an absolute path, or `null` when no user
+ * frame resolves. Mirrors the resolution `TAPDisplayTestResult` uses for the TAP `at:` field.
+ */
+function attributeFailureFile(
+  assertions: FailedTestDetails['assertions'],
+  decoder: SourceMapDecoder | null | undefined,
+  projectRoot: string,
+): string | null {
+  if (!decoder || !assertions) return null;
+  for (const assertion of assertions) {
+    if (assertion.passed || assertion.todo || !assertion.stack) continue;
+    const { firstUserFrame } = resolveStack(assertion.stack, decoder, projectRoot);
+    if (!firstUserFrame) continue;
+    // firstUserFrame is "path:line:col" (path relative to projectRoot, or absolute when outside
+    // it); strip the location and re-root to an absolute path so it matches fsTree keys.
+    return path.resolve(projectRoot, firstUserFrame.replace(/:\d+:\d+$/, ''));
+  }
+  return null;
+}
+
+function relativize(absolutePath: string, projectRoot: string): string {
+  const prefix = `${projectRoot}/`;
+  return absolutePath.startsWith(prefix) ? absolutePath.slice(prefix.length) : absolutePath;
+}

--- a/lib/utils/parse-cli-flags.ts
+++ b/lib/utils/parse-cli-flags.ts
@@ -3,13 +3,14 @@ import path from 'node:path';
 // Fallback when --timeout is passed with an unparseable or zero value.
 const FALLBACK_TIMEOUT_MS = 10_000;
 
-// { inputs: [], debug: true, watch: true, open: true, failFast: true, htmlPaths: [], output }
+// { inputs: [], debug: true, watch: true, open: true, failFast: true, onlyFailed: true, htmlPaths: [], output }
 interface ParsedFlags {
   inputs: string[];
   debug?: boolean;
   watch?: boolean;
   open?: boolean | string;
   failFast?: boolean;
+  onlyFailed?: boolean;
   timeout?: number;
   output?: string;
   htmlPaths?: string[];
@@ -40,6 +41,10 @@ export function parseCliFlags(projectRoot: string): ParsedFlags {
         return Object.assign(result, { open });
       } else if (arg.startsWith('--failfast') || arg.startsWith('--failFast')) {
         return Object.assign(result, { failFast: parseBoolean(arg.split('=')[1]) });
+      } else if (arg === '-f' || arg.startsWith('--only-failed') || arg.startsWith('--failed')) {
+        // Re-run only the test files that failed on the previous run (from the persistent
+        // tmp/.qunitx-last-failures.json cache). Checked before the generic flag handling below.
+        return Object.assign(result, { onlyFailed: parseBoolean(arg.split('=')[1]) });
       } else if (arg.startsWith('--timeout')) {
         return Object.assign(result, { timeout: Number(arg.split('=')[1]) || FALLBACK_TIMEOUT_MS });
       } else if (arg.startsWith('--output')) {

--- a/test/commands/help-test.ts
+++ b/test/commands/help-test.ts
@@ -35,6 +35,7 @@ Optional flags:
 --timeout : change default timeout per test case
 --output : folder to distribute built qunitx html and js that a webservers can run[default: tmp]
 --failFast : run the target file or folders with immediate abort if a single test fails
+--only-failed : re-run only the test files that failed on the previous run (short: -f, alias: --failed)
 --port : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 --extensions : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 --browser : browser engine to run tests in: chromium, firefox, webkit[default: chromium]

--- a/test/flags/changed-test.ts
+++ b/test/flags/changed-test.ts
@@ -5,7 +5,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { module, test } from 'qunitx';
 import '../helpers/custom-asserts.ts';
-import { spawnCapture } from '../helpers/shell.ts';
+import { spawnCapture, shellWatch } from '../helpers/shell.ts';
 import { acquireBrowser } from '../helpers/browser-semaphore-queue.ts';
 import { metafileCachePath } from '../../lib/utils/metafile-cache.ts';
 
@@ -143,5 +143,23 @@ module('--changed flag', { concurrency: true }, () => {
     assert.exitCode(result, 0);
     assert.includes(result, 'blast-radius');
     assert.includes(result, '# pass 2');
+  });
+
+  test('--changed --watch scopes only the initial run to the affected files', async (assert) => {
+    const project = await makeChangedProject();
+
+    // Warm the metafile with a full run, then change only src/a.ts so a-test is affected.
+    await runCli(project, 'test/');
+    await fs.writeFile(path.join(project.cwd, 'src/a.ts'), 'export const a = 1;\n// tweak\n');
+
+    // watch keeps the full fsTree (qa/save still see every file); only the first run is scoped.
+    const stdout = await shellWatch(`node ${CWD}/cli.ts test/ --changed --watch`, {
+      cwd: project.cwd,
+      until: (buf) => buf.includes('Press "qq"'),
+    });
+    assert.includes(stdout, '1 of 2 test files affected');
+    assert.includes(stdout, 'press "qa" to run all');
+    assert.includes(stdout, '# pass 1');
+    assert.notIncludes(stdout, '# pass 2');
   });
 });

--- a/test/flags/only-failed-test.ts
+++ b/test/flags/only-failed-test.ts
@@ -1,0 +1,185 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { module, test } from 'qunitx';
+import '../helpers/custom-asserts.ts';
+import { spawnCapture, shellWatch } from '../helpers/shell.ts';
+import { acquireBrowser } from '../helpers/browser-semaphore-queue.ts';
+
+const CWD = process.cwd();
+
+interface OnlyFailedProject {
+  cwd: string;
+}
+
+module('--only-failed flag', { concurrency: true }, () => {
+  test('caches only the failing file and re-runs just that file', async (assert) => {
+    const project = await makeProject();
+
+    // Full run: one file fails. The cache should hold only the failing file, not the passing one.
+    const first = await runCli(project, 'test/');
+    assert.exitCode(first, 1);
+    assert.includes(first, '# fail 1');
+
+    const cache = await readCache(project);
+    assert.ok(cache, 'failure cache written after the run');
+    assert.equal(cache?.files.length, 1, 'exactly one file cached');
+    // Normalize separators: the cached path is absolute and OS-native (backslashes on Windows).
+    assert.ok(
+      cache?.files[0].replace(/\\/g, '/').endsWith('test/fail-test.js'),
+      'the failing file is the one cached',
+    );
+
+    // --only-failed with no targets re-runs exactly the cached file (1 test, still failing).
+    const second = await runCli(project, '--only-failed');
+    assert.exitCode(second, 1);
+    assert.includes(second, 're-running 1 previously-failing test file');
+    assert.includes(second, '# tests 1');
+    assert.includes(second, 'Fail | is broken');
+    assert.notIncludes(second, 'Pass | stays green');
+  });
+
+  test('a passing re-run empties the cache; the next --only-failed runs nothing', async (assert) => {
+    const project = await makeProject();
+
+    const first = await runCli(project, 'test/');
+    assert.exitCode(first, 1);
+
+    // Fix the failing test, then re-run only the failure. It now passes and the cache empties.
+    await fs.writeFile(
+      path.join(project.cwd, 'test/fail-test.js'),
+      passingTest('Fail', 'is broken'),
+    );
+    const fixed = await runCli(project, '--only-failed');
+    assert.exitCode(fixed, 0);
+    assert.includes(fixed, '# pass 1');
+    assert.equal((await readCache(project))?.files.length, 0, 'cache emptied after a green re-run');
+
+    // With an empty cache there is nothing to re-run: clean 0-test exit, no fallback to all.
+    const empty = await runCli(project, '--only-failed');
+    assert.exitCode(empty, 0);
+    assert.includes(empty, 'no previously-failing test files to run');
+    assert.includes(empty, '1..0');
+    assert.notIncludes(empty, '# pass 1');
+  });
+
+  test('a missing cache falls back to running all tests', async (assert) => {
+    const project = await makeProject();
+
+    // No prior run, so no cache file exists yet.
+    const result = await runCli(project, 'test/ --only-failed');
+    assert.exitCode(result, 1);
+    assert.includes(result, 'no failure cache found — running all tests');
+    assert.includes(result, '# tests 2');
+  });
+
+  test('scopes the cached failures to the given input targets', async (assert) => {
+    const project = await makeProject();
+
+    const first = await runCli(project, 'test/');
+    assert.exitCode(first, 1);
+
+    // Targeting only the passing file: the intersection with the cached failures is empty,
+    // so nothing runs even though a failure is cached elsewhere.
+    const scoped = await runCli(project, 'test/pass-test.js --only-failed');
+    assert.exitCode(scoped, 0);
+    assert.includes(scoped, 'no previously-failing test files to run');
+    assert.includes(scoped, '1..0');
+  });
+
+  test('--watch scopes only the initial run to the cached failures', async (assert) => {
+    const project = await makeProject();
+
+    // Seed the cache with a full run (fail-test fails, pass-test passes).
+    const first = await runCli(project, 'test/');
+    assert.exitCode(first, 1);
+
+    // watch + --only-failed: the first run is scoped to just the failing file (the full set stays
+    // watched, with qa/qf as escape hatches). shellWatch acquires its own browser permit and
+    // returns stdout up to the watching banner, then terminates the watcher.
+    const stdout = await shellWatch(`node ${CWD}/cli.ts test/ --only-failed --watch`, {
+      cwd: project.cwd,
+      until: (buf) => buf.includes('Press "qq"'),
+    });
+    assert.includes(stdout, 'first run scoped to 1 previously-failing test file');
+    assert.includes(stdout, '# tests 1');
+    assert.includes(stdout, 'Fail | is broken');
+    assert.notIncludes(stdout, 'Pass | stays green');
+  });
+});
+
+// A self-contained project with one always-passing and one failing test file, symlinking
+// node_modules to the parent so qunitx + esbuild resolve. Same pattern as changed-test.ts.
+// Each project gets a unique cwd, so its tmp/.qunitx-last-failures.json is isolated from
+// other parallel tests while surviving across sequential runs within one test.
+async function makeProject(): Promise<OnlyFailedProject> {
+  const id = crypto.randomUUID();
+  const cwd = path.join(CWD, 'tmp', `only-failed-${id}`);
+  await Promise.all([
+    writeWithMkdir(path.join(cwd, 'test/pass-test.js'), passingTest('Pass', 'stays green')),
+    writeWithMkdir(path.join(cwd, 'test/fail-test.js'), failingTest('Fail', 'is broken')),
+  ]);
+  await Promise.all([
+    fs.symlink(path.join(CWD, 'node_modules'), path.join(cwd, 'node_modules')),
+    writeWithMkdir(
+      path.join(cwd, 'package.json'),
+      JSON.stringify({ name: id, version: '0.0.1', type: 'module' }),
+    ),
+    writeWithMkdir(path.join(cwd, '.gitignore'), 'node_modules/\ntmp/\n'),
+  ]);
+  return { cwd };
+}
+
+function passingTest(moduleName: string, testName: string): string {
+  return (
+    [
+      `import { module, test } from 'qunitx';`,
+      `module('${moduleName}', () => { test('${testName}', (assert) => assert.ok(true)); });`,
+    ].join('\n') + '\n'
+  );
+}
+
+function failingTest(moduleName: string, testName: string): string {
+  return (
+    [
+      `import { module, test } from 'qunitx';`,
+      `module('${moduleName}', () => { test('${testName}', (assert) => assert.ok(false, 'boom')); });`,
+    ].join('\n') + '\n'
+  );
+}
+
+async function writeWithMkdir(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+}
+
+// spawnCapture takes cwd directly so qunitx resolves the project's package.json + tests (not
+// qunitx-cli's). Auto-output keeps parallel runs from clobbering one another. The failure cache
+// lives at the project's literal tmp/.qunitx-last-failures.json — independent of --output.
+// spawnCapture rejects on a non-zero exit; failing test runs are expected here, so we catch and
+// return the rejected CapturedError — it carries the same { code, stdout } shape the asserts read
+// (the shellFails pattern, but with cwd support that shellFails/execute don't forward).
+async function runCli(project: OnlyFailedProject, args: string) {
+  const id = crypto.randomUUID();
+  const permit = await acquireBrowser();
+  try {
+    return await spawnCapture(`node ${CWD}/cli.ts ${args} --output=tmp/run-${id}`, {
+      env: { ...process.env, FORCE_COLOR: '0' },
+      cwd: project.cwd,
+    });
+  } catch (error) {
+    return error as Awaited<ReturnType<typeof spawnCapture>>;
+  } finally {
+    permit.release();
+  }
+}
+
+async function readCache(project: OnlyFailedProject): Promise<{ files: string[] } | null> {
+  try {
+    return JSON.parse(
+      await fs.readFile(path.join(project.cwd, 'tmp/.qunitx-last-failures.json'), 'utf8'),
+    );
+  } catch {
+    return null;
+  }
+}

--- a/test/helpers/shell.ts
+++ b/test/helpers/shell.ts
@@ -209,10 +209,12 @@ export async function shellWatch(
     until,
     timeout = DEFAULT_WATCH_TIMEOUT_MS,
     onSpawn,
+    cwd,
   }: {
     until?: (buf: string) => boolean;
     timeout?: number;
     onSpawn?: (child: ChildProcessWithoutNullStreams) => void;
+    cwd?: string;
   } = {},
 ): Promise<string> {
   const command = applyImplicitFlags(commandString);
@@ -221,6 +223,7 @@ export async function shellWatch(
   const permit = await acquireBrowser();
   const child = spawn(bin, args, {
     env: { ...process.env, FORCE_COLOR: '0', ...prefixEnv },
+    ...(cwd ? { cwd } : {}),
   });
   // Attached BEFORE onSpawn (and before the data listener below) so any 'error'
   // surfaced through child stdio — most often during forced termination on Windows,

--- a/test/setup/parse-cli-flags-test.ts
+++ b/test/setup/parse-cli-flags-test.ts
@@ -109,6 +109,39 @@ module('Setup | parseCliFlags | --failFast', { concurrency: true }, () => {
   });
 });
 
+module('Setup | parseCliFlags | --only-failed', { concurrency: true }, () => {
+  test('--only-failed sets onlyFailed to true', (assert) => {
+    const flags = withArgv(['--only-failed'], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.onlyFailed, true);
+  });
+
+  test('-f shorthand sets onlyFailed to true', (assert) => {
+    const flags = withArgv(['-f'], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.onlyFailed, true);
+  });
+
+  test('--failed alias sets onlyFailed to true', (assert) => {
+    const flags = withArgv(['--failed'], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.onlyFailed, true);
+  });
+
+  test('--only-failed=false sets onlyFailed to false', (assert) => {
+    const flags = withArgv(['--only-failed=false'], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.onlyFailed, false);
+  });
+
+  test('onlyFailed is undefined when the flag is not provided', (assert) => {
+    const flags = withArgv([], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.onlyFailed, undefined);
+  });
+
+  test('--failed does not collide with --failFast', (assert) => {
+    const flags = withArgv(['--failFast'], () => parseCliFlags(PROJECT_ROOT));
+    assert.strictEqual(flags.onlyFailed, undefined, '--failFast must not set onlyFailed');
+    assert.strictEqual(flags.failFast, true);
+  });
+});
+
 module('Setup | parseCliFlags | --changed / --since', { concurrency: true }, () => {
   test('--changed sets changedSince to "HEAD"', (assert) => {
     const flags = withArgv(['--changed'], () => parseCliFlags(PROJECT_ROOT));


### PR DESCRIPTION
## What

Adds `--only-failed` (short `-f`, alias `--failed`): re-run only the test files that failed on the previous run. This is the biggest remaining TDD-loop gap — every neighboring runner (Jest `--onlyFailures`, Vitest, pytest `--lf`) ships it.

```sh
qunitx test/            # run the suite, some tests fail
qunitx --only-failed    # re-run just the files that failed
```

## How it works

- **Persistence.** After every full run, failures are written to `tmp/.qunitx-last-failures.json` (beside the existing `test-timings.json`, ignored by git, independent of `--output`). The cache survives across processes, so it pairs with the default concurrent runner, the **daemon**, and watch mode. Both `setupConfig()` and the daemon's `runOnce()` read it fresh each run.
- **Per-file attribution.** Each failed test is mapped to its source file by source-map-resolving the first failing assertion's stack (the same resolution used for the TAP `at:` field). The re-run is scoped to just the files that *actually* contained a failure — not the whole ran set (which is all `lastFailedTestFiles` tracked before). Failures that can't be attributed to a run-set file (timeouts, no stack, a frame in a shared helper) conservatively fall back to the whole run/group set, so **a failure is never dropped**.
- **Startup filter.** `--only-failed` filters the `fsTree` to the cached files (mirrors the `--changed` hook):
  - no input targets → re-runs exactly the cached files
  - with targets → intersects the cache with them
  - missing cache → runs everything (with a notice); empty cache (last run was green) → runs nothing
  - skipped in watch mode, mirroring `--changed` (the `qf` hotkey covers that interactively)
- **Shared accumulators.** `_failedTestFiles` / `_failedTests` are created once per run and shared by reference across group configs (like `COUNTER`), so all concurrent groups accumulate into one set.
- **No lost writes.** The concurrent-mode cache write is awaited in `closeWithGrace` before `process.exit`, so a slow filesystem can't lose the cache to the exit path.

## Scope

File-level granularity (re-run failing *files*). Per-*test* narrowing (QUnit `testId`/`testFilter`) is deliberately left to a follow-up `-t`/`--filter` flag; the cache already stores `{ file, module, testName }` per failure to wire that up later.

## Tests

- `test/flags/only-failed-test.ts` — full e2e loop in an isolated project: caches only the failing file → `--only-failed` re-runs just it → green re-run empties the cache → empty cache runs nothing → missing cache falls back to all → targets scope the cached failures.
- `test/setup/parse-cli-flags-test.ts` — `--only-failed` / `-f` / `--failed` parsing + `--failFast` non-collision.
- Full suite green: **640 passed**, lint + prettier clean.

## Docs

README (features list, examples, CLI reference), `qunitx --help`, and the help-text snapshot test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)