### PR TITLE
feat: reporters (tap/spec/dot/github), JUnit reports, and V8 code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ output to the terminal.
 - `--timeout` controls the maximum ms to wait for the full suite to finish
 - `--port` defaults to 1234 and auto-increments if taken; fails fast if an explicit port is unavailable
 - `--browser` flag to run tests in Chromium, Firefox, or WebKit
+- `--reporter=junit` writes a JUnit XML report for CI dashboards while TAP keeps streaming to the terminal
 - `--version` / `-v` prints the installed version
 - Optional daemon mode (`qunitx daemon start`) keeps Chrome and the esbuild context warm across runs — roughly halves the wall-clock time of repeated invocations
 - Docker image for zero-install CI usage
@@ -380,6 +381,8 @@ Options:
   --open=<binary>     Open output in a specific browser binary (e.g. brave, google-chrome-lts)
   --port=<n>          HTTP server port (auto-selects a free port if taken)
   --browser=<name>    Browser engine: chromium (default), firefox, or webkit
+  --reporter=<name>   Output reporter: tap (default) or junit (also writes a JUnit XML file)
+  --junit-output=<f>  JUnit XML path when --reporter=junit  [default: <output>/junit.xml]
   --no-daemon         Don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn
 
 Subcommands:
@@ -387,6 +390,25 @@ Subcommands:
   qunitx init                             Bootstrap qunitx config + base HTML in this project
   qunitx new <testFileName>               Create a new qunitx test file
 ```
+
+## JUnit reporter
+
+Most CI dashboards (GitHub Actions test summaries, GitLab merge-request views, CircleCI Insights,
+BuildKite, Jenkins) ingest JUnit XML natively but not TAP. `--reporter=junit` writes a JUnit XML
+file **in addition to** the normal TAP stream — the terminal output is unchanged, so humans and
+`--failFast` keep working while CI gets a machine-readable artifact.
+
+```bash
+qunitx test/                              # writes tmp/junit.xml (default output dir)
+qunitx test/ --reporter=junit --junit-output=reports/junit.xml
+```
+
+- One `<testsuite>` is emitted per QUnit module; each test is a `<testcase>`.
+- Failing tests carry a `<failure>` with the assertion message and a stack resolved back to your
+  original source files (same mapping as the TAP `at:` field).
+- Skipped tests and `todo` tests are reported as `<skipped/>`.
+- The default path is `<output>/junit.xml` (so `tmp/junit.xml` by default); override with
+  `--junit-output`. `reporter` can also be set under `qunitx` in `package.json`.
 
 ## Timezone
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ output to the terminal.
 - `--timeout` controls the maximum ms to wait for the full suite to finish
 - `--port` defaults to 1234 and auto-increments if taken; fails fast if an explicit port is unavailable
 - `--browser` flag to run tests in Chromium, Firefox, or WebKit
-- `--reporter` picks the stdout format: `tap` (default), `spec` (readable, module-grouped), or `dot`
+- `--reporter` picks the stdout format: `tap` (default), `spec`, `dot`, or `github` (annotates failures on the PR diff)
 - `--junit` writes a JUnit XML report for CI dashboards, alongside the normal terminal output
 - `--coverage` reports V8 line coverage (terminal summary, plus optional `lcov` and `html` reports)
 - `--version` / `-v` prints the installed version
@@ -383,7 +383,7 @@ Options:
   --open=<binary>     Open output in a specific browser binary (e.g. brave, google-chrome-lts)
   --port=<n>          HTTP server port (auto-selects a free port if taken)
   --browser=<name>    Browser engine: chromium (default), firefox, or webkit
-  --reporter=<name>   Stdout format: tap, spec, dot  [default: tap]
+  --reporter=<name>   Stdout format: tap, spec, dot, github  [default: tap]
   --junit[=<path>]    Also write a JUnit XML report  [default: <output>/junit.xml]
   --coverage[=fmts]   Collect V8 line coverage (chromium only). fmts: lcov,html (comma-separated)
   --no-daemon         Don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ output to the terminal.
 - `--timeout` controls the maximum ms to wait for the full suite to finish
 - `--port` defaults to 1234 and auto-increments if taken; fails fast if an explicit port is unavailable
 - `--browser` flag to run tests in Chromium, Firefox, or WebKit
-- `--reporter` picks the stdout format: `tap` (default) or `spec` (readable, module-grouped)
+- `--reporter` picks the stdout format: `tap` (default), `spec` (readable, module-grouped), or `dot`
 - `--junit` writes a JUnit XML report for CI dashboards, alongside the normal terminal output
 - `--coverage` reports V8 line coverage (terminal summary, plus optional `lcov` and `html` reports)
 - `--version` / `-v` prints the installed version
@@ -383,7 +383,7 @@ Options:
   --open=<binary>     Open output in a specific browser binary (e.g. brave, google-chrome-lts)
   --port=<n>          HTTP server port (auto-selects a free port if taken)
   --browser=<name>    Browser engine: chromium (default), firefox, or webkit
-  --reporter=<name>   Stdout format: tap, spec  [default: tap]
+  --reporter=<name>   Stdout format: tap, spec, dot  [default: tap]
   --junit[=<path>]    Also write a JUnit XML report  [default: <output>/junit.xml]
   --coverage[=fmts]   Collect V8 line coverage (chromium only). fmts: lcov,html (comma-separated)
   --no-daemon         Don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ output to the terminal.
 - `--timeout` controls the maximum ms to wait for the full suite to finish
 - `--port` defaults to 1234 and auto-increments if taken; fails fast if an explicit port is unavailable
 - `--browser` flag to run tests in Chromium, Firefox, or WebKit
+- `--reporter` picks the stdout format: `tap` (default) or `spec` (readable, module-grouped)
 - `--junit` writes a JUnit XML report for CI dashboards, alongside the normal terminal output
 - `--coverage` reports V8 line coverage (terminal summary, plus optional `lcov` and `html` reports)
 - `--version` / `-v` prints the installed version
@@ -382,7 +383,7 @@ Options:
   --open=<binary>     Open output in a specific browser binary (e.g. brave, google-chrome-lts)
   --port=<n>          HTTP server port (auto-selects a free port if taken)
   --browser=<name>    Browser engine: chromium (default), firefox, or webkit
-  --reporter=<name>   Stdout format: tap  [default: tap]
+  --reporter=<name>   Stdout format: tap, spec  [default: tap]
   --junit[=<path>]    Also write a JUnit XML report  [default: <output>/junit.xml]
   --coverage[=fmts]   Collect V8 line coverage (chromium only). fmts: lcov,html (comma-separated)
   --no-daemon         Don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ output to the terminal.
 - `--port` defaults to 1234 and auto-increments if taken; fails fast if an explicit port is unavailable
 - `--browser` flag to run tests in Chromium, Firefox, or WebKit
 - `--reporter=junit` writes a JUnit XML report for CI dashboards while TAP keeps streaming to the terminal
+- `--coverage` reports V8 line coverage (terminal summary, plus optional `lcov` and `html` reports)
 - `--version` / `-v` prints the installed version
 - Optional daemon mode (`qunitx daemon start`) keeps Chrome and the esbuild context warm across runs — roughly halves the wall-clock time of repeated invocations
 - Docker image for zero-install CI usage
@@ -383,6 +384,7 @@ Options:
   --browser=<name>    Browser engine: chromium (default), firefox, or webkit
   --reporter=<name>   Output reporter: tap (default) or junit (also writes a JUnit XML file)
   --junit-output=<f>  JUnit XML path when --reporter=junit  [default: <output>/junit.xml]
+  --coverage[=fmts]   Collect V8 line coverage (chromium only). fmts: lcov,html (comma-separated)
   --no-daemon         Don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn
 
 Subcommands:
@@ -409,6 +411,25 @@ qunitx test/ --reporter=junit --junit-output=reports/junit.xml
 - Skipped tests and `todo` tests are reported as `<skipped/>`.
 - The default path is `<output>/junit.xml` (so `tmp/junit.xml` by default); override with
   `--junit-output`. `reporter` can also be set under `qunitx` in `package.json`.
+
+## Code coverage
+
+`--coverage` collects **V8 line coverage** of your test bundle over the Chrome DevTools Protocol
+and maps it back through the bundle's source map to your original files. Because everything is
+bundled, only the non-test source your tests actually import is reported — test files and
+`node_modules` are excluded, and code eliminated by tree-shaking (never shipped to the browser)
+does not appear.
+
+```bash
+qunitx test/                    # terminal summary only
+qunitx test/ --coverage=lcov    # + tmp/coverage/lcov.info  (Codecov, Coveralls, GitLab, genhtml)
+qunitx test/ --coverage=html    # + tmp/coverage/index.html (self-contained, line-highlighted)
+qunitx test/ --coverage=lcov,html
+```
+
+- Chromium only — Firefox/WebKit runs print a warning and skip coverage.
+- The terminal summary is always printed when `--coverage` is on; `lcov`/`html` are additive.
+- Reports are written under `<output>/coverage/`.
 
 ## Timezone
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ output to the terminal.
 - `--timeout` controls the maximum ms to wait for the full suite to finish
 - `--port` defaults to 1234 and auto-increments if taken; fails fast if an explicit port is unavailable
 - `--browser` flag to run tests in Chromium, Firefox, or WebKit
-- `--reporter=junit` writes a JUnit XML report for CI dashboards while TAP keeps streaming to the terminal
+- `--junit` writes a JUnit XML report for CI dashboards, alongside the normal terminal output
 - `--coverage` reports V8 line coverage (terminal summary, plus optional `lcov` and `html` reports)
 - `--version` / `-v` prints the installed version
 - Optional daemon mode (`qunitx daemon start`) keeps Chrome and the esbuild context warm across runs — roughly halves the wall-clock time of repeated invocations
@@ -382,8 +382,8 @@ Options:
   --open=<binary>     Open output in a specific browser binary (e.g. brave, google-chrome-lts)
   --port=<n>          HTTP server port (auto-selects a free port if taken)
   --browser=<name>    Browser engine: chromium (default), firefox, or webkit
-  --reporter=<name>   Output reporter: tap (default) or junit (also writes a JUnit XML file)
-  --junit-output=<f>  JUnit XML path when --reporter=junit  [default: <output>/junit.xml]
+  --reporter=<name>   Stdout format: tap  [default: tap]
+  --junit[=<path>]    Also write a JUnit XML report  [default: <output>/junit.xml]
   --coverage[=fmts]   Collect V8 line coverage (chromium only). fmts: lcov,html (comma-separated)
   --no-daemon         Don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn
 
@@ -393,24 +393,20 @@ Subcommands:
   qunitx new <testFileName>               Create a new qunitx test file
 ```
 
-## JUnit reporter
+## JUnit reports
 
-Most CI dashboards (GitHub Actions test summaries, GitLab merge-request views, CircleCI Insights,
-BuildKite, Jenkins) ingest JUnit XML natively but not TAP. `--reporter=junit` writes a JUnit XML
-file **in addition to** the normal TAP stream — the terminal output is unchanged, so humans and
-`--failFast` keep working while CI gets a machine-readable artifact.
+Most CI dashboards ingest JUnit XML but not TAP. `--junit` writes one **in addition to** the
+terminal output, so `--reporter` keeps owning stdout.
 
 ```bash
-qunitx test/                              # writes tmp/junit.xml (default output dir)
-qunitx test/ --reporter=junit --junit-output=reports/junit.xml
+qunitx test/ --junit                    # writes tmp/junit.xml
+qunitx test/ --junit=reports/junit.xml  # custom path
 ```
 
-- One `<testsuite>` is emitted per QUnit module; each test is a `<testcase>`.
-- Failing tests carry a `<failure>` with the assertion message and a stack resolved back to your
-  original source files (same mapping as the TAP `at:` field).
-- Skipped tests and `todo` tests are reported as `<skipped/>`.
-- The default path is `<output>/junit.xml` (so `tmp/junit.xml` by default); override with
-  `--junit-output`. `reporter` can also be set under `qunitx` in `package.json`.
+- One `<testsuite>` per QUnit module; each test is a `<testcase>`.
+- Failures carry a `<failure>` with the message and a stack mapped back to your source.
+- Skipped and `todo` tests are reported as `<skipped/>`.
+- Settable as `junit` under `qunitx` in `package.json`.
 
 ## Code coverage
 

--- a/benches/tap.bench.ts
+++ b/benches/tap.bench.ts
@@ -5,6 +5,19 @@
  */
 import TAPDisplayTestResult from "../lib/tap/display-test-result.ts";
 import TAPDisplayFinalResult from "../lib/tap/display-final-result.ts";
+import { updateCounter } from "../lib/reporter/types.ts";
+import { failedAssertions } from "../lib/reporter/failure.ts";
+
+// Mirrors what a real run does per test (reportTestEnd -> TapReporter.onTestEnd): count it,
+// resolve any failures, then render. TAPDisplayTestResult is a pure formatter now, so calling
+// it alone would measure less work than the runner actually performs.
+const displayTestResult = (
+  counter: Parameters<typeof updateCounter>[0],
+  details: Parameters<typeof failedAssertions>[0],
+) => {
+  updateCounter(counter, details);
+  TAPDisplayTestResult(counter.testCount, details, failedAssertions(details));
+};
 
 // Suppress all output once at module level — patching inside each
 // iteration deoptimises V8's JIT-compiled inline cache, inflating
@@ -49,23 +62,23 @@ Deno.bench("tap: display single passing result", {
   baseline: true,
 }, () => {
   const counter = { testCount: 0, passCount: 0, skipCount: 0, todoCount: 0, failCount: 0, errorCount: 0 };
-  TAPDisplayTestResult(counter, PASSING_DETAILS);
+  displayTestResult(counter, PASSING_DETAILS);
 });
 
 Deno.bench("tap: display single failing result", {
   group: "tap",
 }, () => {
   const counter = { testCount: 0, passCount: 0, skipCount: 0, todoCount: 0, failCount: 0, errorCount: 0 };
-  TAPDisplayTestResult(counter, FAILING_DETAILS);
+  displayTestResult(counter, FAILING_DETAILS);
 });
 
 Deno.bench("tap: display 100 mixed results", {
   group: "tap",
 }, () => {
   const counter = { testCount: 0, passCount: 0, skipCount: 0, todoCount: 0, failCount: 0, errorCount: 0 };
-  for (let i = 0; i < 80; i++) TAPDisplayTestResult(counter, PASSING_DETAILS);
-  for (let i = 0; i < 10; i++) TAPDisplayTestResult(counter, FAILING_DETAILS);
-  for (let i = 0; i < 10; i++) TAPDisplayTestResult(counter, SKIPPED_DETAILS);
+  for (let i = 0; i < 80; i++) displayTestResult(counter, PASSING_DETAILS);
+  for (let i = 0; i < 10; i++) displayTestResult(counter, FAILING_DETAILS);
+  for (let i = 0; i < 10; i++) displayTestResult(counter, SKIPPED_DETAILS);
 });
 
 Deno.bench("tap: display final result summary", {

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -27,8 +27,8 @@ ${color('--only-failed')} : re-run only the test files that failed on the previo
 ${color('--port')} : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 ${color('--extensions')} : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 ${color('--browser')} : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
-${color('--reporter')} : output reporter: tap (default) or junit; ${color('junit')} also writes a JUnit XML file (TAP still streams to stdout)
-${color('--junit-output')} : JUnit XML file path when ${color('--reporter=junit')} [default: <output>/junit.xml]
+${color('--reporter')} : stdout format: tap[default: tap]
+${color('--junit')} : also write a JUnit XML report[default path: <output>/junit.xml; ${color('--junit=<path>')} to override]
 ${color('--coverage')} : collect V8 line coverage (chromium only); ${color('--coverage=lcov,html')} also writes <output>/coverage/ reports
 ${color('--before')} : run a script before the tests(i.e start a new web server before tests)
 ${color('--after')} : run a script after the tests(i.e save test results to a file)

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -27,7 +27,7 @@ ${color('--only-failed')} : re-run only the test files that failed on the previo
 ${color('--port')} : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 ${color('--extensions')} : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 ${color('--browser')} : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
-${color('--reporter')} : stdout format: tap[default: tap]
+${color('--reporter')} : stdout format: tap, spec[default: tap]
 ${color('--junit')} : also write a JUnit XML report[default path: <output>/junit.xml; ${color('--junit=<path>')} to override]
 ${color('--coverage')} : collect V8 line coverage (chromium only); ${color('--coverage=lcov,html')} also writes <output>/coverage/ reports
 ${color('--before')} : run a script before the tests(i.e start a new web server before tests)

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -27,7 +27,7 @@ ${color('--only-failed')} : re-run only the test files that failed on the previo
 ${color('--port')} : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 ${color('--extensions')} : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 ${color('--browser')} : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
-${color('--reporter')} : stdout format: tap, spec, dot[default: tap]
+${color('--reporter')} : stdout format: tap, spec, dot, github[default: tap]
 ${color('--junit')} : also write a JUnit XML report[default path: <output>/junit.xml; ${color('--junit=<path>')} to override]
 ${color('--coverage')} : collect V8 line coverage (chromium only); ${color('--coverage=lcov,html')} also writes <output>/coverage/ reports
 ${color('--before')} : run a script before the tests(i.e start a new web server before tests)

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -29,6 +29,7 @@ ${color('--extensions')} : comma-separated file extensions to track for discover
 ${color('--browser')} : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
 ${color('--reporter')} : output reporter: tap (default) or junit; ${color('junit')} also writes a JUnit XML file (TAP still streams to stdout)
 ${color('--junit-output')} : JUnit XML file path when ${color('--reporter=junit')} [default: <output>/junit.xml]
+${color('--coverage')} : collect V8 line coverage (chromium only); ${color('--coverage=lcov,html')} also writes <output>/coverage/ reports
 ${color('--before')} : run a script before the tests(i.e start a new web server before tests)
 ${color('--after')} : run a script after the tests(i.e save test results to a file)
 ${color('--no-daemon')} : don't use the daemon for this run — skips a running daemon and prevents ${color('QUNITX_DAEMON')} auto-spawn

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -27,7 +27,7 @@ ${color('--only-failed')} : re-run only the test files that failed on the previo
 ${color('--port')} : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 ${color('--extensions')} : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 ${color('--browser')} : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
-${color('--reporter')} : stdout format: tap, spec[default: tap]
+${color('--reporter')} : stdout format: tap, spec, dot[default: tap]
 ${color('--junit')} : also write a JUnit XML report[default path: <output>/junit.xml; ${color('--junit=<path>')} to override]
 ${color('--coverage')} : collect V8 line coverage (chromium only); ${color('--coverage=lcov,html')} also writes <output>/coverage/ reports
 ${color('--before')} : run a script before the tests(i.e start a new web server before tests)

--- a/lib/commands/help.ts
+++ b/lib/commands/help.ts
@@ -27,6 +27,8 @@ ${color('--only-failed')} : re-run only the test files that failed on the previo
 ${color('--port')} : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 ${color('--extensions')} : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 ${color('--browser')} : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
+${color('--reporter')} : output reporter: tap (default) or junit; ${color('junit')} also writes a JUnit XML file (TAP still streams to stdout)
+${color('--junit-output')} : JUnit XML file path when ${color('--reporter=junit')} [default: <output>/junit.xml]
 ${color('--before')} : run a script before the tests(i.e start a new web server before tests)
 ${color('--after')} : run a script after the tests(i.e save test results to a file)
 ${color('--no-daemon')} : don't use the daemon for this run — skips a running daemon and prevents ${color('QUNITX_DAEMON')} auto-spawn

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -41,6 +41,7 @@ import {
   resolveOnlyFailedFiles,
 } from '../utils/failure-cache.ts';
 import { writeJUnitReport } from '../reporter/junit.ts';
+import { writeCoverageReport } from '../coverage/report.ts';
 import type { Config, CachedContent } from '../types.ts';
 
 // Playwright navigation timeout for headed watch-mode reloads (not test execution).
@@ -75,6 +76,15 @@ const EXIT_CODE_SIGTERM = 128 + 15;
  * @returns {Promise<void>}
  */
 export async function run(config: Config): Promise<void> {
+  // Coverage is V8-precise-coverage over CDP, which only the chromium engine exposes. For
+  // firefox/webkit, warn once and disable so the rest of the pipeline treats it as off.
+  if (config.coverage && config.browser !== 'chromium') {
+    console.log(
+      `# Warning: --coverage requires the chromium browser; skipping coverage for ${config.browser}.`,
+    );
+    config.coverage = false;
+  }
+
   // Kick off all I/O that doesn't need cachedContent in parallel with buildCachedContent:
   //   launchBrowser: CDP connect to pre-launched Chrome (~30-50ms)
   //   readTimingCache: reads tmp/test-timings.json (~2ms)
@@ -303,10 +313,11 @@ export async function run(config: Config): Promise<void> {
     config._failedTestFiles = new Set();
     config._failedTests = [];
 
-    // Shared JUnit accumulator. Set on the parent config BEFORE the group configs are spread
-    // off it, so every group pushes into the same collector and the final report covers the
-    // whole run (mirrors how COUNTER is shared above).
+    // Shared reporter/coverage accumulators. Set on the parent config BEFORE the group
+    // configs are spread off it, so every group pushes into the same collector and the
+    // final report covers the whole run (mirrors how COUNTER is shared above).
     config._junitCollector = config.reporter === 'junit' ? [] : null;
+    config._coverageCollector = config.coverage ? new Map() : null;
 
     const groupConfigs = groups.map((groupFiles, i) => ({
       ...config,
@@ -498,6 +509,7 @@ export async function run(config: Config): Promise<void> {
     TAPDisplayFinalResult(config.COUNTER, TIME_COUNTER.stop());
 
     if (config.reporter === 'junit') await writeJUnitReport(config);
+    if (config.coverage) await writeCoverageReport(config, allFiles);
 
     const fileTimes = computeFileTimes(groups, weights, wallTimes);
     persistTimings(fileTimes, config.projectRoot).catch(

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -40,6 +40,7 @@ import {
   buildFailureCache,
   resolveOnlyFailedFiles,
 } from '../utils/failure-cache.ts';
+import { writeJUnitReport } from '../reporter/junit.ts';
 import type { Config, CachedContent } from '../types.ts';
 
 // Playwright navigation timeout for headed watch-mode reloads (not test execution).
@@ -302,6 +303,11 @@ export async function run(config: Config): Promise<void> {
     config._failedTestFiles = new Set();
     config._failedTests = [];
 
+    // Shared JUnit accumulator. Set on the parent config BEFORE the group configs are spread
+    // off it, so every group pushes into the same collector and the final report covers the
+    // whole run (mirrors how COUNTER is shared above).
+    config._junitCollector = config.reporter === 'junit' ? [] : null;
+
     const groupConfigs = groups.map((groupFiles, i) => ({
       ...config,
       // Per-group dedup map for the testEnd handler — see
@@ -490,6 +496,8 @@ export async function run(config: Config): Promise<void> {
     }
 
     TAPDisplayFinalResult(config.COUNTER, TIME_COUNTER.stop());
+
+    if (config.reporter === 'junit') await writeJUnitReport(config);
 
     const fileTimes = computeFileTimes(groups, weights, wallTimes);
     persistTimings(fileTimes, config.projectRoot).catch(

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -30,7 +30,7 @@ import { runUserModule } from '../utils/run-user-module.ts';
 import { setupKeyboardEvents } from '../setup/keyboard-events.ts';
 import { writeOutputStaticFiles } from '../setup/write-output-static-files.ts';
 import { timeCounter } from '../utils/time-counter.ts';
-import { TAPDisplayFinalResult } from '../tap/display-final-result.ts';
+import { reportRunStart, reportRunEnd } from '../reporter/index.ts';
 import { readTemplate } from '../utils/read-template.ts';
 import { isCustomTemplate } from '../utils/html.ts';
 import { closeWithGrace } from '../utils/close-with-grace.ts';
@@ -283,10 +283,7 @@ export async function run(config: Config): Promise<void> {
     // groupConfigs[0]. In daemon mode, throw DaemonRunError so the daemon's
     // run handler closes the run cleanly and stays alive for the next call.
     if (allFiles.length === 0) {
-      process.stdout.write('TAP version 13\n');
-      process.stdout.write(
-        `# Running 0 test files${config._daemonMode ? ' (daemon)' : ''}\n1..0\n`,
-      );
+      reportRunStart(config, { fileCount: 0, groupCount: 0 });
       if (config._daemonMode) throw new DaemonRunError(0);
       if (!config.watch) {
         const browser = config._daemonBrowser ? null : await browserPromise!;
@@ -359,10 +356,7 @@ export async function run(config: Config): Promise<void> {
           })()
         : null;
 
-    process.stdout.write('TAP version 13\n');
-    process.stdout.write(
-      `# Running ${allFiles.length} test file${allFiles.length === 1 ? '' : 's'} across ${groupCount} group${groupCount === 1 ? '' : 's'}${config._daemonMode ? ' (daemon)' : ''}\n`,
-    );
+    reportRunStart(config, { fileCount: allFiles.length, groupCount });
 
     // Build all group bundles and write static files while the browser is starting up.
     // Bind the shared server's port in the same parallel window when active.
@@ -506,7 +500,7 @@ export async function run(config: Config): Promise<void> {
       );
     }
 
-    TAPDisplayFinalResult(config.COUNTER, TIME_COUNTER.stop());
+    await reportRunEnd(config, { durationMs: TIME_COUNTER.stop() });
 
     if (config.reporter === 'junit') await writeJUnitReport(config);
     if (config.coverage) await writeCoverageReport(config, allFiles);

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -40,7 +40,6 @@ import {
   buildFailureCache,
   resolveOnlyFailedFiles,
 } from '../utils/failure-cache.ts';
-import { writeJUnitReport } from '../reporter/junit.ts';
 import { writeCoverageReport } from '../coverage/report.ts';
 import type { Config, CachedContent } from '../types.ts';
 
@@ -313,7 +312,6 @@ export async function run(config: Config): Promise<void> {
     // Shared reporter/coverage accumulators. Set on the parent config BEFORE the group
     // configs are spread off it, so every group pushes into the same collector and the
     // final report covers the whole run (mirrors how COUNTER is shared above).
-    config._junitCollector = config.reporter === 'junit' ? [] : null;
     config._coverageCollector = config.coverage ? new Map() : null;
 
     const groupConfigs = groups.map((groupFiles, i) => ({
@@ -502,7 +500,6 @@ export async function run(config: Config): Promise<void> {
 
     await reportRunEnd(config, { durationMs: TIME_COUNTER.stop() });
 
-    if (config.reporter === 'junit') await writeJUnitReport(config);
     if (config.coverage) await writeCoverageReport(config, allFiles);
 
     const fileTimes = computeFileTimes(groups, weights, wallTimes);

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -9,7 +9,6 @@ import { runUserModule } from '../../utils/run-user-module.ts';
 import { reportRunEnd } from '../../reporter/index.ts';
 import { buildErrorHTML, buildNoTestsHTML } from '../../setup/web-server.ts';
 import { extractInlineSourceMap } from '../../utils/source-map-decoder.ts';
-import { writeJUnitReport } from '../../reporter/junit.ts';
 import { collectCoverage } from '../../coverage/collect.ts';
 import { writeCoverageReport } from '../../coverage/report.ts';
 import { writeMetafileCache } from '../../utils/metafile-cache.ts';
@@ -284,7 +283,6 @@ export async function runTestsInBrowser(
     // Fresh reporter/coverage accumulators per run in single/watch mode (group mode owns
     // these on the parent config in run.ts). Reset in lockstep with COUNTER so a watch
     // rerun reports only that run's cases and coverage, not an accumulation across reruns.
-    config._junitCollector = config.reporter === 'junit' ? [] : null;
     config._coverageCollector = config.coverage ? new Map() : null;
   }
   config.lastRanTestFiles = targetTestFilesToFilter || allTestFilePaths;
@@ -379,7 +377,6 @@ export async function runTestsInBrowser(
         );
       }
 
-      if (config.reporter === 'junit') await writeJUnitReport(config);
       if (config.coverage) await writeCoverageReport(config, allTestFilePaths);
 
       if (config.after) {

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -10,6 +10,8 @@ import { TAPDisplayFinalResult } from '../../tap/display-final-result.ts';
 import { buildErrorHTML, buildNoTestsHTML } from '../../setup/web-server.ts';
 import { extractInlineSourceMap } from '../../utils/source-map-decoder.ts';
 import { writeJUnitReport } from '../../reporter/junit.ts';
+import { collectCoverage } from '../../coverage/collect.ts';
+import { writeCoverageReport } from '../../coverage/report.ts';
 import { writeMetafileCache } from '../../utils/metafile-cache.ts';
 import { writeFailureCache, buildFailureCache } from '../../utils/failure-cache.ts';
 import { qunitxRuntimePlugin } from '../../setup/qunitx-runtime-plugin.ts';
@@ -279,10 +281,11 @@ export async function runTestsInBrowser(
     // resets these once on the parent config in run.ts before the shared spread.
     config._failedTestFiles = new Set();
     config._failedTests = [];
-    // Fresh JUnit accumulator per run in single/watch mode (group mode owns it on the parent
-    // config in run.ts). Reset in lockstep with COUNTER so a watch rerun reports only that
-    // run's cases, not an accumulation across reruns.
+    // Fresh reporter/coverage accumulators per run in single/watch mode (group mode owns
+    // these on the parent config in run.ts). Reset in lockstep with COUNTER so a watch
+    // rerun reports only that run's cases and coverage, not an accumulation across reruns.
     config._junitCollector = config.reporter === 'junit' ? [] : null;
+    config._coverageCollector = config.coverage ? new Map() : null;
   }
   config.lastRanTestFiles = targetTestFilesToFilter || allTestFilePaths;
 
@@ -377,6 +380,7 @@ export async function runTestsInBrowser(
       }
 
       if (config.reporter === 'junit') await writeJUnitReport(config);
+      if (config.coverage) await writeCoverageReport(config, allTestFilePaths);
 
       if (config.after) {
         await runUserModule(`${process.cwd()}/${config.after}`, config.COUNTER, 'after');
@@ -799,6 +803,11 @@ async function runTestInsideHTMLFile(
   // before test bundle compilation finishes). Distinguishes "WS never opened" from "WS opened
   // but tests.js compiled too slowly" — both appear as TIMEOUT but have different root causes.
   let wsConnected = false;
+  // Tracks whether V8 coverage was successfully armed on this page so `finally` only calls
+  // stopJSCoverage() when a matching start succeeded (a double-start throws; a stop without a
+  // start rejects). Coverage is chromium-only (guarded in run.ts) and page.coverage exists
+  // only on chromium pages, so guard the start behind both flags.
+  let coverageStarted = false;
 
   // Single promise driven by the WS handler:
   //   config._testRunDone()      → tests finished normally
@@ -878,6 +887,18 @@ async function runTestInsideHTMLFile(
       timeoutHandle = setTimeout(resolveTestRace, config.timeout + TEST_STALL_BUFFER_MS);
     };
 
+    // Arm V8 coverage before navigation. resetOnNavigation:false keeps the collected data
+    // across the goto/reload below so the bundle's execution is captured (Playwright's
+    // page.coverage is Chromium-only; config.coverage is already gated to chromium in run.ts).
+    if (config.coverage && (config.browser ?? 'chromium') === 'chromium') {
+      await page.coverage
+        .startJSCoverage({ resetOnNavigation: false })
+        .then(() => {
+          coverageStarted = true;
+        })
+        .catch(() => {});
+    }
+
     const targetUrl = `http://localhost:${config.port}${filePath}`;
     const navOptions = { timeout: navMs, waitUntil: 'commit' as const };
     // Use 'commit' (navigation committed, HTTP response started) rather than 'domcontentloaded'.
@@ -925,6 +946,20 @@ async function runTestInsideHTMLFile(
     config._resetTestTimeout = null;
     config._testRunDone = null;
     config._lastQUnitResult = null;
+    // Collect coverage before the caller closes the page. stopJSCoverage returns the V8 ranges
+    // + bundle source for every script; collectCoverage keeps only the test bundle and maps it
+    // back to original sources via config._sourceMapDecoder, merging into the shared collector.
+    if (coverageStarted) {
+      const entries = await page.coverage.stopJSCoverage().catch(() => []);
+      try {
+        await collectCoverage(config, entries);
+      } catch (error) {
+        config.debug &&
+          process.stderr.write(
+            `# [qunitx] coverage collection failed: ${(error as Error).message}\n`,
+          );
+      }
+    }
   }
 
   if (!QUNIT_RESULT) {

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -833,7 +833,12 @@ async function runTestInsideHTMLFile(
   page.on('close', resolveTestRace);
 
   try {
-    console.log('#', blue(`QUnitX running: http://localhost:${config.port}${filePath}`));
+    // A TAP `#` comment, so it only belongs in the TAP stream — it would be noise in a
+    // spec/dot/github run. --debug forces it on regardless: the URL is the whole point of
+    // debug mode (open it in a real browser), whatever the reporter.
+    if (config.reporter === 'tap' || config.debug) {
+      console.log('#', blue(`QUnitX running: http://localhost:${config.port}${filePath}`));
+    }
 
     // navMs is the budget Playwright gets to commit the navigation. Startup race timers must
     // never expire before navigation can complete — they are floored at navMs so that small

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -9,6 +9,7 @@ import { runUserModule } from '../../utils/run-user-module.ts';
 import { TAPDisplayFinalResult } from '../../tap/display-final-result.ts';
 import { buildErrorHTML, buildNoTestsHTML } from '../../setup/web-server.ts';
 import { extractInlineSourceMap } from '../../utils/source-map-decoder.ts';
+import { writeJUnitReport } from '../../reporter/junit.ts';
 import { writeMetafileCache } from '../../utils/metafile-cache.ts';
 import { writeFailureCache, buildFailureCache } from '../../utils/failure-cache.ts';
 import { qunitxRuntimePlugin } from '../../setup/qunitx-runtime-plugin.ts';
@@ -278,6 +279,10 @@ export async function runTestsInBrowser(
     // resets these once on the parent config in run.ts before the shared spread.
     config._failedTestFiles = new Set();
     config._failedTests = [];
+    // Fresh JUnit accumulator per run in single/watch mode (group mode owns it on the parent
+    // config in run.ts). Reset in lockstep with COUNTER so a watch rerun reports only that
+    // run's cases, not an accumulation across reruns.
+    config._junitCollector = config.reporter === 'junit' ? [] : null;
   }
   config.lastRanTestFiles = targetTestFilesToFilter || allTestFilePaths;
 
@@ -370,6 +375,8 @@ export async function runTestsInBrowser(
             config.debug && process.stderr.write(`# [qunitx] writeFailureCache: ${err.message}\n`),
         );
       }
+
+      if (config.reporter === 'junit') await writeJUnitReport(config);
 
       if (config.after) {
         await runUserModule(`${process.cwd()}/${config.after}`, config.COUNTER, 'after');

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -6,7 +6,7 @@ import { closeWithGrace } from '../../utils/close-with-grace.ts';
 import esbuild from 'esbuild';
 import { timeCounter } from '../../utils/time-counter.ts';
 import { runUserModule } from '../../utils/run-user-module.ts';
-import { TAPDisplayFinalResult } from '../../tap/display-final-result.ts';
+import { reportRunEnd } from '../../reporter/index.ts';
 import { buildErrorHTML, buildNoTestsHTML } from '../../setup/web-server.ts';
 import { extractInlineSourceMap } from '../../utils/source-map-decoder.ts';
 import { writeJUnitReport } from '../../reporter/junit.ts';
@@ -368,7 +368,7 @@ export async function runTestsInBrowser(
         );
       }
 
-      TAPDisplayFinalResult(config.COUNTER, TIME_TAKEN);
+      await reportRunEnd(config, { durationMs: TIME_TAKEN });
 
       // Persist failures for the next `--only-failed`. Skip filtered (partial) reruns so a
       // scoped re-run can't shrink the cache below the full known-failing set.

--- a/lib/coverage/collect.ts
+++ b/lib/coverage/collect.ts
@@ -1,0 +1,151 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { isBundleUrl, sourceAbsolutePath } from '../utils/source-map-decoder.ts';
+import type { SourceMapDecoder } from '../utils/source-map-decoder.ts';
+import type { Config, CoverageFileMap } from '../types.ts';
+
+/**
+ * Collects V8 line coverage from a page's `stopJSCoverage()` result and merges it into the
+ * run's shared coverage map.
+ *
+ * Approach (line coverage): V8 reports per-function byte-offset ranges with hit counts against
+ * the *bundle* (tests.js). We paint those counts across the bundle, then walk the bundle's
+ * source-map segments — each maps a bundle position back to an original (file, line) — and mark
+ * that original line coverable, and covered when the painted count at the mapped position is > 0.
+ * This reuses the same decoded source map the TAP `at:` resolver already builds, and attributes
+ * coverage to the original files the user wrote rather than the concatenated bundle.
+ *
+ * node_modules sources are dropped here; the report layer additionally drops the test entry files.
+ */
+interface V8ScriptCoverage {
+  url: string;
+  scriptId: string;
+  source?: string;
+  functions: Array<{
+    functionName: string;
+    isBlockCoverage: boolean;
+    ranges: Array<{ count: number; startOffset: number; endOffset: number }>;
+  }>;
+}
+
+/**
+ * Merges one page's `stopJSCoverage()` result into `config._coverageCollector`. No-op unless
+ * coverage is enabled and a source-map decoder is present. Only the test bundle is attributed;
+ * node_modules sources are dropped here (test entry files are dropped later, in the report layer).
+ */
+export async function collectCoverage(config: Config, entries: V8ScriptCoverage[]): Promise<void> {
+  const decoder = config._sourceMapDecoder;
+  const collector = config._coverageCollector;
+  if (!decoder || !collector) return;
+
+  for (const entry of entries) {
+    if (!isBundleUrl(entry.url)) continue;
+    // Playwright's `source` is often empty for the served bundle; the on-disk tests.js the server
+    // wrote is byte-identical to what V8 measured (same buffer), so read it as a fallback. V8
+    // ranges are offsets into that exact text, so the source must match the served bytes precisely.
+    const source = entry.source || (await readBundleSource(config, entry.url));
+    if (!source) continue;
+    attributeEntry(source, entry.functions, decoder, collector);
+  }
+}
+
+export { collectCoverage as default };
+
+/** Reads the served bundle (`tests.js` / `filtered-tests.js`) from the group's output dir. */
+function readBundleSource(config: Config, url: string): Promise<string | null> {
+  const fileName = url.endsWith('filtered-tests.js') ? 'filtered-tests.js' : 'tests.js';
+  const bundlePath = path.join(path.resolve(config.projectRoot, config.output), fileName);
+  return fs.readFile(bundlePath, 'utf8').catch(() => null);
+}
+
+function attributeEntry(
+  source: string,
+  functions: V8ScriptCoverage['functions'],
+  decoder: SourceMapDecoder,
+  collector: CoverageFileMap,
+): void {
+  const counts = paintCounts(source, functions);
+  const lineStarts = computeLineStarts(source);
+  const sourceLength = source.length;
+  const segmentsByLine = decoder.segmentsByLine;
+  // Cache per-sourceIndex absolute-path resolution (null = excluded, e.g. node_modules).
+  const pathCache = new Map<number, string | null>();
+
+  for (let generatedLine = 0; generatedLine < segmentsByLine.length; generatedLine++) {
+    const segments = segmentsByLine[generatedLine];
+    if (!segments || segments.length === 0) continue;
+    const lineStart = lineStarts[generatedLine];
+    if (lineStart === undefined) continue;
+
+    for (const segment of segments) {
+      const offset = lineStart + segment.generatedCol;
+      if (offset >= sourceLength) continue;
+      const count = counts[offset];
+      if (count < 0) continue; // no V8 range covered this position — unknown, skip
+
+      let absolutePath = pathCache.get(segment.sourceIndex);
+      if (absolutePath === undefined) {
+        absolutePath = resolveIncludedSource(decoder, segment.sourceIndex);
+        pathCache.set(segment.sourceIndex, absolutePath);
+      }
+      if (absolutePath === null) continue;
+
+      let fileCoverage = collector.get(absolutePath);
+      if (!fileCoverage) {
+        fileCoverage = {
+          coverable: new Set<number>(),
+          covered: new Map<number, number>(),
+          sourceContent: decoder.sourcesContent[segment.sourceIndex] ?? null,
+        };
+        collector.set(absolutePath, fileCoverage);
+      }
+
+      const line = segment.sourceLine + 1; // decoder lines are 0-based; report/lcov are 1-based
+      fileCoverage.coverable.add(line);
+      if (count > 0) {
+        const previous = fileCoverage.covered.get(line) ?? 0;
+        if (count > previous) fileCoverage.covered.set(line, count);
+      }
+    }
+  }
+}
+
+/** Returns the absolute source path for `sourceIndex`, or `null` for node_modules / unresolvable. */
+function resolveIncludedSource(decoder: SourceMapDecoder, sourceIndex: number): string | null {
+  const absolutePath = sourceAbsolutePath(decoder, sourceIndex);
+  if (!absolutePath) return null;
+  if (absolutePath.includes('/node_modules/') || absolutePath.includes('\\node_modules\\')) {
+    return null;
+  }
+  return absolutePath;
+}
+
+/**
+ * Builds a per-character hit-count array for the bundle. `-1` marks positions no V8 range
+ * covered (unknown). Ranges are painted outermost-first (start ascending, then end descending),
+ * so a nested block's count correctly overwrites its enclosing function's count — the standard
+ * V8 block-coverage nesting rule.
+ */
+function paintCounts(source: string, functions: V8ScriptCoverage['functions']): Int32Array {
+  const counts = new Int32Array(source.length).fill(-1);
+  const ranges: Array<{ count: number; startOffset: number; endOffset: number }> = [];
+  for (const fn of functions) {
+    for (const range of fn.ranges) ranges.push(range);
+  }
+  ranges.sort((a, b) => a.startOffset - b.startOffset || b.endOffset - a.endOffset);
+
+  for (const range of ranges) {
+    const end = Math.min(range.endOffset, source.length);
+    for (let i = range.startOffset; i < end; i++) counts[i] = range.count;
+  }
+  return counts;
+}
+
+/** Offset of the first character of each 0-based line in `source`. */
+function computeLineStarts(source: string): number[] {
+  const starts = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) === 10 /* \n */) starts.push(i + 1);
+  }
+  return starts;
+}

--- a/lib/coverage/collect.ts
+++ b/lib/coverage/collect.ts
@@ -68,7 +68,7 @@ function attributeEntry(
   const lineStarts = computeLineStarts(source);
   const sourceLength = source.length;
   const segmentsByLine = decoder.segmentsByLine;
-  // Cache per-sourceIndex absolute-path resolution (null = excluded, e.g. node_modules).
+  // Cache per-sourceIndex path resolution (null = a dependency, or unresolvable).
   const pathCache = new Map<number, string | null>();
 
   for (let generatedLine = 0; generatedLine < segmentsByLine.length; generatedLine++) {
@@ -85,7 +85,8 @@ function attributeEntry(
 
       let absolutePath = pathCache.get(segment.sourceIndex);
       if (absolutePath === undefined) {
-        absolutePath = resolveIncludedSource(decoder, segment.sourceIndex);
+        const resolved = sourceAbsolutePath(decoder, segment.sourceIndex);
+        absolutePath = resolved && !isDependencyPath(resolved) ? resolved : null;
         pathCache.set(segment.sourceIndex, absolutePath);
       }
       if (absolutePath === null) continue;
@@ -110,14 +111,12 @@ function attributeEntry(
   }
 }
 
-/** Returns the absolute source path for `sourceIndex`, or `null` for node_modules / unresolvable. */
-function resolveIncludedSource(decoder: SourceMapDecoder, sourceIndex: number): string | null {
-  const absolutePath = sourceAbsolutePath(decoder, sourceIndex);
-  if (!absolutePath) return null;
-  if (absolutePath.includes('/node_modules/') || absolutePath.includes('\\node_modules\\')) {
-    return null;
-  }
-  return absolutePath;
+/**
+ * The bundle inlines every dependency it imports — qunitx itself is most of the bytes — but that
+ * code is not the user's to fix, so it never enters the report.
+ */
+function isDependencyPath(absolutePath: string): boolean {
+  return absolutePath.includes('/node_modules/') || absolutePath.includes('\\node_modules\\');
 }
 
 /**

--- a/lib/coverage/report.ts
+++ b/lib/coverage/report.ts
@@ -1,0 +1,267 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { green, red, yellow } from '../utils/color.ts';
+import type { Config, CoverageFileMap, FileCoverage } from '../types.ts';
+
+/**
+ * Renders the run's accumulated line coverage: an always-on terminal summary, plus the optional
+ * `lcov.info` and self-contained `index.html` reports under `<output>/coverage/` when the user
+ * requested them via `--coverage=lcov,html`. Test entry files are excluded from the report — the
+ * bundle maps to them too, but coverage of the code under test is what users expect.
+ */
+
+// A coverage threshold below which a file's percentage is highlighted red; above the upper one
+// it is green; between, yellow. Purely cosmetic (terminal + HTML), not a pass/fail gate.
+const GOOD_PCT = 80;
+const OK_PCT = 50;
+
+interface FileRow {
+  displayPath: string;
+  total: number; // coverable (executable) lines
+  covered: number; // coverable lines with hit count > 0
+  pct: number;
+  fileCoverage: FileCoverage;
+}
+
+// The optional on-disk formats `--coverage=` accepts, in the order their `# wrote` lines print.
+// Adding a format is a row here plus a builder — never another branch in writeCoverageReport.
+const ARTIFACTS = [
+  { format: 'lcov', file: 'lcov.info', render: buildLcov },
+  { format: 'html', file: 'index.html', render: buildHtml },
+];
+
+/**
+ * Renders the run's accumulated coverage: always prints the terminal summary, then writes the
+ * `lcov`/`html` reports the user requested via `config.coverageFormats`. `testFiles` (the run's
+ * test entry paths) are excluded so the report reflects the code under test, not the tests.
+ */
+export async function writeCoverageReport(config: Config, testFiles: string[]): Promise<void> {
+  const collector = config._coverageCollector;
+  if (!collector || collector.size === 0) {
+    process.stdout.write(
+      '# Coverage: no coverable sources found (bundle mapped only to node_modules / test files)\n',
+    );
+    return;
+  }
+
+  const rows = buildRows(collector, new Set(testFiles), config.projectRoot);
+  if (rows.length === 0) {
+    process.stdout.write('# Coverage: no non-test sources found to report\n');
+    return;
+  }
+
+  printTerminalSummary(rows);
+
+  const formats = config.coverageFormats ?? [];
+  if (formats.length === 0) return;
+
+  const coverageDir = path.join(path.resolve(config.projectRoot, config.output), 'coverage');
+  await fs.mkdir(coverageDir, { recursive: true });
+
+  // Independent files, so write them concurrently. Each resolves to its own `# wrote` line,
+  // emitted after the join in array order, so output stays deterministic no matter which
+  // write settles first.
+  const formatWrites = ARTIFACTS.filter(({ format }) => formats.includes(format)).map(
+    async ({ format, file, render }) => {
+      const filePath = path.join(coverageDir, file);
+      await fs.writeFile(filePath, render(rows));
+      return `# wrote coverage ${format} to ${toDisplayPath(filePath, config.projectRoot)}\n`;
+    },
+  );
+  process.stdout.write((await Promise.all(formatWrites)).join(''));
+}
+
+export { writeCoverageReport as default };
+
+/** Turns the raw coverage map into sorted, test-file-filtered rows with computed percentages. */
+export function buildRows(
+  collector: CoverageFileMap,
+  testFiles: Set<string>,
+  projectRoot: string,
+): FileRow[] {
+  // Compare on the project-relative POSIX path rather than the raw key. The two sides arrive
+  // in different shapes — `testFiles` are OS paths from fsTree (backslashes on Windows), while
+  // coverage keys come from the source map (always `/`). Without normalizing, `has()` never
+  // matches on Windows and test files leak into the report.
+  const excluded = new Set([...testFiles].map((file) => toDisplayPath(file, projectRoot)));
+
+  // One pass: returning `[]` drops a file, returning the row keeps it. The early exit means
+  // excluded and empty files never pay for the line count, same as the filter did.
+  return [...collector]
+    .flatMap(([absolutePath, fileCoverage]) => {
+      const displayPath = toDisplayPath(absolutePath, projectRoot);
+      const total = fileCoverage.coverable.size;
+      if (excluded.has(displayPath) || total === 0) return [];
+
+      const covered = [...fileCoverage.coverable].filter(
+        (line) => (fileCoverage.covered.get(line) ?? 0) > 0,
+      ).length;
+      return { displayPath, total, covered, pct: (covered / total) * 100, fileCoverage };
+    })
+    .sort((a, b) => a.displayPath.localeCompare(b.displayPath));
+}
+
+function printTerminalSummary(rows: FileRow[]): void {
+  const totalLines = rows.reduce((sum, row) => sum + row.total, 0);
+  const coveredLines = rows.reduce((sum, row) => sum + row.covered, 0);
+  const overallPct = totalLines > 0 ? (coveredLines / totalLines) * 100 : 0;
+
+  const pathWidth = Math.min(
+    60,
+    Math.max(9, ...rows.map((row) => row.displayPath.length), 'All files'.length),
+  );
+  const divider = `# ${'-'.repeat(pathWidth + 20)}`;
+
+  // Assemble, then write once. The table is one frame of output, and a concurrent group's TAP
+  // interleaving between rows would tear it apart — a per-row write invites exactly that.
+  process.stdout.write(
+    [
+      '#',
+      '# Coverage (V8 line coverage)',
+      divider,
+      `# ${'File'.padEnd(pathWidth)}   ${'% Lines'.padStart(8)}   Lines`,
+      divider,
+      ...rows.map((row) => formatRow(row.displayPath, row.pct, row.covered, row.total, pathWidth)),
+      divider,
+      formatRow('All files', overallPct, coveredLines, totalLines, pathWidth),
+      divider,
+      '',
+    ].join('\n'),
+  );
+}
+
+function formatRow(
+  label: string,
+  pct: number,
+  covered: number,
+  total: number,
+  pathWidth: number,
+): string {
+  const truncated = label.length > pathWidth ? `…${label.slice(-(pathWidth - 1))}` : label;
+  const pctText = `${pct.toFixed(2)}%`.padStart(8);
+  const colored = pct >= GOOD_PCT ? green(pctText) : pct >= OK_PCT ? yellow(pctText) : red(pctText);
+  return `# ${truncated.padEnd(pathWidth)}   ${colored}   ${covered}/${total}`;
+}
+
+/** Builds a standard LCOV `lcov.info` string (line coverage only: DA/LF/LH per file). */
+export function buildLcov(rows: FileRow[]): string {
+  return (
+    rows
+      .map(({ displayPath, total, covered, fileCoverage }) =>
+        [
+          'TN:',
+          `SF:${displayPath}`,
+          ...[...fileCoverage.coverable]
+            .sort((a, b) => a - b)
+            .map((line) => `DA:${line},${fileCoverage.covered.get(line) ?? 0}`),
+          `LF:${total}`,
+          `LH:${covered}`,
+          'end_of_record',
+        ].join('\n'),
+      )
+      .join('\n') + '\n'
+  );
+}
+
+/** Builds a self-contained HTML report: a summary table plus per-file source with line coloring. */
+export function buildHtml(rows: FileRow[]): string {
+  const totalLines = rows.reduce((sum, row) => sum + row.total, 0);
+  const coveredLines = rows.reduce((sum, row) => sum + row.covered, 0);
+  const overallPct = totalLines > 0 ? (coveredLines / totalLines) * 100 : 0;
+
+  const summaryRows = rows
+    .map(
+      (row) =>
+        `<tr><td><a href="#${escapeAttr(row.displayPath)}">${escapeHtml(row.displayPath)}</a></td>` +
+        `<td class="${pctClass(row.pct)}">${row.pct.toFixed(2)}%</td>` +
+        `<td>${row.covered}/${row.total}</td></tr>`,
+    )
+    .join('\n');
+
+  const fileSections = rows.map(renderFileSection).join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>qunitx coverage</title>
+<style>
+  body { font-family: -apple-system, "Helvetica Neue", Arial, sans-serif; margin: 2rem; color: #1a1a1a; }
+  h1 { font-size: 1.4rem; }
+  table { border-collapse: collapse; margin: 1rem 0; }
+  th, td { padding: 0.35rem 0.9rem; border-bottom: 1px solid #e2e2e2; text-align: left; }
+  th { background: #0d3349; color: #fff; }
+  td.good { color: #157a3d; font-weight: 600; }
+  td.ok { color: #9a7500; font-weight: 600; }
+  td.bad { color: #b3261e; font-weight: 600; }
+  .file { margin: 2rem 0; }
+  .file h2 { font-size: 1rem; font-family: Menlo, Monaco, Consolas, monospace; }
+  pre { margin: 0; border: 1px solid #e2e2e2; border-radius: 4px; overflow-x: auto; }
+  .ln { display: flex; font-family: Menlo, Monaco, Consolas, monospace; font-size: 12px; line-height: 1.5; }
+  .ln .no { width: 3.5rem; text-align: right; padding-right: 0.8rem; color: #999; user-select: none; flex: none; }
+  .ln .ct { width: 3rem; text-align: right; padding-right: 0.8rem; color: #999; user-select: none; flex: none; }
+  .ln .src { white-space: pre; }
+  .ln.hit { background: #e6ffed; }
+  .ln.miss { background: #ffeef0; }
+  .ln.hit .ct { color: #157a3d; }
+  .ln.miss .ct { color: #b3261e; }
+</style>
+</head>
+<body>
+<h1>qunitx coverage <span class="${pctClass(overallPct)}">${overallPct.toFixed(2)}%</span> (${coveredLines}/${totalLines} lines)</h1>
+<table>
+<thead><tr><th>File</th><th>% Lines</th><th>Lines</th></tr></thead>
+<tbody>
+${summaryRows}
+</tbody>
+</table>
+${fileSections}
+</body>
+</html>
+`;
+}
+
+function renderFileSection({ displayPath, pct, covered, total, fileCoverage }: FileRow): string {
+  const header = `<div class="file" id="${escapeAttr(displayPath)}"><h2>${escapeHtml(displayPath)} — <span class="${pctClass(pct)}">${pct.toFixed(2)}%</span> (${covered}/${total})</h2>`;
+  if (fileCoverage.sourceContent === null) {
+    return `${header}<p>Source text unavailable.</p></div>`;
+  }
+
+  const rendered = fileCoverage.sourceContent
+    .split('\n')
+    .map((text, index) => {
+      const lineNumber = index + 1;
+      const isCoverable = fileCoverage.coverable.has(lineNumber);
+      const count = fileCoverage.covered.get(lineNumber) ?? 0;
+      const cls = !isCoverable ? '' : count > 0 ? 'hit' : 'miss';
+      return `<div class="ln ${cls}"><span class="no">${lineNumber}</span><span class="ct">${isCoverable ? count : ''}</span><span class="src">${escapeHtml(text) || ' '}</span></div>`;
+    })
+    .join('');
+  return `${header}<pre>${rendered}</pre></div>`;
+}
+
+function pctClass(pct: number): string {
+  return pct >= GOOD_PCT ? 'good' : pct >= OK_PCT ? 'ok' : 'bad';
+}
+
+/**
+ * The canonical key for a source file: POSIX separators, relative to the project root. Used for
+ * both display and test-file exclusion so the two can't disagree. Paths reach us in two shapes —
+ * OS paths from fsTree and `/`-separated paths from the source map — and on Windows those differ
+ * by separator (and the map's may already be project-relative), so normalize before comparing.
+ * Paths outside the project root are left absolute.
+ */
+function toDisplayPath(filePath: string, projectRoot: string): string {
+  const posixPath = filePath.replace(/\\/g, '/');
+  const posixRoot = projectRoot.replace(/\\/g, '/');
+  return posixPath.startsWith(`${posixRoot}/`) ? posixPath.slice(posixRoot.length + 1) : posixPath;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escapeAttr(value: string): string {
+  return escapeHtml(value).replace(/"/g, '&quot;');
+}

--- a/lib/reporter/dot.ts
+++ b/lib/reporter/dot.ts
@@ -1,0 +1,84 @@
+import { green, red, yellow } from '../utils/color.ts';
+import { failedAssertions } from './failure.ts';
+import { formatFailureBlock } from './spec.ts';
+import { indentString } from '../utils/indent-string.ts';
+import type { Reporter, RunStartInfo, RunEndInfo, TestDetails } from './types.ts';
+import type { Config } from '../types.ts';
+
+/** Dots per line before wrapping — comfortably inside an 80-column terminal. */
+const LINE_WIDTH = 72;
+
+/**
+ * One character per test, failures reported in full at the end. The right shape for large
+ * suites and CI logs, where a line per test is thousands of lines of noise but you still
+ * want live progress.
+ *
+ * Unlike spec, failure detail is buffered rather than printed inline — interleaving failure
+ * blocks with the dot matrix would break the matrix apart and lose the at-a-glance shape.
+ */
+export class DotReporter implements Reporter {
+  #column = 0;
+  #failures: Array<{ name: string; block: string }> = [];
+
+  /** Resets the matrix column and buffered failures, then prints the run banner. */
+  onRunStart(_config: Config, info: RunStartInfo): void {
+    this.#column = 0;
+    this.#failures = [];
+    if (info.fileCount === null) return;
+    if (info.fileCount === 0) {
+      process.stdout.write('\nNo test files found.\n');
+      return;
+    }
+    const files = `${info.fileCount} test file${info.fileCount === 1 ? '' : 's'}`;
+    process.stdout.write(`\nRunning ${files} across ${info.groupCount} worker(s)\n\n`);
+  }
+
+  /** Writes this test's character, wrapping the matrix, and buffers any failure detail. */
+  onTestEnd(config: Config, details: TestDetails): void {
+    // Dot and any wrap in one write: this runs per test, and a split write invites another
+    // group's output between the character and its own newline.
+    const wrapped = ++this.#column >= LINE_WIDTH;
+    if (wrapped) this.#column = 0;
+    process.stdout.write(wrapped ? `${statusDot(details.status)}\n` : statusDot(details.status));
+
+    if (details.status !== 'failed') return;
+    this.#failures.push({
+      name: details.fullName.join(' | '),
+      block: formatFailureBlock(
+        failedAssertions(details, config._sourceMapDecoder, config.projectRoot),
+      ),
+    });
+  }
+
+  /** Closes the matrix line, then prints the counts and every buffered failure. */
+  onRunEnd(config: Config, info: RunEndInfo): void {
+    const { passCount, failCount, skipCount, todoCount } = config.COUNTER;
+    // Zero counts stay off the summary — "0 failing" is noise on a green run.
+    const counts = [
+      `\n  ${green(`${passCount} passing`)} (${info.durationMs}ms)`,
+      ...(failCount > 0 ? [`  ${red(`${failCount} failing`)}`] : []),
+      ...(skipCount > 0 ? [`  ${yellow(`${skipCount} skipped`)}`] : []),
+      ...(todoCount > 0 ? [`  ${yellow(`${todoCount} todo`)}`] : []),
+    ].join('\n');
+
+    const recap = this.#failures.length
+      ? `\n${red('Failures:')}\n${this.#failures
+          .map(
+            ({ name, block }, index) =>
+              `\n  ${index + 1}) ${name}\n${block ? indentString(block, 5) : ''}`,
+          )
+          .join('')}`
+      : '';
+
+    // Leading newline closes the dot matrix when it ends mid-line.
+    process.stdout.write(`${this.#column > 0 ? '\n' : ''}${counts}\n${recap}\n`);
+  }
+}
+
+// Built once: `color.ts` freezes its enabled/disabled decision at module load, so precomputing
+// costs nothing and can't drift from a call-time green()/red().
+const DOTS: Record<string, string> = { passed: green('.'), failed: red('F'), todo: yellow('t') };
+
+function statusDot(status: string): string {
+  return DOTS[status] ?? yellow('s'); // anything else (skipped) is an 's'
+}

--- a/lib/reporter/failure.ts
+++ b/lib/reporter/failure.ts
@@ -1,0 +1,116 @@
+import { resolveStack, type SourceMapDecoder } from '../utils/source-map-decoder.ts';
+import type { TestDetails } from './types.ts';
+
+/**
+ * Extracts the source location from a stack trace string.
+ * Supports Chrome/Node style "at func (url:line:col)" and Firefox/WebKit style "@url:line:col".
+ * Returns a clean location string without surrounding parens, or null if nothing can be extracted.
+ */
+export function extractStackAt(stack: string | null | undefined): string | null {
+  if (!stack) return null;
+  // Chrome/Node: "at func (url:line:col)" — capture inside parens
+  const chromeMatch = stack.match(/\(([^)\n]+:[0-9]+:[0-9]+)\)/);
+  if (chromeMatch) return chromeMatch[1].replace('file://', '');
+  // Firefox/WebKit: "funcname@url:line:col" or just "@url:line:col"
+  const geckoMatch = stack.match(/@([^\s\n@]+:[0-9]+:[0-9]+)/);
+  if (geckoMatch) return geckoMatch[1];
+  return null;
+}
+
+/**
+ * One failing assertion, normalized for rendering. Every reporter needs the same three
+ * things — what failed, where in the *original* source, and the values involved — so the
+ * source-map resolution and value normalization happen once here rather than per reporter.
+ */
+export interface FailureInfo {
+  /** 1-based index of the assertion within the test (matches TAP's `Assertion #N`). */
+  index: number;
+  /** The assertion's message, or `null` when it had none. */
+  message: string | null;
+  /** The value the assertion saw, normalized so circular refs are safe to dump. */
+  actual: unknown;
+  /** The value the assertion required, normalized the same way as `actual`. */
+  expected: unknown;
+  /** Stack with bundle frames rewritten to original sources when a decoder is available. */
+  stack: string | null;
+  /** `path:line:col` of the first user frame (preferred) or the raw stack location. */
+  at: string | null;
+  /** The original source line's text, when the map embeds `sourcesContent`. */
+  source: string | null;
+}
+
+/**
+ * Extracts every genuinely-failing assertion (todo assertions are expected to fail and are
+ * excluded) from a `testEnd` payload, resolving stacks back to original sources.
+ */
+export function failedAssertions(
+  details: TestDetails,
+  decoder?: SourceMapDecoder | null,
+  projectRoot?: string,
+): FailureInfo[] {
+  // `index` counts every assertion, not only the failing ones — it is TAP's `Assertion #N`, so
+  // it must not shift when passing ones drop out. flatMap keeps that index without a filter
+  // pass: returning `[]` skips, returning the object keeps it (flatMap flattens one level).
+  return (details.assertions ?? []).flatMap((assertion, index) =>
+    assertion.passed || assertion.todo !== false
+      ? []
+      : {
+          index: index + 1,
+          message: assertion.message || null,
+          actual: normalizeValue(assertion.actual),
+          expected: normalizeValue(assertion.expected),
+          ...resolveLocation(assertion.stack, decoder, projectRoot),
+        },
+  );
+}
+
+/** Splits an `at` string (`path:line:col`) into parts; returns null when it isn't a location. */
+export function parseAt(at: string | null): { file: string; line: number; col: number } | null {
+  if (!at) return null;
+  const match = /^(.+):(\d+):(\d+)$/.exec(at);
+  return match ? { file: match[1], line: Number(match[2]), col: Number(match[3]) } : null;
+}
+
+// Without a decoder the raw stack is all we have. With one, frames resolve back to the original
+// sources and `at` prefers the first user frame — when every frame is node_modules or
+// unresolvable, null is cleaner than pointing at the bundle URL.
+function resolveLocation(
+  stack: string | null | undefined,
+  decoder?: SourceMapDecoder | null,
+  projectRoot?: string,
+): Pick<FailureInfo, 'stack' | 'at' | 'source'> {
+  if (!decoder || !projectRoot || !stack) {
+    return { stack: stack?.trim() || null, at: extractStackAt(stack), source: null };
+  }
+
+  const { resolvedStack, firstUserFrame, firstUserSourceText } = resolveStack(
+    stack,
+    decoder,
+    projectRoot,
+  );
+  return { stack: resolvedStack.trim() || null, at: firstUserFrame, source: firstUserSourceText };
+}
+
+// QUnit assertion values can carry circular references (DOM nodes, framework objects). Round
+// -tripping through JSON with a circular replacer keeps them dumpable by every reporter.
+function normalizeValue(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  return JSON.parse(JSON.stringify(value, getCircularReplacer()));
+}
+
+function getCircularReplacer(): (_key: string, value: unknown) => unknown {
+  const ancestors: object[] = [];
+  return function (this: object, _key: string, value: unknown) {
+    if (typeof value !== 'object' || value === null) {
+      return value;
+    }
+    while (ancestors.length > 0 && ancestors.at(-1) !== this) {
+      ancestors.pop();
+    }
+    if (ancestors.includes(value)) {
+      return '[Circular]';
+    }
+    ancestors.push(value);
+    return value;
+  };
+}

--- a/lib/reporter/github.ts
+++ b/lib/reporter/github.ts
@@ -1,0 +1,88 @@
+import { SpecReporter } from './spec.ts';
+import { failedAssertions, parseAt, type FailureInfo } from './failure.ts';
+import type { Reporter, RunStartInfo, RunEndInfo, TestDetails } from './types.ts';
+import type { Config } from '../types.ts';
+
+/**
+ * GitHub Actions reporter: spec output, plus a `::error` workflow command per failure so the
+ * failure is annotated inline on the PR diff.
+ *
+ * Getting annotations otherwise costs an artifact upload, a second workflow, a third-party
+ * reporter action, and a fork-token dance. Here it's one flag — the file:line is already
+ * resolved back to original sources by the shared failure descriptor.
+ *
+ * Composes SpecReporter rather than reimplementing it: the log stays as readable as a normal
+ * spec run, and annotations are strictly additional.
+ */
+export class GithubReporter implements Reporter {
+  #spec = new SpecReporter();
+
+  /** Delegates the run banner to the spec renderer. */
+  onRunStart(config: Config, info: RunStartInfo): void {
+    this.#spec.onRunStart(config, info);
+  }
+
+  /** Renders the spec line, then annotates each failing assertion for the PR diff. */
+  onTestEnd(config: Config, details: TestDetails): void {
+    this.#spec.onTestEnd(config, details);
+    if (details.status !== 'failed') return;
+
+    // One annotation per failing assertion: each has its own location, and GitHub renders
+    // them at their exact line. Emitted as one write so the block can't be split apart.
+    const title = details.fullName.join(' | ');
+    process.stdout.write(
+      failedAssertions(details, config._sourceMapDecoder, config.projectRoot)
+        .map((failure) => `${annotation(title, failure)}\n`)
+        .join(''),
+    );
+  }
+
+  /** Delegates the summary + failure recap to the spec renderer. */
+  onRunEnd(config: Config, info: RunEndInfo): void {
+    this.#spec.onRunEnd(config, info);
+  }
+}
+
+/** Builds one `::error file=…,line=…,col=…,title=…::message` workflow command. */
+export function annotation(title: string, failure: FailureInfo): string {
+  const location = parseAt(failure.at);
+  const properties = [
+    ...(location
+      ? [`file=${escapeProperty(location.file)}`, `line=${location.line}`, `col=${location.col}`]
+      : []),
+    `title=${escapeProperty(title)}`,
+  ];
+
+  const message = [
+    failure.message ?? `Assertion #${failure.index} failed`,
+    failure.expected !== undefined || failure.actual !== undefined
+      ? `expected: ${format(failure.expected)}\nactual:   ${format(failure.actual)}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return `::error ${properties.join(',')}::${escapeData(message)}`;
+}
+
+// GitHub workflow-command escaping. Without this a message containing a newline would end the
+// command early and the rest would leak into the log as plain text.
+// https://docs.github.com/actions/reference/workflow-commands-for-github-actions
+function escapeData(value: string): string {
+  return value.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+// Property values additionally escape `:` and `,` — the command's own delimiters.
+function escapeProperty(value: string): string {
+  return escapeData(value).replace(/:/g, '%3A').replace(/,/g, '%2C');
+}
+
+function format(value: unknown): string {
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (value === undefined) return 'undefined';
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/lib/reporter/index.ts
+++ b/lib/reporter/index.ts
@@ -1,10 +1,20 @@
 import { TapReporter } from './tap.ts';
 import { SpecReporter } from './spec.ts';
 import { DotReporter } from './dot.ts';
+import { GithubReporter } from './github.ts';
 import { JUnitReporter } from './junit.ts';
 import { updateCounter } from './types.ts';
-import type { Reporter, RunStartInfo, RunEndInfo, TestDetails } from './types.ts';
+import type { Reporter, ReporterName, RunStartInfo, RunEndInfo, TestDetails } from './types.ts';
 import type { Config } from '../types.ts';
+
+// The `--reporter` value -> stdout reporter. Keyed by ReporterName so adding a name to
+// REPORTERS without wiring it up here is a type error rather than a silent fall back to tap.
+const STDOUT_REPORTERS: Record<ReporterName, new () => Reporter> = {
+  tap: TapReporter,
+  spec: SpecReporter,
+  dot: DotReporter,
+  github: GithubReporter,
+};
 
 /**
  * Reporter wiring. `config.reporter` selects exactly one stdout reporter; artifact
@@ -13,10 +23,9 @@ import type { Config } from '../types.ts';
  * they all reference this same array (the same way `COUNTER` is shared).
  */
 export function createReporters(config: Config): Reporter[] {
-  const reporters: Reporter[] = [stdoutReporter(config)];
-  // Additive artifact reporters stack on top of whichever stdout reporter is active.
-  if (config.junit) reporters.push(new JUnitReporter());
-  return reporters;
+  // Exactly one stdout reporter, plus any additive artifact reporters. A plain run is a
+  // 1-element array; `--reporter=dot --junit` is 2 — one owning stdout, one owning the file.
+  return [stdoutReporter(config), ...(config.junit ? [new JUnitReporter()] : [])];
 }
 
 /** Emits run start to every active reporter. In watch mode this fires once per rerun. */
@@ -46,7 +55,5 @@ export type { Reporter, RunStartInfo, RunEndInfo, TestDetails };
 // Exactly one stdout reporter per run. `--reporter` is validated in parse-cli-flags, so an
 // unknown value never reaches here; tap is the default and the fallback.
 function stdoutReporter(config: Config): Reporter {
-  if (config.reporter === 'spec') return new SpecReporter();
-  if (config.reporter === 'dot') return new DotReporter();
-  return new TapReporter();
+  return new (STDOUT_REPORTERS[config.reporter ?? 'tap'] ?? TapReporter)();
 }

--- a/lib/reporter/index.ts
+++ b/lib/reporter/index.ts
@@ -1,0 +1,38 @@
+import { TapReporter } from './tap.ts';
+import { updateCounter } from './types.ts';
+import type { Reporter, RunStartInfo, RunEndInfo, TestDetails } from './types.ts';
+import type { Config } from '../types.ts';
+
+/**
+ * Reporter wiring. `config.reporter` selects exactly one stdout reporter; artifact
+ * reporters (JUnit) are additive and stack on top. Built once per run in `setupConfig` and
+ * shared by every concurrent group — the group configs are spread off the parent config, so
+ * they all reference this same array (the same way `COUNTER` is shared).
+ */
+export function createReporters(_config: Config): Reporter[] {
+  return [new TapReporter()];
+}
+
+/** Emits run start to every active reporter. In watch mode this fires once per rerun. */
+export function reportRunStart(config: Config, info: RunStartInfo): void {
+  config._reporters?.forEach((reporter) => reporter.onRunStart?.(config, info));
+}
+
+/**
+ * Applies one `testEnd` to the counters, then fans it out to every active reporter.
+ * The counter update happens here — exactly once, before any reporter runs — so counts stay
+ * correct regardless of how many reporters are attached.
+ */
+export function reportTestEnd(config: Config, details: TestDetails): void {
+  updateCounter(config.COUNTER, details);
+  config._reporters?.forEach((reporter) => reporter.onTestEnd?.(config, details));
+}
+
+/** Emits run end to every active reporter, awaiting any that flush asynchronously. */
+export async function reportRunEnd(config: Config, info: RunEndInfo): Promise<void> {
+  for (const reporter of config._reporters ?? []) {
+    await reporter.onRunEnd?.(config, info);
+  }
+}
+
+export type { Reporter, RunStartInfo, RunEndInfo, TestDetails };

--- a/lib/reporter/index.ts
+++ b/lib/reporter/index.ts
@@ -1,5 +1,6 @@
 import { TapReporter } from './tap.ts';
 import { SpecReporter } from './spec.ts';
+import { DotReporter } from './dot.ts';
 import { JUnitReporter } from './junit.ts';
 import { updateCounter } from './types.ts';
 import type { Reporter, RunStartInfo, RunEndInfo, TestDetails } from './types.ts';
@@ -12,9 +13,7 @@ import type { Config } from '../types.ts';
  * they all reference this same array (the same way `COUNTER` is shared).
  */
 export function createReporters(config: Config): Reporter[] {
-  const reporters: Reporter[] = [
-    config.reporter === 'spec' ? new SpecReporter() : new TapReporter(),
-  ];
+  const reporters: Reporter[] = [stdoutReporter(config)];
   // Additive artifact reporters stack on top of whichever stdout reporter is active.
   if (config.junit) reporters.push(new JUnitReporter());
   return reporters;
@@ -43,3 +42,11 @@ export async function reportRunEnd(config: Config, info: RunEndInfo): Promise<vo
 }
 
 export type { Reporter, RunStartInfo, RunEndInfo, TestDetails };
+
+// Exactly one stdout reporter per run. `--reporter` is validated in parse-cli-flags, so an
+// unknown value never reaches here; tap is the default and the fallback.
+function stdoutReporter(config: Config): Reporter {
+  if (config.reporter === 'spec') return new SpecReporter();
+  if (config.reporter === 'dot') return new DotReporter();
+  return new TapReporter();
+}

--- a/lib/reporter/index.ts
+++ b/lib/reporter/index.ts
@@ -1,4 +1,5 @@
 import { TapReporter } from './tap.ts';
+import { JUnitReporter } from './junit.ts';
 import { updateCounter } from './types.ts';
 import type { Reporter, RunStartInfo, RunEndInfo, TestDetails } from './types.ts';
 import type { Config } from '../types.ts';
@@ -9,8 +10,11 @@ import type { Config } from '../types.ts';
  * shared by every concurrent group — the group configs are spread off the parent config, so
  * they all reference this same array (the same way `COUNTER` is shared).
  */
-export function createReporters(_config: Config): Reporter[] {
-  return [new TapReporter()];
+export function createReporters(config: Config): Reporter[] {
+  const reporters: Reporter[] = [new TapReporter()];
+  // Additive artifact reporters stack on top of whichever stdout reporter is active.
+  if (config.junit) reporters.push(new JUnitReporter());
+  return reporters;
 }
 
 /** Emits run start to every active reporter. In watch mode this fires once per rerun. */

--- a/lib/reporter/index.ts
+++ b/lib/reporter/index.ts
@@ -1,4 +1,5 @@
 import { TapReporter } from './tap.ts';
+import { SpecReporter } from './spec.ts';
 import { JUnitReporter } from './junit.ts';
 import { updateCounter } from './types.ts';
 import type { Reporter, RunStartInfo, RunEndInfo, TestDetails } from './types.ts';
@@ -11,7 +12,9 @@ import type { Config } from '../types.ts';
  * they all reference this same array (the same way `COUNTER` is shared).
  */
 export function createReporters(config: Config): Reporter[] {
-  const reporters: Reporter[] = [new TapReporter()];
+  const reporters: Reporter[] = [
+    config.reporter === 'spec' ? new SpecReporter() : new TapReporter(),
+  ];
   // Additive artifact reporters stack on top of whichever stdout reporter is active.
   if (config.junit) reporters.push(new JUnitReporter());
   return reporters;

--- a/lib/reporter/junit.ts
+++ b/lib/reporter/junit.ts
@@ -1,0 +1,196 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { resolveStack } from '../utils/source-map-decoder.ts';
+import type { Config, JUnitCase } from '../types.ts';
+
+/**
+ * JUnit XML reporter. When `--reporter=junit` is active, `recordJUnitCase` is called from the
+ * WebSocket `testEnd` handler (the same point TAP is streamed) for every test, and
+ * `writeJUnitReport` serializes the accumulated cases into a `junit.xml` file at run end.
+ * TAP continues to stream to stdout unchanged — the XML is an additional machine-readable
+ * artifact for CI dashboards (GitHub Actions, GitLab, CircleCI, Jenkins, …).
+ */
+
+// Shape of the QUnit `testEnd` payload the WS handler forwards. Non-failed tests carry the
+// trimmed `{ status, fullName, runtime }`; failed tests carry the full details incl. assertions.
+interface TestDetails {
+  status: string;
+  fullName: string[];
+  runtime: number;
+  assertions?: Array<{
+    passed: boolean;
+    todo: boolean;
+    message?: string;
+    stack?: string;
+  }>;
+}
+
+/**
+ * Records one `testEnd` as a JUnit `<testcase>` on the run's shared collector. No-op unless a
+ * collector is present (i.e. `--reporter=junit`). Failing assertions are flattened into a
+ * `failureDetail` string with stacks resolved back to original sources via the bundle's source
+ * map, matching the TAP `at:` behavior.
+ */
+export function recordJUnitCase(config: Config, details: TestDetails): void {
+  const collector = config._junitCollector;
+  if (!collector) return;
+
+  const fullName = details.fullName;
+  const name = fullName[fullName.length - 1] ?? fullName.join(' | ');
+  const classname = fullName.slice(0, -1).join(' > ') || '(root)';
+  const status = normalizeStatus(details.status);
+  const testCase: JUnitCase = {
+    classname,
+    name,
+    time: (details.runtime ?? 0) / 1000,
+    status,
+  };
+
+  if (status === 'failed') {
+    const failed = (details.assertions ?? []).filter((a) => !a.passed && a.todo === false);
+    if (failed.length > 0) {
+      testCase.failureMessage = failed[0].message || 'Assertion failed';
+      testCase.failureDetail = failed
+        .map((assertion, index) => {
+          const message = assertion.message || `Assertion #${index + 1} failed`;
+          const stack = resolveAssertionStack(config, assertion.stack);
+          return stack ? `${message}\n${stack}` : message;
+        })
+        .join('\n\n');
+    } else {
+      // Failed status with no failing assertion recorded (e.g. an uncaught error mid-test).
+      testCase.failureMessage = 'Test failed';
+    }
+  }
+
+  collector.push(testCase);
+}
+
+/**
+ * Serializes the run's accumulated JUnit cases to `config.junitOutput` (default
+ * `<output>/junit.xml`, resolved against `projectRoot`), grouping cases into one `<testsuite>`
+ * per QUnit module. Prints the destination as a TAP `#` comment. No-op when no cases collected.
+ */
+export async function writeJUnitReport(config: Config): Promise<void> {
+  const collector = config._junitCollector;
+  if (!collector) return;
+
+  const outputPath = config.junitOutput
+    ? path.resolve(config.projectRoot, config.junitOutput)
+    : path.join(path.resolve(config.projectRoot, config.output), 'junit.xml');
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, buildJUnitXML(collector));
+  process.stdout.write(
+    `# wrote JUnit report to ${relativeToRoot(outputPath, config.projectRoot)}\n`,
+  );
+}
+
+/** Builds the full JUnit XML document string from a flat list of test cases. */
+export function buildJUnitXML(cases: JUnitCase[]): string {
+  const suites = new Map<string, JUnitCase[]>();
+  for (const testCase of cases) {
+    const bucket = suites.get(testCase.classname);
+    if (bucket) bucket.push(testCase);
+    else suites.set(testCase.classname, [testCase]);
+  }
+
+  const totalTime = cases.reduce((sum, testCase) => sum + testCase.time, 0);
+  const totalFailures = cases.filter((testCase) => testCase.status === 'failed').length;
+  const totalSkipped = cases.filter(
+    (testCase) => testCase.status === 'skipped' || testCase.status === 'todo',
+  ).length;
+
+  const lines: string[] = ['<?xml version="1.0" encoding="UTF-8"?>'];
+  lines.push(
+    `<testsuites name="qunitx" tests="${cases.length}" failures="${totalFailures}" ` +
+      `skipped="${totalSkipped}" time="${formatTime(totalTime)}">`,
+  );
+  for (const [suiteName, suiteCases] of suites) {
+    lines.push(...buildSuite(suiteName, suiteCases));
+  }
+  lines.push('</testsuites>');
+  return lines.join('\n') + '\n';
+}
+
+export { writeJUnitReport as default };
+
+/** Builds the `<testsuite>` block (with nested `<testcase>` elements) for one QUnit module. */
+function buildSuite(suiteName: string, cases: JUnitCase[]): string[] {
+  const suiteTime = cases.reduce((sum, testCase) => sum + testCase.time, 0);
+  const failures = cases.filter((testCase) => testCase.status === 'failed').length;
+  const skipped = cases.filter(
+    (testCase) => testCase.status === 'skipped' || testCase.status === 'todo',
+  ).length;
+
+  const lines = [
+    `  <testsuite name="${escapeAttr(suiteName)}" tests="${cases.length}" ` +
+      `failures="${failures}" skipped="${skipped}" time="${formatTime(suiteTime)}">`,
+  ];
+  for (const testCase of cases) {
+    const open =
+      `    <testcase name="${escapeAttr(testCase.name)}" ` +
+      `classname="${escapeAttr(testCase.classname)}" time="${formatTime(testCase.time)}"`;
+    if (testCase.status === 'failed') {
+      lines.push(`${open}>`);
+      lines.push(
+        `      <failure message="${escapeAttr(testCase.failureMessage ?? 'failed')}">` +
+          `${escapeText(testCase.failureDetail ?? testCase.failureMessage ?? '')}</failure>`,
+      );
+      lines.push('    </testcase>');
+    } else if (testCase.status === 'skipped' || testCase.status === 'todo') {
+      lines.push(`${open}>`);
+      lines.push(`      <skipped/>`);
+      lines.push('    </testcase>');
+    } else {
+      lines.push(`${open}/>`);
+    }
+  }
+  lines.push('  </testsuite>');
+  return lines;
+}
+
+// QUnit's `skipped` maps to JUnit `<skipped/>`; `todo` (expected-fail work-in-progress) has no
+// JUnit equivalent, so it is reported as skipped rather than polluting the failure count.
+function normalizeStatus(status: string): JUnitCase['status'] {
+  if (status === 'failed') return 'failed';
+  if (status === 'skipped') return 'skipped';
+  if (status === 'todo') return 'todo';
+  return 'passed';
+}
+
+function resolveAssertionStack(config: Config, stack?: string): string | null {
+  if (!stack) return null;
+  const decoder = config._sourceMapDecoder;
+  if (decoder && config.projectRoot) {
+    return resolveStack(stack, decoder, config.projectRoot).resolvedStack.trim() || stack.trim();
+  }
+  return stack.trim();
+}
+
+function relativeToRoot(absolutePath: string, projectRoot: string): string {
+  const prefix = `${projectRoot}/`;
+  return absolutePath.startsWith(prefix) ? absolutePath.slice(prefix.length) : absolutePath;
+}
+
+/** JUnit `time` is seconds with millisecond precision. */
+function formatTime(seconds: number): string {
+  return seconds.toFixed(3);
+}
+
+function escapeAttr(value: string): string {
+  return escapeText(value).replace(/"/g, '&quot;');
+}
+
+function escapeText(value: string): string {
+  return (
+    value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      // Strip control chars XML 1.0 forbids (except tab/newline/carriage-return) so stacks
+      // with stray escape sequences don't produce an unparseable document.
+      // deno-lint-ignore no-control-regex
+      .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, '')
+  );
+}

--- a/lib/reporter/junit.ts
+++ b/lib/reporter/junit.ts
@@ -1,40 +1,58 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { resolveStack } from '../utils/source-map-decoder.ts';
+import { failedAssertions } from './failure.ts';
+import type { Reporter, RunEndInfo, TestDetails } from './types.ts';
 import type { Config, JUnitCase } from '../types.ts';
 
 /**
- * JUnit XML reporter. When `--reporter=junit` is active, `recordJUnitCase` is called from the
- * WebSocket `testEnd` handler (the same point TAP is streamed) for every test, and
- * `writeJUnitReport` serializes the accumulated cases into a `junit.xml` file at run end.
- * TAP continues to stream to stdout unchanged — the XML is an additional machine-readable
- * artifact for CI dashboards (GitHub Actions, GitLab, CircleCI, Jenkins, …).
+ * JUnit XML reporter — an *additive artifact* reporter, not a stdout format. Enabled with
+ * `--junit[=<path>]`, it accumulates a `<testcase>` per `testEnd` and writes the document at
+ * run end, while whichever `--reporter` is active keeps owning stdout. That split matters:
+ * CI wants a readable log *and* a machine-readable file, and it's what `--coverage=lcov`
+ * already does for coverage artifacts.
+ *
+ * Cases live on the instance (not on `config`), and the instance is shared across concurrent
+ * groups, so one document covers the whole run. `onRunStart` resets it for watch reruns.
  */
+export class JUnitReporter implements Reporter {
+  #cases: JUnitCase[] = [];
 
-// Shape of the QUnit `testEnd` payload the WS handler forwards. Non-failed tests carry the
-// trimmed `{ status, fullName, runtime }`; failed tests carry the full details incl. assertions.
-interface TestDetails {
-  status: string;
-  fullName: string[];
-  runtime: number;
-  assertions?: Array<{
-    passed: boolean;
-    todo: boolean;
-    message?: string;
-    stack?: string;
-  }>;
+  /** Drops cases from any previous run so watch reruns start clean. */
+  onRunStart(): void {
+    this.#cases = [];
+  }
+
+  /** Accumulates one `<testcase>`; the document is written once at run end. */
+  onTestEnd(config: Config, details: TestDetails): void {
+    this.#cases.push(toJUnitCase(config, details));
+  }
+
+  /** Serializes the accumulated cases and writes the XML document to disk. */
+  async onRunEnd(config: Config, _info: RunEndInfo): Promise<void> {
+    const outputPath = junitOutputPath(config);
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, buildJUnitXML(this.#cases));
+    process.stdout.write(
+      `# wrote JUnit report to ${relativeToRoot(outputPath, config.projectRoot)}\n`,
+    );
+  }
 }
 
 /**
- * Records one `testEnd` as a JUnit `<testcase>` on the run's shared collector. No-op unless a
- * collector is present (i.e. `--reporter=junit`). Failing assertions are flattened into a
- * `failureDetail` string with stacks resolved back to original sources via the bundle's source
- * map, matching the TAP `at:` behavior.
+ * Resolves where the JUnit document is written: `--junit=<path>` (relative to the project
+ * root) when given a string, else `<output>/junit.xml`.
  */
-export function recordJUnitCase(config: Config, details: TestDetails): void {
-  const collector = config._junitCollector;
-  if (!collector) return;
+export function junitOutputPath(config: Config): string {
+  return typeof config.junit === 'string'
+    ? path.resolve(config.projectRoot, config.junit)
+    : path.join(path.resolve(config.projectRoot, config.output), 'junit.xml');
+}
 
+/**
+ * Converts one `testEnd` into a JUnit `<testcase>`. Failing assertions are flattened into a
+ * `failureDetail` with stacks resolved back to original sources (same as the TAP `at:` field).
+ */
+export function toJUnitCase(config: Config, details: TestDetails): JUnitCase {
   const fullName = details.fullName;
   const name = fullName[fullName.length - 1] ?? fullName.join(' | ');
   const classname = fullName.slice(0, -1).join(' > ') || '(root)';
@@ -46,126 +64,95 @@ export function recordJUnitCase(config: Config, details: TestDetails): void {
     status,
   };
 
-  if (status === 'failed') {
-    const failed = (details.assertions ?? []).filter((a) => !a.passed && a.todo === false);
-    if (failed.length > 0) {
-      testCase.failureMessage = failed[0].message || 'Assertion failed';
-      testCase.failureDetail = failed
-        .map((assertion, index) => {
-          const message = assertion.message || `Assertion #${index + 1} failed`;
-          const stack = resolveAssertionStack(config, assertion.stack);
-          return stack ? `${message}\n${stack}` : message;
-        })
-        .join('\n\n');
-    } else {
-      // Failed status with no failing assertion recorded (e.g. an uncaught error mid-test).
-      testCase.failureMessage = 'Test failed';
-    }
+  if (status !== 'failed') return testCase;
+
+  const failures = failedAssertions(details, config._sourceMapDecoder, config.projectRoot);
+  if (failures.length === 0) {
+    // Failed status with no failing assertion recorded (e.g. an uncaught error mid-test).
+    testCase.failureMessage = 'Test failed';
+    return testCase;
   }
-
-  collector.push(testCase);
-}
-
-/**
- * Serializes the run's accumulated JUnit cases to `config.junitOutput` (default
- * `<output>/junit.xml`, resolved against `projectRoot`), grouping cases into one `<testsuite>`
- * per QUnit module. Prints the destination as a TAP `#` comment. No-op when no cases collected.
- */
-export async function writeJUnitReport(config: Config): Promise<void> {
-  const collector = config._junitCollector;
-  if (!collector) return;
-
-  const outputPath = config.junitOutput
-    ? path.resolve(config.projectRoot, config.junitOutput)
-    : path.join(path.resolve(config.projectRoot, config.output), 'junit.xml');
-
-  await fs.mkdir(path.dirname(outputPath), { recursive: true });
-  await fs.writeFile(outputPath, buildJUnitXML(collector));
-  process.stdout.write(
-    `# wrote JUnit report to ${relativeToRoot(outputPath, config.projectRoot)}\n`,
-  );
+  testCase.failureMessage = failures[0].message || 'Assertion failed';
+  testCase.failureDetail = failures
+    .map((failure) => {
+      const message = failure.message || `Assertion #${failure.index} failed`;
+      return failure.stack ? `${message}\n${failure.stack}` : message;
+    })
+    .join('\n\n');
+  return testCase;
 }
 
 /** Builds the full JUnit XML document string from a flat list of test cases. */
 export function buildJUnitXML(cases: JUnitCase[]): string {
-  const suites = new Map<string, JUnitCase[]>();
-  for (const testCase of cases) {
-    const bucket = suites.get(testCase.classname);
-    if (bucket) bucket.push(testCase);
-    else suites.set(testCase.classname, [testCase]);
-  }
+  // Map.groupBy keys by first appearance, so suites stay in the order their tests ran.
+  const suites = Map.groupBy(cases, (testCase) => testCase.classname);
 
-  const totalTime = cases.reduce((sum, testCase) => sum + testCase.time, 0);
-  const totalFailures = cases.filter((testCase) => testCase.status === 'failed').length;
-  const totalSkipped = cases.filter(
-    (testCase) => testCase.status === 'skipped' || testCase.status === 'todo',
-  ).length;
-
-  const lines: string[] = ['<?xml version="1.0" encoding="UTF-8"?>'];
-  lines.push(
-    `<testsuites name="qunitx" tests="${cases.length}" failures="${totalFailures}" ` +
-      `skipped="${totalSkipped}" time="${formatTime(totalTime)}">`,
+  return (
+    [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      `<testsuites name="qunitx" tests="${cases.length}" failures="${countFailed(cases)}" ` +
+        `skipped="${countSkipped(cases)}" time="${formatTime(totalTime(cases))}">`,
+      ...[...suites].flatMap(([suiteName, suiteCases]) => buildSuite(suiteName, suiteCases)),
+      '</testsuites>',
+    ].join('\n') + '\n'
   );
-  for (const [suiteName, suiteCases] of suites) {
-    lines.push(...buildSuite(suiteName, suiteCases));
-  }
-  lines.push('</testsuites>');
-  return lines.join('\n') + '\n';
 }
-
-export { writeJUnitReport as default };
 
 /** Builds the `<testsuite>` block (with nested `<testcase>` elements) for one QUnit module. */
 function buildSuite(suiteName: string, cases: JUnitCase[]): string[] {
-  const suiteTime = cases.reduce((sum, testCase) => sum + testCase.time, 0);
-  const failures = cases.filter((testCase) => testCase.status === 'failed').length;
-  const skipped = cases.filter(
-    (testCase) => testCase.status === 'skipped' || testCase.status === 'todo',
-  ).length;
-
-  const lines = [
+  return [
     `  <testsuite name="${escapeAttr(suiteName)}" tests="${cases.length}" ` +
-      `failures="${failures}" skipped="${skipped}" time="${formatTime(suiteTime)}">`,
+      `failures="${countFailed(cases)}" skipped="${countSkipped(cases)}" ` +
+      `time="${formatTime(totalTime(cases))}">`,
+    ...cases.flatMap(buildCase),
+    '  </testsuite>',
   ];
-  for (const testCase of cases) {
-    const open =
-      `    <testcase name="${escapeAttr(testCase.name)}" ` +
-      `classname="${escapeAttr(testCase.classname)}" time="${formatTime(testCase.time)}"`;
-    if (testCase.status === 'failed') {
-      lines.push(`${open}>`);
-      lines.push(
-        `      <failure message="${escapeAttr(testCase.failureMessage ?? 'failed')}">` +
-          `${escapeText(testCase.failureDetail ?? testCase.failureMessage ?? '')}</failure>`,
-      );
-      lines.push('    </testcase>');
-    } else if (testCase.status === 'skipped' || testCase.status === 'todo') {
-      lines.push(`${open}>`);
-      lines.push(`      <skipped/>`);
-      lines.push('    </testcase>');
-    } else {
-      lines.push(`${open}/>`);
-    }
+}
+
+/** One `<testcase>`: self-closing when it passed, wrapping `<failure>`/`<skipped/>` otherwise. */
+function buildCase(testCase: JUnitCase): string[] {
+  const open =
+    `    <testcase name="${escapeAttr(testCase.name)}" ` +
+    `classname="${escapeAttr(testCase.classname)}" time="${formatTime(testCase.time)}"`;
+
+  if (testCase.status === 'failed') {
+    return [
+      `${open}>`,
+      `      <failure message="${escapeAttr(testCase.failureMessage ?? 'failed')}">` +
+        `${escapeText(testCase.failureDetail ?? testCase.failureMessage ?? '')}</failure>`,
+      '    </testcase>',
+    ];
+  } else if (testCase.status === 'skipped' || testCase.status === 'todo') {
+    return [`${open}>`, `      <skipped/>`, '    </testcase>'];
   }
-  lines.push('  </testsuite>');
-  return lines;
+  return [`${open}/>`];
+}
+
+function totalTime(cases: JUnitCase[]): number {
+  return cases.reduce((sum, testCase) => sum + testCase.time, 0);
+}
+
+function countFailed(cases: JUnitCase[]): number {
+  return cases.filter((testCase) => testCase.status === 'failed').length;
+}
+
+// `todo` has no JUnit equivalent and reports as skipped (see normalizeStatus), so both statuses
+// count here. Shared by the <testsuites> and <testsuite> levels so the two can never disagree.
+function countSkipped(cases: JUnitCase[]): number {
+  return cases.filter((testCase) => testCase.status === 'skipped' || testCase.status === 'todo')
+    .length;
 }
 
 // QUnit's `skipped` maps to JUnit `<skipped/>`; `todo` (expected-fail work-in-progress) has no
 // JUnit equivalent, so it is reported as skipped rather than polluting the failure count.
-function normalizeStatus(status: string): JUnitCase['status'] {
-  if (status === 'failed') return 'failed';
-  if (status === 'skipped') return 'skipped';
-  if (status === 'todo') return 'todo';
-  return 'passed';
-}
+const JUNIT_STATUSES: Record<string, JUnitCase['status']> = {
+  failed: 'failed',
+  skipped: 'skipped',
+  todo: 'todo',
+};
 
-function resolveAssertionStack(config: Config, stack?: string): string | null {
-  if (!stack) return null;
-  const decoder = config._sourceMapDecoder;
-  if (decoder && config.projectRoot) {
-    return resolveStack(stack, decoder, config.projectRoot).resolvedStack.trim() || stack.trim();
-  }
-  return stack.trim();
+function normalizeStatus(status: string): JUnitCase['status'] {
+  return JUNIT_STATUSES[status] ?? 'passed';
 }
 
 function relativeToRoot(absolutePath: string, projectRoot: string): string {

--- a/lib/reporter/spec.ts
+++ b/lib/reporter/spec.ts
@@ -1,0 +1,121 @@
+import { green, red, yellow, blue } from '../utils/color.ts';
+import { failedAssertions, type FailureInfo } from './failure.ts';
+import { indentString } from '../utils/indent-string.ts';
+import type { Reporter, RunStartInfo, RunEndInfo, TestDetails } from './types.ts';
+import type { Config } from '../types.ts';
+
+/**
+ * Human-readable reporter: tests nested under their QUnit module, with failures shown inline
+ * where they happen. The shape Node, Vitest and Mocha all default to — raw TAP is a poor
+ * local-dev experience.
+ *
+ * Module headers are printed on change rather than buffered to the end, so output streams.
+ * Under concurrent groups the testEnd events interleave, so a module header can legitimately
+ * reappear — that reflects what actually ran, and beats withholding output until the run ends.
+ */
+export class SpecReporter implements Reporter {
+  #lastModule: string | null = null;
+  #failures: string[] = [];
+
+  /** Resets per-run state and prints the run banner. */
+  onRunStart(_config: Config, info: RunStartInfo): void {
+    this.#lastModule = null;
+    this.#failures = [];
+    if (info.fileCount === null) return;
+    if (info.fileCount === 0) {
+      process.stdout.write('\nNo test files found.\n');
+      return;
+    }
+    const files = `${info.fileCount} test file${info.fileCount === 1 ? '' : 's'}`;
+    process.stdout.write(`\nRunning ${files} across ${info.groupCount} worker(s)\n`);
+  }
+
+  /** Prints the module header when it changes, then this test's result line. */
+  onTestEnd(config: Config, details: TestDetails): void {
+    const moduleName = details.fullName.slice(0, -1).join(' > ') || '(root)';
+    // Header only when the module changes; under concurrent groups it can legitimately repeat.
+    const header = moduleName === this.#lastModule ? '' : `\n${blue(moduleName)}\n`;
+    this.#lastModule = moduleName;
+    const line = `  ${statusMark(details.status)} ${details.fullName.at(-1) ?? ''}${duration(details)}\n`;
+
+    if (details.status !== 'failed') {
+      process.stdout.write(header + line);
+      return;
+    }
+
+    // Header, result and failure block in one write — this runs per test, and a split write
+    // lets a concurrent group's line land between a test and its own failure detail.
+    const block = formatFailureBlock(
+      failedAssertions(details, config._sourceMapDecoder, config.projectRoot),
+    );
+    process.stdout.write(header + line + (block ? indentString(block, 4) : ''));
+    // Remember the headline for the end-of-run recap so a failure buried thousands of lines
+    // up is still actionable.
+    this.#failures.push(details.fullName.join(' | '));
+  }
+
+  /** Prints the outcome counts and, when any test failed, the failure recap. */
+  onRunEnd(config: Config, info: RunEndInfo): void {
+    const { passCount, failCount, skipCount, todoCount } = config.COUNTER;
+    // Zero counts stay off the summary — "0 failing" is noise on a green run.
+    const counts = [
+      `\n  ${green(`${passCount} passing`)} (${info.durationMs}ms)`,
+      ...(failCount > 0 ? [`  ${red(`${failCount} failing`)}`] : []),
+      ...(skipCount > 0 ? [`  ${yellow(`${skipCount} skipped`)}`] : []),
+      ...(todoCount > 0 ? [`  ${yellow(`${todoCount} todo`)}`] : []),
+    ].join('\n');
+
+    const recap = this.#failures.length
+      ? `\n${red('Failures:')}\n${this.#failures.map((name, index) => `  ${index + 1}) ${name}`).join('\n')}\n`
+      : '';
+
+    process.stdout.write(`${counts}\n${recap}\n`);
+  }
+}
+
+/** Renders every failing assertion of one test: message, values, and source location. */
+export function formatFailureBlock(failures: FailureInfo[]): string {
+  if (failures.length === 0) return '';
+  return (
+    failures
+      .map((failure) =>
+        [
+          red(failure.message ?? `Assertion #${failure.index} failed`),
+          // Values only when they carry signal — a bare `ok()` has neither.
+          ...(failure.expected !== undefined || failure.actual !== undefined
+            ? [`expected: ${format(failure.expected)}`, `actual:   ${format(failure.actual)}`]
+            : []),
+          ...(failure.source ? [`source:   ${failure.source}`] : []),
+          ...(failure.at ? [`at ${failure.at}`] : []),
+        ].join('\n'),
+      )
+      .join('\n\n') + '\n'
+  );
+}
+
+// Built once: `color.ts` freezes its enabled/disabled decision at module load.
+const MARKS: Record<string, string> = {
+  passed: green('✔'),
+  failed: red('✖'),
+  todo: yellow('◌'),
+};
+
+function statusMark(status: string): string {
+  return MARKS[status] ?? yellow('-'); // anything else (skipped) is a dash
+}
+
+// Skipped/todo tests never ran, so a "(0ms)" suffix on them is noise.
+function duration(details: TestDetails): string {
+  if (details.status === 'skipped' || details.status === 'todo') return '';
+  return ` (${details.runtime.toFixed(0)}ms)`;
+}
+
+function format(value: unknown): string {
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (value === undefined) return 'undefined';
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/lib/reporter/tap.ts
+++ b/lib/reporter/tap.ts
@@ -30,11 +30,15 @@ export class TapReporter implements Reporter {
 
   /** Emits the `ok` / `not ok` line, with a YAML block for each failing assertion. */
   onTestEnd(config: Config, details: TestDetails): void {
-    TAPDisplayTestResult(
-      config.COUNTER.testCount,
-      details,
-      failedAssertions(details, config._sourceMapDecoder, config.projectRoot),
-    );
+    // Only failed tests carry assertions — the injected runtime sends the trimmed
+    // `{ status, fullName, runtime }` for every other status — so resolving failures for a
+    // passing test is a call and an allocation that can never produce output. Guarding here
+    // matches what every other reporter already does.
+    const failures =
+      details.status === 'failed'
+        ? failedAssertions(details, config._sourceMapDecoder, config.projectRoot)
+        : [];
+    TAPDisplayTestResult(config.COUNTER.testCount, details, failures);
   }
 
   /** Emits the TAP plan line and the run summary. */

--- a/lib/reporter/tap.ts
+++ b/lib/reporter/tap.ts
@@ -1,0 +1,44 @@
+import { TAPDisplayTestResult } from '../tap/display-test-result.ts';
+import { TAPDisplayFinalResult } from '../tap/display-final-result.ts';
+import { failedAssertions } from './failure.ts';
+import type { Reporter, RunStartInfo, RunEndInfo, TestDetails } from './types.ts';
+import type { Config } from '../types.ts';
+
+/**
+ * The default reporter: streams TAP version 13 to stdout. Stateless — every number it
+ * prints comes from `config.COUNTER`, which the dispatcher updates before `onTestEnd`.
+ */
+export class TapReporter implements Reporter {
+  /** Emits the TAP version header, plus the run banner as a `#` comment. */
+  onRunStart(config: Config, info: RunStartInfo): void {
+    process.stdout.write('TAP version 13\n');
+    // Watch mode emits the header per browser connection and has no file/group counts to
+    // report at that point.
+    if (info.fileCount === null) return;
+
+    const daemon = config._daemonMode ? ' (daemon)' : '';
+    if (info.fileCount === 0) {
+      // No test files matched (e.g. --changed filtered everything out): emit a complete,
+      // valid TAP document — header plus an empty plan — so parsers see a clean zero run.
+      process.stdout.write(`# Running 0 test files${daemon}\n1..0\n`);
+      return;
+    }
+    const files = `${info.fileCount} test file${info.fileCount === 1 ? '' : 's'}`;
+    const groups = `${info.groupCount} group${info.groupCount === 1 ? '' : 's'}`;
+    process.stdout.write(`# Running ${files} across ${groups}${daemon}\n`);
+  }
+
+  /** Emits the `ok` / `not ok` line, with a YAML block for each failing assertion. */
+  onTestEnd(config: Config, details: TestDetails): void {
+    TAPDisplayTestResult(
+      config.COUNTER.testCount,
+      details,
+      failedAssertions(details, config._sourceMapDecoder, config.projectRoot),
+    );
+  }
+
+  /** Emits the TAP plan line and the run summary. */
+  onRunEnd(config: Config, info: RunEndInfo): void {
+    TAPDisplayFinalResult(config.COUNTER, info.durationMs);
+  }
+}

--- a/lib/reporter/types.ts
+++ b/lib/reporter/types.ts
@@ -6,7 +6,7 @@ import type { Config, Counter } from '../types.ts';
  * This module is a leaf (type-only imports), so `parse-cli-flags` can validate against it
  * without pulling the reporter implementations into the CLI's startup path.
  */
-export const REPORTERS = ['tap'] as const;
+export const REPORTERS = ['tap', 'spec'] as const;
 
 /** A valid `--reporter` value. */
 export type ReporterName = (typeof REPORTERS)[number];

--- a/lib/reporter/types.ts
+++ b/lib/reporter/types.ts
@@ -6,7 +6,7 @@ import type { Config, Counter } from '../types.ts';
  * This module is a leaf (type-only imports), so `parse-cli-flags` can validate against it
  * without pulling the reporter implementations into the CLI's startup path.
  */
-export const REPORTERS = ['tap', 'spec', 'dot'] as const;
+export const REPORTERS = ['tap', 'spec', 'dot', 'github'] as const;
 
 /** A valid `--reporter` value. */
 export type ReporterName = (typeof REPORTERS)[number];

--- a/lib/reporter/types.ts
+++ b/lib/reporter/types.ts
@@ -6,7 +6,7 @@ import type { Config, Counter } from '../types.ts';
  * This module is a leaf (type-only imports), so `parse-cli-flags` can validate against it
  * without pulling the reporter implementations into the CLI's startup path.
  */
-export const REPORTERS = ['tap', 'spec'] as const;
+export const REPORTERS = ['tap', 'spec', 'dot'] as const;
 
 /** A valid `--reporter` value. */
 export type ReporterName = (typeof REPORTERS)[number];

--- a/lib/reporter/types.ts
+++ b/lib/reporter/types.ts
@@ -1,0 +1,96 @@
+import type { Config, Counter } from '../types.ts';
+
+/**
+ * The internal reporter contract. Reporters render a run to stdout (or to a file, for
+ * additive artifact reporters like JUnit). This is deliberately **not** public API — it is
+ * not exported from the package entry point and carries no stability promise. Custom
+ * reporters are expected to arrive later via the JS API's event stream, not by freezing
+ * QUnit's `testEnd` payload as third-party surface.
+ *
+ * Lifecycle: `onRunStart` → `onTestEnd` (× N) → `onRunEnd`. In watch mode the whole cycle
+ * repeats per rerun, so stateful reporters must reset in `onRunStart`.
+ *
+ * Concurrency: one reporter instance is shared across all concurrent groups (the group
+ * configs are spread off the parent config, so `_reporters` is the same array). `onTestEnd`
+ * therefore arrives interleaved across groups.
+ */
+export interface Reporter {
+  /** Called once before any test output. In watch mode, once per rerun. */
+  onRunStart?(config: Config, info: RunStartInfo): void;
+  /** Called once per test, after `COUNTER` has already been updated for this test. */
+  onTestEnd?(config: Config, details: TestDetails): void;
+  /** Called once when the run finishes, with the final counts on `config.COUNTER`. */
+  onRunEnd?(config: Config, info: RunEndInfo): void | Promise<void>;
+}
+
+/** One QUnit assertion inside a `testEnd` payload. */
+export interface TestAssertion {
+  /** `true` when the assertion held. */
+  passed: boolean;
+  /** `true` for assertions inside a `todo` test, which are expected to fail. */
+  todo: boolean;
+  /** Raw stack captured at the assertion, with frames pointing at the bundle. */
+  stack?: string;
+  /** The value the assertion actually saw. */
+  actual?: unknown;
+  /** The value the assertion required. */
+  expected?: unknown;
+  /** The assertion's message, when one was given. */
+  message?: string;
+}
+
+/**
+ * The QUnit `testEnd` payload as it arrives over the WebSocket. Passing tests carry the
+ * trimmed `{ status, fullName, runtime }`; failing tests additionally carry `assertions`.
+ */
+export interface TestDetails {
+  /** QUnit's outcome: `passed` | `failed` | `skipped` | `todo`. */
+  status: string;
+  /** Module path followed by the test name, e.g. `['Math', 'adds']`. */
+  fullName: string[];
+  /** Test duration in milliseconds. */
+  runtime: number;
+  /** Present on failing tests only (QUnit trims the payload otherwise). */
+  assertions?: TestAssertion[];
+}
+
+/**
+ * Run-scope counts. `fileCount === null` means "counts unknown at this point" (watch mode,
+ * where the header is emitted per browser connection rather than per file batch).
+ */
+export interface RunStartInfo {
+  /** Test files in this run, or `null` when not known at announce time. */
+  fileCount: number | null;
+  /** Concurrent groups the files were split across, or `null` alongside a null `fileCount`. */
+  groupCount: number | null;
+}
+
+/** Final run info; the counts themselves live on `config.COUNTER`. */
+export interface RunEndInfo {
+  /** Wall-clock duration of the run in milliseconds. */
+  durationMs: number;
+}
+
+/**
+ * Applies one `testEnd` to the run's counters. Kept separate from any reporter so the
+ * numbers are identical no matter which reporter (or how many) is active — the exit code
+ * and the TAP plan both read `COUNTER`, so it must be updated exactly once per test.
+ */
+export function updateCounter(COUNTER: Counter, details: TestDetails): void {
+  COUNTER.testCount++;
+
+  if (details.status === 'skipped') {
+    COUNTER.skipCount++;
+  } else if (details.status === 'todo') {
+    COUNTER.todoCount = (COUNTER.todoCount ?? 0) + 1;
+  } else if (details.status === 'failed') {
+    COUNTER.failCount++;
+    (details.assertions ?? []).forEach((assertion) => {
+      if (!assertion.passed && assertion.todo === false) {
+        COUNTER.errorCount = (COUNTER.errorCount ?? 0) + 1;
+      }
+    });
+  } else if (details.status === 'passed') {
+    COUNTER.passCount++;
+  }
+}

--- a/lib/reporter/types.ts
+++ b/lib/reporter/types.ts
@@ -1,6 +1,17 @@
 import type { Config, Counter } from '../types.ts';
 
 /**
+ * Every stdout reporter `--reporter` accepts, in help/error-message order. Exactly one is
+ * active per run — artifact outputs (`--junit`, `--coverage`) are separate additive flags.
+ * This module is a leaf (type-only imports), so `parse-cli-flags` can validate against it
+ * without pulling the reporter implementations into the CLI's startup path.
+ */
+export const REPORTERS = ['tap'] as const;
+
+/** A valid `--reporter` value. */
+export type ReporterName = (typeof REPORTERS)[number];
+
+/**
  * The internal reporter contract. Reporters render a run to stdout (or to a file, for
  * additive artifact reporters like JUnit). This is deliberately **not** public API — it is
  * not exported from the package entry point and carries no stability promise. Custom

--- a/lib/setup/config.ts
+++ b/lib/setup/config.ts
@@ -8,6 +8,7 @@ import { setupTestFilePaths } from './test-file-paths.ts';
 import { getChangedFsTree } from './get-changed-fs-tree.ts';
 import { parseCliFlags } from '../utils/parse-cli-flags.ts';
 import { resolveOnlyFailedFiles, type FailedTestRecord } from '../utils/failure-cache.ts';
+import { createReporters } from '../reporter/index.ts';
 import type { Config, FSTree } from '../types.ts';
 import type { Plugin as EsbuildPlugin } from 'esbuild';
 
@@ -73,6 +74,10 @@ export async function setupConfig(): Promise<Config> {
   if (config.onlyFailed && !config.watch) {
     config.fsTree = await applyOnlyFailedFilter(config as Config);
   }
+
+  // Built last: reporter selection reads the fully-merged flags. One instance per run, shared
+  // by every concurrent group via the group-config spread in run.ts.
+  (config as Config)._reporters = createReporters(config as Config);
 
   return config as Config;
 }

--- a/lib/setup/default-project-config-values.ts
+++ b/lib/setup/default-project-config-values.ts
@@ -6,4 +6,5 @@ export const defaultProjectConfigValues = {
   port: 1234,
   extensions: ['js', 'ts', 'jsx', 'tsx'],
   browser: 'chromium',
+  reporter: 'tap',
 };

--- a/lib/setup/web-server.ts
+++ b/lib/setup/web-server.ts
@@ -5,7 +5,6 @@ import { findInternalAssetsFromHTML } from '../utils/find-internal-assets-from-h
 import { injectScript } from '../utils/html.ts';
 import { reportRunStart, reportTestEnd } from '../reporter/index.ts';
 import { recordFailedTest } from '../utils/failure-cache.ts';
-import { recordJUnitCase } from '../reporter/junit.ts';
 import { blue } from '../utils/color.ts';
 import { HTTPServer, MIME_TYPES } from '../servers/web.ts';
 import { createReconnectingSocket } from './ws-client.js';
@@ -172,7 +171,6 @@ export function setupWebServer(config: Config, cachedContent: CachedContent): HT
         }
         config._resetTestTimeout?.();
         reportTestEnd(config, details);
-        recordJUnitCase(config, details);
       } else if (event === 'done') {
         // Signal test completion. TCP ordering guarantees all testEnd messages
         // preceding this on the same connection are already processed by Node.js.
@@ -755,7 +753,6 @@ export function setupGroupWSHandler(server: HTTPServer, groupConfigs: Config[]):
         }
         config._resetTestTimeout?.();
         reportTestEnd(config, details);
-        recordJUnitCase(config, details);
       } else if (event === 'done') {
         config._phase = 'done';
         config._lastQUnitResult = qunitResult ?? null;

--- a/lib/setup/web-server.ts
+++ b/lib/setup/web-server.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 import { findInternalAssetsFromHTML } from '../utils/find-internal-assets-from-html.ts';
 import { injectScript } from '../utils/html.ts';
-import { TAPDisplayTestResult } from '../tap/display-test-result.ts';
+import { reportRunStart, reportTestEnd } from '../reporter/index.ts';
 import { recordFailedTest } from '../utils/failure-cache.ts';
 import { recordJUnitCase } from '../reporter/junit.ts';
 import { blue } from '../utils/color.ts';
@@ -131,9 +131,11 @@ export function setupWebServer(config: Config, cachedContent: CachedContent): HT
         // testEnd arriving just after `connection` for a watch rerun got
         // counted spuriously because the dedup map had been wiped. The map
         // is now reset only at the same lifecycle boundary as COUNTER.
-        // In daemon mode the daemon emits one TAP version 13 header per run before the
-        // run starts; suppressing here keeps the stream parser-clean across runs.
-        if (!config._groupMode && !config._daemonMode) process.stdout.write('TAP version 13\n');
+        // Group and daemon runs emit run-start once up front in run.ts; only the watch/single
+        // path announces per browser connection (each rerun opens a fresh one).
+        if (!config._groupMode && !config._daemonMode) {
+          reportRunStart(config, { fileCount: null, groupCount: null });
+        }
         if (config.debug && config._groupMode) debugGroupHeader(config);
         config._resetTestTimeout?.();
       } else if (event === 'testEnd' && !abort) {
@@ -169,7 +171,7 @@ export function setupWebServer(config: Config, cachedContent: CachedContent): HT
           );
         }
         config._resetTestTimeout?.();
-        TAPDisplayTestResult(config.COUNTER, details, config._sourceMapDecoder, config.projectRoot);
+        reportTestEnd(config, details);
         recordJUnitCase(config, details);
       } else if (event === 'done') {
         // Signal test completion. TCP ordering guarantees all testEnd messages
@@ -752,7 +754,7 @@ export function setupGroupWSHandler(server: HTTPServer, groupConfigs: Config[]):
           );
         }
         config._resetTestTimeout?.();
-        TAPDisplayTestResult(config.COUNTER, details, config._sourceMapDecoder, config.projectRoot);
+        reportTestEnd(config, details);
         recordJUnitCase(config, details);
       } else if (event === 'done') {
         config._phase = 'done';

--- a/lib/setup/web-server.ts
+++ b/lib/setup/web-server.ts
@@ -5,6 +5,7 @@ import { findInternalAssetsFromHTML } from '../utils/find-internal-assets-from-h
 import { injectScript } from '../utils/html.ts';
 import { TAPDisplayTestResult } from '../tap/display-test-result.ts';
 import { recordFailedTest } from '../utils/failure-cache.ts';
+import { recordJUnitCase } from '../reporter/junit.ts';
 import { blue } from '../utils/color.ts';
 import { HTTPServer, MIME_TYPES } from '../servers/web.ts';
 import { createReconnectingSocket } from './ws-client.js';
@@ -169,6 +170,7 @@ export function setupWebServer(config: Config, cachedContent: CachedContent): HT
         }
         config._resetTestTimeout?.();
         TAPDisplayTestResult(config.COUNTER, details, config._sourceMapDecoder, config.projectRoot);
+        recordJUnitCase(config, details);
       } else if (event === 'done') {
         // Signal test completion. TCP ordering guarantees all testEnd messages
         // preceding this on the same connection are already processed by Node.js.
@@ -751,6 +753,7 @@ export function setupGroupWSHandler(server: HTTPServer, groupConfigs: Config[]):
         }
         config._resetTestTimeout?.();
         TAPDisplayTestResult(config.COUNTER, details, config._sourceMapDecoder, config.projectRoot);
+        recordJUnitCase(config, details);
       } else if (event === 'done') {
         config._phase = 'done';
         config._lastQUnitResult = qunitResult ?? null;

--- a/lib/tap/display-test-result.ts
+++ b/lib/tap/display-test-result.ts
@@ -1,114 +1,51 @@
 import { dumpYaml } from './dump-yaml.ts';
 import { indentString } from '../utils/indent-string.ts';
-import { resolveStack, type SourceMapDecoder } from '../utils/source-map-decoder.ts';
-import type { Counter } from '../types.ts';
-
-interface TestAssertion {
-  passed: boolean;
-  todo: boolean;
-  stack?: string;
-  actual?: unknown;
-  expected?: unknown;
-  message?: string;
-}
-interface TestDetails {
-  status: string;
-  fullName: string[];
-  runtime: number;
-  assertions: TestAssertion[];
-}
+import type { TestDetails } from '../reporter/types.ts';
+import type { FailureInfo } from '../reporter/failure.ts';
 
 // tape TAP output: ['operator', 'stack', 'at', 'expected', 'actual']
 // ava TAP output: ['message', 'name', 'at', 'assertion', 'values'] // Assertion #5, message
 /**
- * Formats and prints a single QUnit testEnd event as a TAP `ok`/`not ok` line with optional YAML failure block.
+ * Formats and prints a single QUnit testEnd event as a TAP `ok`/`not ok` line with an
+ * optional YAML failure block. A pure formatter: `testNumber` is the TAP sequence number
+ * (the caller owns counting) and `failures` are pre-resolved by `failedAssertions`.
  * @returns {void}
  */
 export function TAPDisplayTestResult(
-  COUNTER: Counter,
+  testNumber: number,
   details: TestDetails,
-  decoder?: SourceMapDecoder | null,
-  projectRoot?: string,
+  failures: FailureInfo[] = [],
 ): void {
   // NOTE: https://github.com/qunitjs/qunit/blob/master/src/html-reporter/diff.js
-  COUNTER.testCount++;
+  const name = details.fullName.join(' | ');
 
   if (details.status === 'skipped') {
-    COUNTER.skipCount++;
-    process.stdout.write(`ok ${COUNTER.testCount} ${details.fullName.join(' | ')} # skip\n`);
+    process.stdout.write(`ok ${testNumber} ${name} # skip\n`);
   } else if (details.status === 'todo') {
-    COUNTER.todoCount = (COUNTER.todoCount ?? 0) + 1;
-    process.stdout.write(`not ok ${COUNTER.testCount} ${details.fullName.join(' | ')} # TODO\n`);
+    process.stdout.write(`not ok ${testNumber} ${name} # TODO\n`);
   } else if (details.status === 'failed') {
-    COUNTER.failCount++;
-    process.stdout.write(
-      `not ok ${COUNTER.testCount} ${details.fullName.join(' | ')} # (${details.runtime.toFixed(0)} ms)\n`,
-    );
-    details.assertions.forEach((assertion, index) => {
-      if (!assertion.passed && assertion.todo === false) {
-        COUNTER.errorCount = (COUNTER.errorCount ?? 0) + 1;
-
-        process.stdout.write('  ---\n');
-        let stackStr: string | null = assertion.stack?.trim() || null;
-        let atStr: string | null = extractStackAt(assertion.stack);
-        let sourceText: string | null = null;
-        if (decoder && projectRoot && assertion.stack) {
-          const { resolvedStack, firstUserFrame, firstUserSourceText } = resolveStack(
-            assertion.stack,
-            decoder,
-            projectRoot,
-          );
-          stackStr = resolvedStack.trim() || null;
-          // When decoder is available, prefer firstUserFrame (original source path) for at:.
-          // If all frames are node_modules or unresolvable, null is cleaner than a bundle URL.
-          atStr = firstUserFrame;
-          sourceText = firstUserSourceText;
-        }
-        process.stdout.write(
-          indentString(
-            dumpYaml({
-              name: `Assertion #${index + 1}`,
-              actual:
-                assertion.actual !== null && typeof assertion.actual === 'object'
-                  ? JSON.parse(JSON.stringify(assertion.actual, getCircularReplacer()))
-                  : assertion.actual,
-              expected:
-                assertion.expected !== null && typeof assertion.expected === 'object'
-                  ? JSON.parse(JSON.stringify(assertion.expected, getCircularReplacer()))
-                  : assertion.expected,
-              message: assertion.message || null,
-              stack: stackStr,
-              source: sourceText,
-              at: atStr,
-            }),
-            4,
-          ),
-        );
-        process.stdout.write('  ...\n');
-      }
+    process.stdout.write(`not ok ${testNumber} ${name} # (${details.runtime.toFixed(0)} ms)\n`);
+    failures.forEach((failure) => {
+      process.stdout.write('  ---\n');
+      process.stdout.write(
+        indentString(
+          dumpYaml({
+            name: `Assertion #${failure.index}`,
+            actual: failure.actual,
+            expected: failure.expected,
+            message: failure.message,
+            stack: failure.stack,
+            source: failure.source,
+            at: failure.at,
+          }),
+          4,
+        ),
+      );
+      process.stdout.write('  ...\n');
     });
   } else if (details.status === 'passed') {
-    COUNTER.passCount++;
-    process.stdout.write(
-      `ok ${COUNTER.testCount} ${details.fullName.join(' | ')} # (${details.runtime.toFixed(0)} ms)\n`,
-    );
+    process.stdout.write(`ok ${testNumber} ${name} # (${details.runtime.toFixed(0)} ms)\n`);
   }
-}
-
-/**
- * Extracts the source location from a stack trace string.
- * Supports Chrome/Node style "at func (url:line:col)" and Firefox/WebKit style "@url:line:col".
- * Returns a clean location string without surrounding parens, or null if nothing can be extracted.
- */
-export function extractStackAt(stack: string | null | undefined): string | null {
-  if (!stack) return null;
-  // Chrome/Node: "at func (url:line:col)" — capture inside parens
-  const chromeMatch = stack.match(/\(([^)\n]+:[0-9]+:[0-9]+)\)/);
-  if (chromeMatch) return chromeMatch[1].replace('file://', '');
-  // Firefox/WebKit: "funcname@url:line:col" or just "@url:line:col"
-  const geckoMatch = stack.match(/@([^\s\n@]+:[0-9]+:[0-9]+)/);
-  if (geckoMatch) return geckoMatch[1];
-  return null;
 }
 
 // not ok 10 test exited without ending: deepEqual true works
@@ -118,30 +55,6 @@ export function extractStackAt(stack: string | null | undefined): string | null 
 //     stack: |-
 //       Error: test exited without ending: deepEqual true works
 //           at Test.assert [as _assert] (/home/izelnakri/ava-test/node_modules/tape/lib/test.js:269:54)
-//           at Test.bound [as _assert] (/home/izelnakri/ava-test/node_modules/tape/lib/test.js:90:32)
-//           at Test.fail (/home/izelnakri/ava-test/node_modules/tape/lib/test.js:363:10)
-//           at Test.bound [as fail] (/home/izelnakri/ava-test/node_modules/tape/lib/test.js:90:32)
-//           at Test._exit (/home/izelnakri/ava-test/node_modules/tape/lib/test.js:226:14)
-//           at Test.bound [as _exit] (/home/izelnakri/ava-test/node_modules/tape/lib/test.js:90:32)
-//           at process.<anonymous> (/home/izelnakri/ava-test/node_modules/tape/index.js:85:19)
-//           at process.emit (node:events:376:20)
 //   ...
 
 export { TAPDisplayTestResult as default };
-
-function getCircularReplacer(): (_key: string, value: unknown) => unknown {
-  const ancestors: object[] = [];
-  return function (this: object, _key: string, value: unknown) {
-    if (typeof value !== 'object' || value === null) {
-      return value;
-    }
-    while (ancestors.length > 0 && ancestors.at(-1) !== this) {
-      ancestors.pop();
-    }
-    if (ancestors.includes(value)) {
-      return '[Circular]';
-    }
-    ancestors.push(value);
-    return value;
-  };
-}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -100,6 +100,22 @@ export interface JUnitCase {
 }
 
 /**
+ * Per-source-file line coverage, accumulated across every executed bundle.
+ * Keyed by absolute source path. Lines are 1-based, matching editor/lcov conventions.
+ */
+export interface FileCoverage {
+  /** 1-based line numbers that the source map attributes to executable bundle positions. */
+  coverable: Set<number>;
+  /** 1-based line number → highest V8 hit count observed for that line. */
+  covered: Map<number, number>;
+  /** Verbatim original source text (from the map's `sourcesContent`), for the HTML report. */
+  sourceContent: string | null;
+}
+
+/** Absolute source path → its accumulated {@link FileCoverage}. */
+export type CoverageFileMap = Map<string, FileCoverage>;
+
+/**
  * Full resolved qunitx configuration for a single run, merging `package.json` settings,
  * CLI flags, and runtime state. Most fields are read-only after `setupConfig()` resolves;
  * underscore-prefixed fields are mutable runtime slots populated during the run lifecycle.
@@ -150,6 +166,16 @@ export interface Config {
    * Defaults to `<output>/junit.xml` (resolved against `projectRoot`).
    */
   junitOutput?: string;
+  /**
+   * When `true`, collect V8 line coverage of the test bundle and emit a terminal summary
+   * at run end. Chromium-only; ignored (with a warning) for firefox/webkit.
+   */
+  coverage?: boolean;
+  /**
+   * Extra coverage report formats beyond the always-on terminal summary:
+   * `'lcov'` writes `<output>/coverage/lcov.info`, `'html'` writes `<output>/coverage/index.html`.
+   */
+  coverageFormats?: string[];
   /** Enable file-watch mode: re-run affected tests on every save. */
   watch?: boolean;
   /**
@@ -288,6 +314,11 @@ export interface Config {
    * off it) so the final `junit.xml` covers the whole run. `null`/absent when TAP-only.
    */
   _junitCollector?: JUnitCase[] | null;
+  /**
+   * Accumulator for per-source line coverage when `coverage` is enabled. Shared across all
+   * concurrent groups (same lifetime as `_junitCollector`). `null`/absent when coverage is off.
+   */
+  _coverageCollector?: CoverageFileMap | null;
 }
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -81,6 +81,25 @@ export interface CachedContent {
 }
 
 /**
+ * One collected JUnit `<testcase>` — accumulated per `testEnd` and serialized into
+ * `junit.xml` at run end when `--reporter=junit` is active.
+ */
+export interface JUnitCase {
+  /** Suite name: the QUnit module path (fullName minus the test name). */
+  classname: string;
+  /** The test-case name (the last element of QUnit's fullName). */
+  name: string;
+  /** Test runtime in **seconds** (QUnit reports ms; converted on record). */
+  time: number;
+  /** Outcome of the test case. */
+  status: 'passed' | 'failed' | 'skipped' | 'todo';
+  /** First failing assertion's message (failed cases only). */
+  failureMessage?: string;
+  /** Concatenated failing-assertion messages + resolved stacks (failed cases only). */
+  failureDetail?: string;
+}
+
+/**
  * Full resolved qunitx configuration for a single run, merging `package.json` settings,
  * CLI flags, and runtime state. Most fields are read-only after `setupConfig()` resolves;
  * underscore-prefixed fields are mutable runtime slots populated during the run lifecycle.
@@ -121,6 +140,16 @@ export interface Config {
    * project-specific resolvers/loaders.
    */
   plugins?: EsbuildPlugin[];
+  /**
+   * Output reporter. `'tap'` (default) streams TAP to stdout. `'junit'` keeps the TAP
+   * stream and additionally writes a JUnit XML file at run end (see `junitOutput`).
+   */
+  reporter?: 'tap' | 'junit';
+  /**
+   * Destination for the JUnit XML file when `reporter === 'junit'`.
+   * Defaults to `<output>/junit.xml` (resolved against `projectRoot`).
+   */
+  junitOutput?: string;
   /** Enable file-watch mode: re-run affected tests on every save. */
   watch?: boolean;
   /**
@@ -253,6 +282,12 @@ export interface Config {
   webServer?: unknown;
   /** Decoded inline source map for the active test bundle; used to resolve stack frames to original sources. */
   _sourceMapDecoder?: SourceMapDecoder | null;
+  /**
+   * Accumulator for JUnit `<testcase>` records when `reporter === 'junit'`. Shared across
+   * all concurrent groups (set once on the parent config before the group configs are spread
+   * off it) so the final `junit.xml` covers the whole run. `null`/absent when TAP-only.
+   */
+  _junitCollector?: JUnitCase[] | null;
 }
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,7 +4,7 @@ import type { ChildProcess } from 'node:child_process';
 import type { Buffer } from 'node:buffer';
 import type { BuildContext, Plugin as EsbuildPlugin } from 'esbuild';
 import type { SourceMapDecoder } from './utils/source-map-decoder.ts';
-import type { Reporter } from './reporter/types.ts';
+import type { Reporter, ReporterName } from './reporter/types.ts';
 import type { FailedTestRecord } from './utils/failure-cache.ts';
 
 /**
@@ -158,15 +158,15 @@ export interface Config {
    */
   plugins?: EsbuildPlugin[];
   /**
-   * Output reporter. `'tap'` (default) streams TAP to stdout. `'junit'` keeps the TAP
-   * stream and additionally writes a JUnit XML file at run end (see `junitOutput`).
+   * The single stdout format for the run (default `'tap'`). Artifact outputs (`junit`,
+   * `coverage`) are separate additive options, not values of this field.
    */
-  reporter?: 'tap' | 'junit';
+  reporter?: ReporterName;
   /**
-   * Destination for the JUnit XML file when `reporter === 'junit'`.
-   * Defaults to `<output>/junit.xml` (resolved against `projectRoot`).
+   * Write a JUnit XML report in addition to the `reporter` stdout stream. `true` writes
+   * `<output>/junit.xml`; a string is a path (resolved against `projectRoot`).
    */
-  junitOutput?: string;
+  junit?: boolean | string;
   /**
    * When `true`, collect V8 line coverage of the test bundle and emit a terminal summary
    * at run end. Chromium-only; ignored (with a warning) for firefox/webkit.
@@ -310,12 +310,6 @@ export interface Config {
   /** Decoded inline source map for the active test bundle; used to resolve stack frames to original sources. */
   _sourceMapDecoder?: SourceMapDecoder | null;
   /**
-   * Accumulator for JUnit `<testcase>` records when `reporter === 'junit'`. Shared across
-   * all concurrent groups (set once on the parent config before the group configs are spread
-   * off it) so the final `junit.xml` covers the whole run. `null`/absent when TAP-only.
-   */
-  _junitCollector?: JUnitCase[] | null;
-  /**
    * Active reporter instances for this run, built by `createReporters` in `setupConfig`.
    * Shared by reference across all concurrent groups (same as `COUNTER`), so a stateful
    * reporter sees the whole run rather than one group's slice.
@@ -323,7 +317,8 @@ export interface Config {
   _reporters?: Reporter[];
   /**
    * Accumulator for per-source line coverage when `coverage` is enabled. Shared across all
-   * concurrent groups (same lifetime as `_junitCollector`). `null`/absent when coverage is off.
+   * concurrent groups (set once on the parent config before the group configs are spread off
+   * it). `null`/absent when coverage is off.
    */
   _coverageCollector?: CoverageFileMap | null;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ import type { ChildProcess } from 'node:child_process';
 import type { Buffer } from 'node:buffer';
 import type { BuildContext, Plugin as EsbuildPlugin } from 'esbuild';
 import type { SourceMapDecoder } from './utils/source-map-decoder.ts';
+import type { Reporter } from './reporter/types.ts';
 import type { FailedTestRecord } from './utils/failure-cache.ts';
 
 /**
@@ -314,6 +315,12 @@ export interface Config {
    * off it) so the final `junit.xml` covers the whole run. `null`/absent when TAP-only.
    */
   _junitCollector?: JUnitCase[] | null;
+  /**
+   * Active reporter instances for this run, built by `createReporters` in `setupConfig`.
+   * Shared by reference across all concurrent groups (same as `COUNTER`), so a stateful
+   * reporter sees the whole run rather than one group's slice.
+   */
+  _reporters?: Reporter[];
   /**
    * Accumulator for per-source line coverage when `coverage` is enabled. Shared across all
    * concurrent groups (same lifetime as `_junitCollector`). `null`/absent when coverage is off.

--- a/lib/utils/get-changed-file-paths-in-git-since.ts
+++ b/lib/utils/get-changed-file-paths-in-git-since.ts
@@ -1,8 +1,54 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+// node:timers' setTimeout returns an unref-able Timer in both Node and Deno; Deno's bare
+// global is the Web variant, which returns a number with no .unref().
+import { setTimeout, clearTimeout } from 'node:timers';
 import path from 'node:path';
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Upper bound on a single git invocation. `--changed` already degrades to "run all tests" when
+ * git fails, so a stuck git should *reject* rather than wedge the run — without a bound the CLI
+ * hangs forever, since neither git nor the caller ever gives up. 30s is orders of magnitude
+ * above a healthy `git status` on a large repo, so it only fires on a genuine wedge.
+ */
+const GIT_TIMEOUT_MS = 30_000;
+/**
+ * Extra window after `execFile`'s own timeout before the outer race gives up. Lets execFile's
+ * kill land first (its error names the signal, which is the more useful diagnostic) and only
+ * falls through when the child's exit is never delivered at all.
+ */
+const GIT_KILL_GRACE_MS = 2_000;
+
+/**
+ * Runs one git command with a hard upper bound on how long it can take.
+ *
+ * Two layers, because they cover different failures: `execFile`'s own `timeout` kills a child
+ * that is merely slow, while the outer race guarantees *this promise settles* even if the
+ * child's exit event never arrives — the case where killing the child doesn't help because
+ * nobody is listening for it to die. That second layer is what turns an unkillable hang into a
+ * normal rejection the caller already knows how to degrade on.
+ */
+export function runGit(args: string[], cwd: string, timeoutMs = GIT_TIMEOUT_MS): Promise<string> {
+  const pending = execFileAsync('git', args, {
+    cwd,
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: timeoutMs,
+    killSignal: 'SIGKILL',
+  }).then((result) => result.stdout);
+
+  let timer: ReturnType<typeof setTimeout>;
+  const bound = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`git ${args[0]} timed out after ${timeoutMs}ms`)),
+      timeoutMs + GIT_KILL_GRACE_MS,
+    );
+    timer.unref?.();
+  });
+
+  return Promise.race([pending, bound]).finally(() => clearTimeout(timer));
+}
 
 /**
  * Exact basenames whose modification invalidates the entire test suite. A change
@@ -26,22 +72,19 @@ const BLAST_RADIUS_PATTERNS = [/^tsconfig.*\.json$/];
  * has changed — those changes can affect every test and must skip the
  * dep-graph filter. The caller treats `null` as "run all tests."
  *
- * Throws on git failure (not a repo, ref doesn't exist, git missing). Callers
- * should catch and degrade to the run-all path with a stderr note.
+ * Throws on git failure (not a repo, ref doesn't exist, git missing, or git exceeding
+ * `timeoutMs`). Callers should catch and degrade to the run-all path with a stderr note.
+ *
+ * `timeoutMs` is injectable for tests; production always uses the default.
  */
 export async function getChangedFilePathsInGitSince(
   projectRoot: string,
   ref: string,
+  timeoutMs = GIT_TIMEOUT_MS,
 ): Promise<Set<string> | null> {
   const [diffOut, statusOut] = await Promise.all([
-    execFileAsync('git', ['diff', '--name-only', '--no-renames', ref, '--', projectRoot], {
-      cwd: projectRoot,
-      maxBuffer: 16 * 1024 * 1024,
-    }).then((r) => r.stdout),
-    execFileAsync('git', ['status', '--porcelain', '--untracked-files=all'], {
-      cwd: projectRoot,
-      maxBuffer: 16 * 1024 * 1024,
-    }).then((r) => r.stdout),
+    runGit(['diff', '--name-only', '--no-renames', ref, '--', projectRoot], projectRoot, timeoutMs),
+    runGit(['status', '--porcelain', '--untracked-files=all'], projectRoot, timeoutMs),
   ]);
 
   // `git status --porcelain` lines look like "XY path" or "XY path -> newpath"
@@ -69,4 +112,4 @@ export async function getChangedFilePathsInGitSince(
   return new Set(Array.from(relPaths, (rel) => path.resolve(projectRoot, rel)));
 }
 
-export { BLAST_RADIUS_FILES, BLAST_RADIUS_PATTERNS };
+export { BLAST_RADIUS_FILES, BLAST_RADIUS_PATTERNS, GIT_TIMEOUT_MS };

--- a/lib/utils/metafile-cache.ts
+++ b/lib/utils/metafile-cache.ts
@@ -23,6 +23,12 @@ interface MetafileCachePayload {
 const CACHE_FILE = 'metafile.json';
 
 /**
+ * Distinguishes concurrent temp files. One process can have two writes in flight (a watch-mode
+ * rebuild starting before the previous write settled), so the pid alone is not unique.
+ */
+let writeSequence = 0;
+
+/**
  * Returns the on-disk cache path for `projectRoot`. The path embeds a SHA-1
  * tag of the absolute project root so projects that share a hoisted/symlinked
  * `node_modules` (pnpm workspaces, monorepos, integration test fixtures) write
@@ -34,21 +40,37 @@ export function metafileCachePath(projectRoot: string): string {
   return path.join(projectRoot, 'node_modules', '.cache', 'qunitx', tag, CACHE_FILE);
 }
 
-/** Best-effort write; failures are swallowed because cache miss on the next read just degrades to "run all tests." */
+/**
+ * Best-effort write; failures are swallowed because a cache miss on the next read just degrades
+ * to "run all tests."
+ *
+ * Publishes by writing a temp file and renaming it into place, because `fs.writeFile` **truncates
+ * on open**: for the whole write window the cache is an empty (then partial) file, and any reader
+ * in that window parses garbage and concludes there is no cache. That is not theoretical — watch
+ * mode fires `buildTestBundle` (which lands here) and *then* calls `getChangedFsTree`, so a
+ * `--changed --watch` run races its own write and intermittently reports "no metafile cache yet
+ * — running all N test files" instead of the affected subset. `rename` is atomic, so a reader
+ * always sees either the previous complete cache or this one, never a torn one. It also makes
+ * concurrent writers (two runs sharing a checkout) and a process killed mid-write safe: the
+ * worst case is a leftover temp file, never a corrupt cache.
+ */
 export async function writeMetafileCache(
   projectRoot: string,
   esbuildCwd: string,
   metafile: AffectedMetafile,
 ): Promise<void> {
   const file = metafileCachePath(projectRoot);
+  const tmpFile = `${file}.${process.pid}-${++writeSequence}.tmp`;
   try {
     await fs.mkdir(path.dirname(file), { recursive: true });
     await fs.writeFile(
-      file,
+      tmpFile,
       JSON.stringify({ esbuildCwd, metafile } satisfies MetafileCachePayload),
     );
+    await fs.rename(tmpFile, file);
   } catch {
     /* node_modules/.cache may not be writable (read-only FS, EACCES); silent degrade. */
+    await fs.unlink(tmpFile).catch(() => {});
   }
 }
 

--- a/lib/utils/parse-cli-flags.ts
+++ b/lib/utils/parse-cli-flags.ts
@@ -21,6 +21,8 @@ interface ParsedFlags {
   before?: string | false;
   after?: string | false;
   changedSince?: string;
+  reporter?: 'tap' | 'junit';
+  junitOutput?: string;
 }
 
 /**
@@ -90,6 +92,17 @@ export function parseCliFlags(projectRoot: string): ParsedFlags {
           process.exit(1);
         }
         return Object.assign(result, { changedSince: ref });
+      } else if (arg.startsWith('--reporter')) {
+        // `--reporter=junit` enables the JUnit XML file (TAP still streams to stdout);
+        // bare `--reporter` is treated as junit. `tap` is the default and a no-op here.
+        const value = arg.split('=')[1];
+        if (value && !['tap', 'junit'].includes(value)) {
+          console.error(`Invalid --reporter value: "${value}". Must be one of: tap, junit`);
+          process.exit(1);
+        }
+        return Object.assign(result, { reporter: (value as 'tap' | 'junit') || 'junit' });
+      } else if (arg.startsWith('--junit-output')) {
+        return Object.assign(result, { junitOutput: arg.split('=')[1] });
       } else if (arg === '--trace-perf') {
         return result; // consumed by perf-logger.js at module load time, not stored in config
       }

--- a/lib/utils/parse-cli-flags.ts
+++ b/lib/utils/parse-cli-flags.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { REPORTERS, type ReporterName } from '../reporter/types.ts';
 
 // Fallback when --timeout is passed with an unparseable or zero value.
 const FALLBACK_TIMEOUT_MS = 10_000;
@@ -21,8 +22,8 @@ interface ParsedFlags {
   before?: string | false;
   after?: string | false;
   changedSince?: string;
-  reporter?: 'tap' | 'junit';
-  junitOutput?: string;
+  reporter?: ReporterName;
+  junit?: boolean | string;
   coverage?: boolean;
   coverageFormats?: string[];
 }
@@ -95,16 +96,20 @@ export function parseCliFlags(projectRoot: string): ParsedFlags {
         }
         return Object.assign(result, { changedSince: ref });
       } else if (arg.startsWith('--reporter')) {
-        // `--reporter=junit` enables the JUnit XML file (TAP still streams to stdout);
-        // bare `--reporter` is treated as junit. `tap` is the default and a no-op here.
+        // `--reporter` selects the single stdout format. Artifacts (--junit, --coverage) are
+        // separate additive flags, so `--reporter=dot --junit` is a coherent combination.
         const value = arg.split('=')[1];
-        if (value && !['tap', 'junit'].includes(value)) {
-          console.error(`Invalid --reporter value: "${value}". Must be one of: tap, junit`);
+        if (!value || !REPORTERS.includes(value as ReporterName)) {
+          console.error(
+            `Invalid --reporter value: "${value ?? ''}". Must be one of: ${REPORTERS.join(', ')}`,
+          );
           process.exit(1);
         }
-        return Object.assign(result, { reporter: (value as 'tap' | 'junit') || 'junit' });
-      } else if (arg.startsWith('--junit-output')) {
-        return Object.assign(result, { junitOutput: arg.split('=')[1] });
+        return Object.assign(result, { reporter: value as ReporterName });
+      } else if (arg.startsWith('--junit')) {
+        // Bare `--junit` writes <output>/junit.xml; `--junit=<path>` overrides the destination.
+        const value = arg.split('=')[1];
+        return Object.assign(result, { junit: value ? value : true });
       } else if (arg.startsWith('--coverage')) {
         // `--coverage` → terminal summary only. `--coverage=lcov,html` → also write those
         // report files. `text` is accepted as an explicit alias for the always-on terminal

--- a/lib/utils/parse-cli-flags.ts
+++ b/lib/utils/parse-cli-flags.ts
@@ -23,6 +23,8 @@ interface ParsedFlags {
   changedSince?: string;
   reporter?: 'tap' | 'junit';
   junitOutput?: string;
+  coverage?: boolean;
+  coverageFormats?: string[];
 }
 
 /**
@@ -103,6 +105,28 @@ export function parseCliFlags(projectRoot: string): ParsedFlags {
         return Object.assign(result, { reporter: (value as 'tap' | 'junit') || 'junit' });
       } else if (arg.startsWith('--junit-output')) {
         return Object.assign(result, { junitOutput: arg.split('=')[1] });
+      } else if (arg.startsWith('--coverage')) {
+        // `--coverage` → terminal summary only. `--coverage=lcov,html` → also write those
+        // report files. `text` is accepted as an explicit alias for the always-on terminal
+        // summary, so it never becomes an extra format.
+        const value = arg.split('=')[1];
+        const formats = value
+          ? value
+              .split(',')
+              .map((format) => format.trim())
+              .filter(Boolean)
+          : [];
+        const invalid = formats.filter((format) => !['text', 'lcov', 'html'].includes(format));
+        if (invalid.length > 0) {
+          console.error(
+            `Invalid --coverage format(s): "${invalid.join(', ')}". Must be one of: lcov, html`,
+          );
+          process.exit(1);
+        }
+        return Object.assign(result, {
+          coverage: true,
+          coverageFormats: formats.filter((format) => format !== 'text'),
+        });
       } else if (arg === '--trace-perf') {
         return result; // consumed by perf-logger.js at module load time, not stored in config
       }

--- a/lib/utils/source-map-decoder.ts
+++ b/lib/utils/source-map-decoder.ts
@@ -252,6 +252,18 @@ export function isBundleUrl(url: string): boolean {
 }
 
 /**
+ * Resolves the absolute path of the source at `sourceIndex` in the map's `sources` array,
+ * applying the same `sourceRoot` + `outDir` rules as position lookups. Returns `null` when
+ * the index is out of range or the entry is empty. Used by the coverage collector to key
+ * accumulated line coverage by absolute source path.
+ */
+export function sourceAbsolutePath(decoder: SourceMapDecoder, sourceIndex: number): string | null {
+  const rawSource = decoder.sources[sourceIndex];
+  if (!rawSource) return null;
+  return toAbsolutePath(rawSource, decoder.outDir, decoder.sourceRoot);
+}
+
+/**
  * Attempts to resolve a single stack-frame line to its original source location.
  * Handles Chrome named (`at FUNC (URL:L:C)`), Chrome anonymous (`at [async] URL:L:C`),
  * and Firefox/WebKit (`FUNC@URL:L:C`) formats.
@@ -399,20 +411,37 @@ function normalizePosix(path: string): string {
   return (path.startsWith('/') ? '/' : '') + parts.join('/');
 }
 
+/**
+ * Everything below is POSIX-only by design — this module runs in the browser, so it cannot use
+ * node:path. Callers hand us OS paths though (`outDir`, `projectRoot`), and on Windows those use
+ * backslashes. `normalizePosix` splits on `/`, so an unconverted Windows path stays a single
+ * glued segment that a leading `..` pops wholesale — turning `D:\proj\tmp\..\node_modules\x`
+ * into the *relative* `node_modules/x`. That silently defeats every prefix check downstream
+ * (`isNodeModulesPath`, `makeDisplayPath`). Converting at the boundary makes both platforms
+ * produce identical absolute paths.
+ */
+function toPosix(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
 function toAbsolutePath(rawSource: string, outDir: string, sourceRoot: string): string {
-  if (rawSource.startsWith('file://')) return rawSource.slice(7);
-  if (rawSource.startsWith('/')) return rawSource;
-  const base = sourceRoot ? normalizePosix(`${outDir}/${sourceRoot}`) : outDir;
-  return normalizePosix(`${base}/${rawSource}`);
+  const source = toPosix(rawSource);
+  if (source.startsWith('file://')) return source.slice(7);
+  if (source.startsWith('/')) return source;
+  const base = sourceRoot
+    ? normalizePosix(`${toPosix(outDir)}/${toPosix(sourceRoot)}`)
+    : toPosix(outDir);
+  return normalizePosix(`${base}/${source}`);
 }
 
 function isNodeModulesPath(path: string): boolean {
-  return path.includes('/node_modules/') || path.includes('\\node_modules\\');
+  return toPosix(path).includes('/node_modules/');
 }
 
 function makeDisplayPath(absolutePath: string, projectRoot: string): string {
-  const prefix = projectRoot + '/';
-  return absolutePath.startsWith(prefix) ? absolutePath.slice(prefix.length) : absolutePath;
+  const prefix = `${toPosix(projectRoot)}/`;
+  const absolute = toPosix(absolutePath);
+  return absolute.startsWith(prefix) ? absolute.slice(prefix.length) : absolute;
 }
 
 /** Resolves a `URL:LINE:COL` string to a display path + userPath + sourceText, or null on miss. */

--- a/test/commands/help-test.ts
+++ b/test/commands/help-test.ts
@@ -39,6 +39,8 @@ Optional flags:
 --port : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 --extensions : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 --browser : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
+--reporter : output reporter: tap (default) or junit; junit also writes a JUnit XML file (TAP still streams to stdout)
+--junit-output : JUnit XML file path when --reporter=junit [default: <output>/junit.xml]
 --before : run a script before the tests(i.e start a new web server before tests)
 --after : run a script after the tests(i.e save test results to a file)
 --no-daemon : don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn

--- a/test/commands/help-test.ts
+++ b/test/commands/help-test.ts
@@ -41,6 +41,7 @@ Optional flags:
 --browser : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
 --reporter : output reporter: tap (default) or junit; junit also writes a JUnit XML file (TAP still streams to stdout)
 --junit-output : JUnit XML file path when --reporter=junit [default: <output>/junit.xml]
+--coverage : collect V8 line coverage (chromium only); --coverage=lcov,html also writes <output>/coverage/ reports
 --before : run a script before the tests(i.e start a new web server before tests)
 --after : run a script after the tests(i.e save test results to a file)
 --no-daemon : don't use the daemon for this run — skips a running daemon and prevents QUNITX_DAEMON auto-spawn

--- a/test/commands/help-test.ts
+++ b/test/commands/help-test.ts
@@ -39,7 +39,7 @@ Optional flags:
 --port : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 --extensions : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 --browser : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
---reporter : stdout format: tap[default: tap]
+--reporter : stdout format: tap, spec[default: tap]
 --junit : also write a JUnit XML report[default path: <output>/junit.xml; --junit=<path> to override]
 --coverage : collect V8 line coverage (chromium only); --coverage=lcov,html also writes <output>/coverage/ reports
 --before : run a script before the tests(i.e start a new web server before tests)

--- a/test/commands/help-test.ts
+++ b/test/commands/help-test.ts
@@ -39,7 +39,7 @@ Optional flags:
 --port : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 --extensions : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 --browser : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
---reporter : stdout format: tap, spec, dot[default: tap]
+--reporter : stdout format: tap, spec, dot, github[default: tap]
 --junit : also write a JUnit XML report[default path: <output>/junit.xml; --junit=<path> to override]
 --coverage : collect V8 line coverage (chromium only); --coverage=lcov,html also writes <output>/coverage/ reports
 --before : run a script before the tests(i.e start a new web server before tests)

--- a/test/commands/help-test.ts
+++ b/test/commands/help-test.ts
@@ -39,8 +39,8 @@ Optional flags:
 --port : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 --extensions : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 --browser : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
---reporter : output reporter: tap (default) or junit; junit also writes a JUnit XML file (TAP still streams to stdout)
---junit-output : JUnit XML file path when --reporter=junit [default: <output>/junit.xml]
+--reporter : stdout format: tap[default: tap]
+--junit : also write a JUnit XML report[default path: <output>/junit.xml; --junit=<path> to override]
 --coverage : collect V8 line coverage (chromium only); --coverage=lcov,html also writes <output>/coverage/ reports
 --before : run a script before the tests(i.e start a new web server before tests)
 --after : run a script after the tests(i.e save test results to a file)

--- a/test/commands/help-test.ts
+++ b/test/commands/help-test.ts
@@ -39,7 +39,7 @@ Optional flags:
 --port : HTTP server port (auto-selects a free port if the given port is taken)[default: 1234]
 --extensions : comma-separated file extensions to track for discovery and watch-mode rebuilds[default: js,ts,jsx,tsx]
 --browser : browser engine to run tests in: chromium, firefox, webkit[default: chromium]
---reporter : stdout format: tap, spec[default: tap]
+--reporter : stdout format: tap, spec, dot[default: tap]
 --junit : also write a JUnit XML report[default path: <output>/junit.xml; --junit=<path> to override]
 --coverage : collect V8 line coverage (chromium only); --coverage=lcov,html also writes <output>/coverage/ reports
 --before : run a script before the tests(i.e start a new web server before tests)

--- a/test/coverage/collect-test.ts
+++ b/test/coverage/collect-test.ts
@@ -1,0 +1,160 @@
+import { module, test } from 'qunitx';
+import { collectCoverage } from '../../lib/coverage/collect.ts';
+import { buildRows, buildLcov } from '../../lib/coverage/report.ts';
+import type { SourceMapDecoder } from '../../lib/utils/source-map-decoder.ts';
+import type { Config, CoverageFileMap } from '../../lib/types.ts';
+
+// A hand-built two-line bundle whose source map attributes each generated line to a distinct
+// original line, so we can assert the V8-range → original-line attribution deterministically
+// without launching a browser.
+//   bundle: "foo();\nbar();\n"   (offsets: line0 = 0..5, '\n' at 6; line1 = 7..12, '\n' at 13)
+const BUNDLE_SOURCE = 'foo();\nbar();\n';
+
+function makeDecoder(): SourceMapDecoder {
+  return {
+    segmentsByLine: [
+      [{ generatedCol: 0, sourceIndex: 0, sourceLine: 0, sourceCol: 0 }], // bundle line0 → src line1
+      [{ generatedCol: 0, sourceIndex: 0, sourceLine: 1, sourceCol: 0 }], // bundle line1 → src line2
+    ],
+    sources: ['src/x.ts'],
+    sourceRoot: '',
+    outDir: '/proj/tmp',
+    sourcesContent: ['foo();\nbar();\n'],
+  };
+}
+
+function makeConfig(decoder: SourceMapDecoder, collector: CoverageFileMap): Config {
+  return {
+    projectRoot: '/proj/tmp',
+    output: 'tmp',
+    _sourceMapDecoder: decoder,
+    _coverageCollector: collector,
+  } as unknown as Config;
+}
+
+// One outer function range covering the whole bundle with count 1, plus a nested range over
+// bundle line1 with count 0 → line1 covered, line2 coverable-but-missed (the V8 nesting rule).
+const V8_ENTRIES = [
+  {
+    url: 'http://localhost:1234/tests.js',
+    scriptId: '1',
+    source: BUNDLE_SOURCE,
+    functions: [
+      {
+        functionName: '',
+        isBlockCoverage: true,
+        ranges: [
+          { startOffset: 0, endOffset: 13, count: 1 },
+          { startOffset: 7, endOffset: 13, count: 0 },
+        ],
+      },
+    ],
+  },
+];
+
+module('coverage | collect + report', { concurrency: true }, () => {
+  test('attributes covered and missed original lines from V8 ranges', async (assert) => {
+    const collector: CoverageFileMap = new Map();
+    await collectCoverage(makeConfig(makeDecoder(), collector), V8_ENTRIES);
+
+    const fileCoverage = collector.get('/proj/tmp/src/x.ts');
+    assert.ok(fileCoverage, 'source file recorded by absolute path');
+    assert.deepEqual([...fileCoverage!.coverable].sort(), [1, 2], 'both lines are coverable');
+    assert.equal(fileCoverage!.covered.get(1), 1, 'line 1 covered (count 1)');
+    assert.equal(fileCoverage!.covered.get(2), undefined, 'line 2 not covered (count 0)');
+  });
+
+  test('reads the bundle from disk only when the entry has no source', async (assert) => {
+    // Empty source + a non-existent output dir → readBundleSource returns null → nothing recorded.
+    const collector: CoverageFileMap = new Map();
+    const entries = [{ ...V8_ENTRIES[0], source: '' }];
+    await collectCoverage(makeConfig(makeDecoder(), collector), entries);
+    assert.equal(collector.size, 0, 'no attribution when source is unavailable');
+  });
+
+  test('skips non-bundle script URLs', async (assert) => {
+    const collector: CoverageFileMap = new Map();
+    const entries = [{ ...V8_ENTRIES[0], url: 'http://localhost:1234/app.js' }];
+    await collectCoverage(makeConfig(makeDecoder(), collector), entries);
+    assert.equal(collector.size, 0, 'only /tests.js (or /filtered-tests.js) is attributed');
+  });
+
+  test('buildRows computes percentages and excludes test entry files', (assert) => {
+    const collector: CoverageFileMap = new Map([
+      [
+        '/proj/tmp/src/x.ts',
+        { coverable: new Set([1, 2]), covered: new Map([[1, 1]]), sourceContent: null },
+      ],
+      [
+        '/proj/tmp/test/x-test.ts',
+        { coverable: new Set([1]), covered: new Map([[1, 1]]), sourceContent: null },
+      ],
+    ]);
+    const rows = buildRows(collector, new Set(['/proj/tmp/test/x-test.ts']), '/proj/tmp');
+    assert.equal(rows.length, 1, 'test entry file excluded');
+    assert.equal(rows[0].displayPath, 'src/x.ts', 'display path relative to projectRoot');
+    assert.equal(rows[0].total, 2);
+    assert.equal(rows[0].covered, 1);
+    assert.equal(rows[0].pct, 50);
+  });
+
+  test('excludes test files when fsTree paths use Windows separators', (assert) => {
+    // Regression: on Windows the two sides arrive in different shapes — fsTree gives OS paths
+    // (backslashes) while coverage keys come from the source map (always `/`). Comparing them
+    // raw never matched, so test files leaked into the report. Simulated here so the platform
+    // bug is reproducible on any OS.
+    const projectRoot = 'D:\\a\\qunitx-cli\\qunitx-cli';
+    const collector: CoverageFileMap = new Map([
+      [
+        'D:/a/qunitx-cli/qunitx-cli/src/x.ts',
+        { coverable: new Set([1]), covered: new Map([[1, 1]]), sourceContent: null },
+      ],
+      [
+        'D:/a/qunitx-cli/qunitx-cli/test/x-test.ts',
+        { coverable: new Set([1]), covered: new Map([[1, 1]]), sourceContent: null },
+      ],
+    ]);
+    const rows = buildRows(
+      collector,
+      new Set(['D:\\a\\qunitx-cli\\qunitx-cli\\test\\x-test.ts']),
+      projectRoot,
+    );
+    assert.equal(rows.length, 1, 'backslash test path still excludes the forward-slash key');
+    assert.equal(rows[0].displayPath, 'src/x.ts', 'display path is POSIX + project-relative');
+  });
+
+  test('excludes test files when the source map yields project-relative paths', (assert) => {
+    // The map can also hand back an already-relative path (Windows outDir normalization);
+    // it must still line up with the absolute fsTree entry.
+    const rows = buildRows(
+      new Map([
+        ['test/x-test.ts', { coverable: new Set([1]), covered: new Map(), sourceContent: null }],
+        ['src/x.ts', { coverable: new Set([1]), covered: new Map(), sourceContent: null }],
+      ]),
+      new Set(['/proj/test/x-test.ts']),
+      '/proj',
+    );
+    assert.equal(rows.length, 1, 'relative coverage key matches the absolute test entry');
+    assert.equal(rows[0].displayPath, 'src/x.ts');
+  });
+
+  test('buildLcov emits DA/LF/LH lines with hit counts', (assert) => {
+    const rows = buildRows(
+      new Map([
+        [
+          '/proj/tmp/src/x.ts',
+          { coverable: new Set([1, 2]), covered: new Map([[1, 3]]), sourceContent: null },
+        ],
+      ]),
+      new Set(),
+      '/proj/tmp',
+    );
+    const lcov = buildLcov(rows);
+    assert.true(lcov.includes('SF:src/x.ts'), 'source file line');
+    assert.true(lcov.includes('DA:1,3'), 'covered line with hit count');
+    assert.true(lcov.includes('DA:2,0'), 'missed line with zero count');
+    assert.true(lcov.includes('LF:2'), 'lines found');
+    assert.true(lcov.includes('LH:1'), 'lines hit');
+    assert.true(lcov.trimEnd().endsWith('end_of_record'), 'record terminator');
+  });
+});

--- a/test/fixtures/coverage/calculator-test.ts
+++ b/test/fixtures/coverage/calculator-test.ts
@@ -1,0 +1,10 @@
+import { module, test } from 'qunitx';
+import { add, double, abs } from './calculator.ts';
+
+module('Calculator', (_hooks) => {
+  test('add and double are exercised', (assert) => {
+    assert.equal(add(2, 3), 5);
+    assert.equal(double(4), 8);
+    assert.equal(abs(5), 5); // only the non-negative branch of abs runs
+  });
+});

--- a/test/fixtures/coverage/calculator.ts
+++ b/test/fixtures/coverage/calculator.ts
@@ -1,0 +1,21 @@
+// Source-under-test fixture for --coverage. `add` and `double` are exercised by the test;
+// `subtract` and the negative branch of `abs` are intentionally left uncovered so the report
+// has both hit and missed lines to assert on.
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+export function subtract(a: number, b: number): number {
+  return a - b;
+}
+
+export function double(n: number): number {
+  return n * 2;
+}
+
+export function abs(n: number): number {
+  if (n < 0) {
+    return -n;
+  }
+  return n;
+}

--- a/test/flags/coverage-test.ts
+++ b/test/flags/coverage-test.ts
@@ -1,0 +1,90 @@
+import { module, test } from 'qunitx';
+import fs from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import '../helpers/custom-asserts.ts';
+import shell from '../helpers/shell.ts';
+
+// Coverage is V8-precise-coverage over CDP — chromium only. On the firefox/webkit CI lanes we
+// assert the warning-and-skip path instead of the report itself.
+const IS_CHROMIUM = (process.env.QUNITX_BROWSER || 'chromium') === 'chromium';
+
+module('--coverage', { concurrency: true }, (_hooks, moduleMetadata) => {
+  test('prints a terminal summary and writes lcov + html reports', async (assert, testMetadata) => {
+    const output = `tmp/cov-${randomUUID()}`;
+    try {
+      const result = await shell(
+        `node cli.ts test/fixtures/coverage/calculator-test.ts --coverage=lcov,html --output=${output}`,
+        { ...moduleMetadata, ...testMetadata },
+      );
+
+      if (!IS_CHROMIUM) {
+        assert.includes(result, 'requires the chromium browser');
+        const dirExists = await fs
+          .stat(`${output}/coverage`)
+          .then(() => true)
+          .catch(() => false);
+        assert.notOk(dirExists, 'no coverage dir on non-chromium browsers');
+        return;
+      }
+
+      assert.includes(result, 'Coverage (V8 line coverage)');
+      assert.includes(result, 'calculator.ts');
+
+      const lcov = await fs.readFile(`${output}/coverage/lcov.info`, 'utf8');
+      assert.ok(
+        lcov.includes('SF:test/fixtures/coverage/calculator.ts'),
+        'source-under-test recorded in lcov',
+      );
+      assert.ok(/DA:\d+,0/.test(lcov), 'has a missed line (the uncovered abs branch)');
+      assert.ok(/DA:\d+,[1-9]/.test(lcov), 'has a covered line');
+      assert.ok(lcov.includes('end_of_record'), 'lcov record terminated');
+
+      const html = await fs.readFile(`${output}/coverage/index.html`, 'utf8');
+      assert.ok(html.includes('qunitx coverage'), 'html report generated');
+      assert.ok(/class="ln (hit|miss)"/.test(html), 'html shows line-level hit/miss');
+    } finally {
+      await fs.rm(output, { recursive: true, force: true });
+    }
+  });
+
+  test('excludes test files and node_modules from the report', async (assert, testMetadata) => {
+    if (!IS_CHROMIUM) {
+      assert.ok(true, 'coverage exclusions only apply on chromium — skipped');
+      return;
+    }
+    const output = `tmp/cov-exclude-${randomUUID()}`;
+    try {
+      await shell(
+        `node cli.ts test/fixtures/coverage/calculator-test.ts --coverage=lcov --output=${output}`,
+        { ...moduleMetadata, ...testMetadata },
+      );
+      const lcov = await fs.readFile(`${output}/coverage/lcov.info`, 'utf8');
+      assert.notOk(lcov.includes('calculator-test.ts'), 'test entry file excluded');
+      assert.notOk(lcov.includes('node_modules'), 'dependencies excluded');
+    } finally {
+      await fs.rm(output, { recursive: true, force: true });
+    }
+  });
+
+  test('bare --coverage prints the summary without writing report files', async (assert, testMetadata) => {
+    const output = `tmp/cov-terminal-${randomUUID()}`;
+    try {
+      const result = await shell(
+        `node cli.ts test/fixtures/coverage/calculator-test.ts --coverage --output=${output}`,
+        { ...moduleMetadata, ...testMetadata },
+      );
+      if (!IS_CHROMIUM) {
+        assert.includes(result, 'requires the chromium browser');
+        return;
+      }
+      assert.includes(result, 'Coverage (V8 line coverage)');
+      const dirExists = await fs
+        .stat(`${output}/coverage`)
+        .then(() => true)
+        .catch(() => false);
+      assert.notOk(dirExists, 'no coverage/ dir for the terminal-only summary');
+    } finally {
+      await fs.rm(output, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/flags/index.ts
+++ b/test/flags/index.ts
@@ -8,5 +8,5 @@ import './watch-test.ts';
 import './watch-rerun-test.ts';
 import './open-test.ts';
 import './timezone-test.ts';
-import './reporter-junit-test.ts';
+import './junit-test.ts';
 import './coverage-test.ts';

--- a/test/flags/index.ts
+++ b/test/flags/index.ts
@@ -9,4 +9,5 @@ import './watch-rerun-test.ts';
 import './open-test.ts';
 import './timezone-test.ts';
 import './junit-test.ts';
+import './reporter-test.ts';
 import './coverage-test.ts';

--- a/test/flags/index.ts
+++ b/test/flags/index.ts
@@ -8,3 +8,4 @@ import './watch-test.ts';
 import './watch-rerun-test.ts';
 import './open-test.ts';
 import './timezone-test.ts';
+import './reporter-junit-test.ts';

--- a/test/flags/index.ts
+++ b/test/flags/index.ts
@@ -9,3 +9,4 @@ import './watch-rerun-test.ts';
 import './open-test.ts';
 import './timezone-test.ts';
 import './reporter-junit-test.ts';
+import './coverage-test.ts';

--- a/test/flags/junit-test.ts
+++ b/test/flags/junit-test.ts
@@ -4,12 +4,12 @@ import { randomUUID } from 'node:crypto';
 import '../helpers/custom-asserts.ts';
 import shell, { shellFails } from '../helpers/shell.ts';
 
-module('--reporter=junit', { concurrency: true }, (_hooks, moduleMetadata) => {
+module('--junit', { concurrency: true }, (_hooks, moduleMetadata) => {
   test('writes junit.xml alongside the streamed TAP for a passing run', async (assert, testMetadata) => {
     const output = `tmp/junit-pass-${randomUUID()}`;
     try {
       const result = await shell(
-        `node cli.ts test/fixtures/passing-tests.ts --reporter=junit --output=${output}`,
+        `node cli.ts test/fixtures/passing-tests.ts --junit --output=${output}`,
         { ...moduleMetadata, ...testMetadata },
       );
 
@@ -36,7 +36,7 @@ module('--reporter=junit', { concurrency: true }, (_hooks, moduleMetadata) => {
     const output = `tmp/junit-fail-${randomUUID()}`;
     try {
       const result = await shellFails(
-        `node cli.ts test/fixtures/failing-tests.ts --reporter=junit --output=${output}`,
+        `node cli.ts test/fixtures/failing-tests.ts --junit --output=${output}`,
         { ...moduleMetadata, ...testMetadata },
       );
       assert.exitCode(result, 1, 'failing run exits 1');
@@ -51,12 +51,12 @@ module('--reporter=junit', { concurrency: true }, (_hooks, moduleMetadata) => {
     }
   });
 
-  test('--junit-output overrides the destination path (nested dirs created)', async (assert, testMetadata) => {
+  test('--junit=<path> overrides the destination path (nested dirs created)', async (assert, testMetadata) => {
     const output = `tmp/junit-custom-${randomUUID()}`;
     const junitPath = `${output}/reports/nested/report.xml`;
     try {
       await shell(
-        `node cli.ts test/fixtures/passing-tests.ts --reporter=junit --junit-output=${junitPath} --output=${output}`,
+        `node cli.ts test/fixtures/passing-tests.ts --junit=${junitPath} --output=${output}`,
         { ...moduleMetadata, ...testMetadata },
       );
       const xml = await fs.readFile(junitPath, 'utf8');
@@ -71,7 +71,31 @@ module('--reporter=junit', { concurrency: true }, (_hooks, moduleMetadata) => {
     }
   });
 
-  test('tap remains the default reporter (no junit.xml without the flag)', async (assert, testMetadata) => {
+  test('composes with an explicit --reporter (separate axes)', async (assert, testMetadata) => {
+    const output = `tmp/junit-axes-${randomUUID()}`;
+    try {
+      const result = await shell(
+        `node cli.ts test/fixtures/passing-tests.ts --reporter=tap --junit --output=${output}`,
+        { ...moduleMetadata, ...testMetadata },
+      );
+      assert.tapResult(result, { testCount: 3 });
+      const xml = await fs.readFile(`${output}/junit.xml`, 'utf8');
+      assert.ok(xml.includes('<testsuites'), '--reporter and --junit are independent');
+    } finally {
+      await fs.rm(output, { recursive: true, force: true });
+    }
+  });
+
+  test('--reporter=junit is rejected — junit is an artifact, not a stdout format', async (assert) => {
+    const result = await shellFails(`node cli.ts test/fixtures/passing-tests.ts --reporter=junit`);
+    assert.exitCode(result, 1, 'invalid reporter value exits 1');
+    assert.ok(
+      /Invalid --reporter value: "junit"/.test(result.stderr ?? ''),
+      'error names the offending value',
+    );
+  });
+
+  test('no junit.xml is written without the flag', async (assert, testMetadata) => {
     const output = `tmp/junit-none-${randomUUID()}`;
     try {
       const result = await shell(`node cli.ts test/fixtures/passing-tests.ts --output=${output}`, {

--- a/test/flags/reporter-junit-test.ts
+++ b/test/flags/reporter-junit-test.ts
@@ -1,0 +1,91 @@
+import { module, test } from 'qunitx';
+import fs from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import '../helpers/custom-asserts.ts';
+import shell, { shellFails } from '../helpers/shell.ts';
+
+module('--reporter=junit', { concurrency: true }, (_hooks, moduleMetadata) => {
+  test('writes junit.xml alongside the streamed TAP for a passing run', async (assert, testMetadata) => {
+    const output = `tmp/junit-pass-${randomUUID()}`;
+    try {
+      const result = await shell(
+        `node cli.ts test/fixtures/passing-tests.ts --reporter=junit --output=${output}`,
+        { ...moduleMetadata, ...testMetadata },
+      );
+
+      // TAP is unchanged — it still streams to stdout.
+      assert.tapResult(result, { testCount: 3 });
+      assert.includes(result, 'wrote JUnit report');
+
+      const xml = await fs.readFile(`${output}/junit.xml`, 'utf8');
+      assert.ok(
+        xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>'),
+        'XML declaration present',
+      );
+      assert.ok(
+        /<testsuites name="qunitx" tests="3" failures="0" skipped="0"/.test(xml),
+        'testsuites totals',
+      );
+      assert.equal((xml.match(/<testcase /g) ?? []).length, 3, 'three testcases');
+    } finally {
+      await fs.rm(output, { recursive: true, force: true });
+    }
+  });
+
+  test('records failures as <failure> elements and still exits non-zero', async (assert, testMetadata) => {
+    const output = `tmp/junit-fail-${randomUUID()}`;
+    try {
+      const result = await shellFails(
+        `node cli.ts test/fixtures/failing-tests.ts --reporter=junit --output=${output}`,
+        { ...moduleMetadata, ...testMetadata },
+      );
+      assert.exitCode(result, 1, 'failing run exits 1');
+
+      const xml = await fs.readFile(`${output}/junit.xml`, 'utf8');
+      assert.ok(/<testsuites name="qunitx" tests="4" failures="3"/.test(xml), 'failure count');
+      assert.ok(xml.includes('<failure'), 'failure element present');
+      // Stack in the failure detail is resolved back to the original source file.
+      assert.ok(xml.includes('test/fixtures/failing-tests.ts'), 'source-mapped stack in failure');
+    } finally {
+      await fs.rm(output, { recursive: true, force: true });
+    }
+  });
+
+  test('--junit-output overrides the destination path (nested dirs created)', async (assert, testMetadata) => {
+    const output = `tmp/junit-custom-${randomUUID()}`;
+    const junitPath = `${output}/reports/nested/report.xml`;
+    try {
+      await shell(
+        `node cli.ts test/fixtures/passing-tests.ts --reporter=junit --junit-output=${junitPath} --output=${output}`,
+        { ...moduleMetadata, ...testMetadata },
+      );
+      const xml = await fs.readFile(junitPath, 'utf8');
+      assert.ok(xml.includes('<testsuites'), 'JUnit written to the overridden path');
+      const defaultExists = await fs
+        .stat(`${output}/junit.xml`)
+        .then(() => true)
+        .catch(() => false);
+      assert.notOk(defaultExists, 'default junit.xml is not written when overridden');
+    } finally {
+      await fs.rm(output, { recursive: true, force: true });
+    }
+  });
+
+  test('tap remains the default reporter (no junit.xml without the flag)', async (assert, testMetadata) => {
+    const output = `tmp/junit-none-${randomUUID()}`;
+    try {
+      const result = await shell(`node cli.ts test/fixtures/passing-tests.ts --output=${output}`, {
+        ...moduleMetadata,
+        ...testMetadata,
+      });
+      assert.notIncludes(result, 'wrote JUnit report');
+      const junitExists = await fs
+        .stat(`${output}/junit.xml`)
+        .then(() => true)
+        .catch(() => false);
+      assert.notOk(junitExists, 'no junit.xml by default');
+    } finally {
+      await fs.rm(output, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/flags/reporter-test.ts
+++ b/test/flags/reporter-test.ts
@@ -1,0 +1,100 @@
+import { module, test } from 'qunitx';
+import { randomUUID } from 'node:crypto';
+import '../helpers/custom-asserts.ts';
+import shell, { shellFails } from '../helpers/shell.ts';
+
+module('--reporter', { concurrency: true }, (_hooks, moduleMetadata) => {
+  test('tap is the default: TAP still streams with no flag', async (assert, testMetadata) => {
+    const result = await shell(
+      `node cli.ts test/fixtures/passing-tests.ts --output=tmp/rep-${randomUUID()}`,
+      { ...moduleMetadata, ...testMetadata },
+    );
+    assert.includes(result, 'TAP version 13');
+    assert.tapResult(result, { testCount: 3 });
+  });
+
+  test('an unknown reporter fails fast and lists the valid values', async (assert) => {
+    const result = await shellFails(
+      `node cli.ts test/fixtures/passing-tests.ts --reporter=nope --output=tmp/rep-${randomUUID()}`,
+    );
+    assert.exitCode(result, 1);
+    assert.ok(
+      /Invalid --reporter value: "nope"\. Must be one of: tap, spec/.test(result.stderr ?? ''),
+      'error names the value and the valid set',
+    );
+  });
+
+  test('--reporter with no value is rejected rather than silently defaulting', async (assert) => {
+    const result = await shellFails(
+      `node cli.ts test/fixtures/passing-tests.ts --reporter --output=tmp/rep-${randomUUID()}`,
+    );
+    assert.exitCode(result, 1);
+    assert.ok(/Invalid --reporter value/.test(result.stderr ?? ''), 'empty value is an error');
+  });
+});
+
+module('--reporter=spec', { concurrency: true }, (_hooks, moduleMetadata) => {
+  test('renders module-grouped results and a summary instead of TAP', async (assert, testMetadata) => {
+    const result = await shell(
+      `node cli.ts test/fixtures/passing-tests.ts --reporter=spec --output=tmp/spec-${randomUUID()}`,
+      { ...moduleMetadata, ...testMetadata },
+    );
+
+    assert.outputContains(result, {
+      contains: [
+        'Running 1 test file across 1 worker(s)',
+        '{{moduleName}} Passing Tests',
+        /✔ assert true works \(\d+ms\)/,
+        '3 passing',
+      ],
+      // The stdout format is owned by spec: no TAP syntax, and no TAP `#` comments.
+      notContains: ['TAP version 13', 'ok 1 ', '1..3', '# tests 3', '# QUnitX running'],
+    });
+  });
+
+  test('failures show the source-mapped location inline and exit non-zero', async (assert, testMetadata) => {
+    const result = await shellFails(
+      `node cli.ts test/fixtures/failing-tests.ts --reporter=spec --output=tmp/spec-${randomUUID()}`,
+      { ...moduleMetadata, ...testMetadata },
+    );
+    assert.exitCode(result, 1, 'failing run still exits 1');
+    assert.outputContains(result, {
+      contains: [
+        /✖ deepEqual true works/,
+        'at test/fixtures/failing-tests.ts:',
+        '3 failing',
+        'Failures:',
+      ],
+      notContains: ['not ok 1 ', 'TAP version 13'],
+    });
+  });
+
+  test('skipped and todo tests are marked and counted', async (assert, testMetadata) => {
+    const result = await shell(
+      `node cli.ts test/helpers/skip-todo-tests.ts --reporter=spec --output=tmp/spec-${randomUUID()}`,
+      { ...moduleMetadata, ...testMetadata },
+    );
+    assert.outputContains(result, {
+      contains: ['- skipped test is not executed', '◌ todo test is expected to fail', '1 skipped'],
+    });
+  });
+
+  test('composes with --junit: spec owns stdout, junit.xml is still written', async (assert, testMetadata) => {
+    const output = `tmp/spec-junit-${randomUUID()}`;
+    const result = await shell(
+      `node cli.ts test/fixtures/passing-tests.ts --reporter=spec --junit --output=${output}`,
+      { ...moduleMetadata, ...testMetadata },
+    );
+    assert.outputContains(result, {
+      contains: ['3 passing', 'wrote JUnit report'],
+      notContains: ['TAP version 13'],
+    });
+    const fs = await import('node:fs/promises');
+    try {
+      const xml = await fs.readFile(`${output}/junit.xml`, 'utf8');
+      assert.ok(/<testsuites name="qunitx" tests="3"/.test(xml), 'junit artifact still produced');
+    } finally {
+      await fs.rm(output, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/flags/reporter-test.ts
+++ b/test/flags/reporter-test.ts
@@ -19,7 +19,7 @@ module('--reporter', { concurrency: true }, (_hooks, moduleMetadata) => {
     );
     assert.exitCode(result, 1);
     assert.ok(
-      /Invalid --reporter value: "nope"\. Must be one of: tap, spec/.test(result.stderr ?? ''),
+      /Invalid --reporter value: "nope"\. Must be one of: tap, spec, dot/.test(result.stderr ?? ''),
       'error names the value and the valid set',
     );
   });
@@ -83,6 +83,64 @@ module('--reporter=spec', { concurrency: true }, (_hooks, moduleMetadata) => {
     const output = `tmp/spec-junit-${randomUUID()}`;
     const result = await shell(
       `node cli.ts test/fixtures/passing-tests.ts --reporter=spec --junit --output=${output}`,
+      { ...moduleMetadata, ...testMetadata },
+    );
+    assert.outputContains(result, {
+      contains: ['3 passing', 'wrote JUnit report'],
+      notContains: ['TAP version 13'],
+    });
+    const fs = await import('node:fs/promises');
+    try {
+      const xml = await fs.readFile(`${output}/junit.xml`, 'utf8');
+      assert.ok(/<testsuites name="qunitx" tests="3"/.test(xml), 'junit artifact still produced');
+    } finally {
+      await fs.rm(output, { recursive: true, force: true });
+    }
+  });
+});
+
+// These assert dot's wiring, not its layout. The matrix is the one piece of output that leaves
+// its line open, so anything else the run prints lands on it: browser console warnings are
+// forwarded to stdout unconditionally (browser.ts `alwaysShow`) and arrive asynchronously —
+// Firefox emits one from the bundle on every run, so the matrix line legitimately reads
+// `...[JavaScript Warning: …]`, and under load the dots can split across lines. That's inherent
+// to a one-char-per-test format (mocha/vitest included). Exact marks, per-status characters and
+// 72-column wrapping are pinned deterministically in test/reporter/dot-test.ts, which owns
+// stdout and can assert them exactly.
+module('--reporter=dot', { concurrency: true }, (_hooks, moduleMetadata) => {
+  test('reports a run through the dot summary rather than TAP', async (assert, testMetadata) => {
+    const result = await shell(
+      `node cli.ts test/fixtures/passing-tests.ts --reporter=dot --output=tmp/dot-${randomUUID()}`,
+      { ...moduleMetadata, ...testMetadata },
+    );
+    assert.outputContains(result, {
+      contains: ['Running 1 test file across 1 worker(s)', '3 passing'],
+      notContains: ['TAP version 13', 'ok 1 ', '1..3', '# QUnitX running'],
+    });
+  });
+
+  test('failures are counted and detailed at the end', async (assert, testMetadata) => {
+    const result = await shellFails(
+      `node cli.ts test/fixtures/failing-tests.ts --reporter=dot --output=tmp/dot-${randomUUID()}`,
+      { ...moduleMetadata, ...testMetadata },
+    );
+    assert.exitCode(result, 1, 'failing run still exits 1');
+    assert.outputContains(result, {
+      contains: [
+        '1 passing',
+        '3 failing',
+        'Failures:',
+        '1) {{moduleName}} Failing Tests | async test finishes',
+        'at test/fixtures/failing-tests.ts:',
+      ],
+      notContains: ['not ok 1 ', 'TAP version 13'],
+    });
+  });
+
+  test('composes with --junit: dot owns stdout, junit.xml is still written', async (assert, testMetadata) => {
+    const output = `tmp/dot-junit-${randomUUID()}`;
+    const result = await shell(
+      `node cli.ts test/fixtures/passing-tests.ts --reporter=dot --junit --output=${output}`,
       { ...moduleMetadata, ...testMetadata },
     );
     assert.outputContains(result, {

--- a/test/flags/reporter-test.ts
+++ b/test/flags/reporter-test.ts
@@ -19,7 +19,9 @@ module('--reporter', { concurrency: true }, (_hooks, moduleMetadata) => {
     );
     assert.exitCode(result, 1);
     assert.ok(
-      /Invalid --reporter value: "nope"\. Must be one of: tap, spec, dot/.test(result.stderr ?? ''),
+      /Invalid --reporter value: "nope"\. Must be one of: tap, spec, dot, github/.test(
+        result.stderr ?? '',
+      ),
       'error names the value and the valid set',
     );
   });
@@ -154,5 +156,36 @@ module('--reporter=dot', { concurrency: true }, (_hooks, moduleMetadata) => {
     } finally {
       await fs.rm(output, { recursive: true, force: true });
     }
+  });
+});
+
+module('--reporter=github', { concurrency: true }, (_hooks, moduleMetadata) => {
+  test('annotates failures at their original source line, on top of spec output', async (assert, testMetadata) => {
+    const result = await shellFails(
+      `node cli.ts test/fixtures/failing-tests.ts --reporter=github --output=tmp/gh-${randomUUID()}`,
+      { ...moduleMetadata, ...testMetadata },
+    );
+    assert.exitCode(result, 1, 'failing run still exits 1');
+    assert.outputContains(result, {
+      contains: [
+        // Annotation points at the original .ts source, not the bundle — the source map is
+        // already resolved by the shared failure descriptor.
+        /::error file=test\/fixtures\/failing-tests\.ts,line=\d+,col=\d+,title=/,
+        '3 failing', // spec output is still there
+        /✖ deepEqual true works/,
+      ],
+      notContains: ['TAP version 13'],
+    });
+  });
+
+  test('a passing run emits no annotations', async (assert, testMetadata) => {
+    const result = await shell(
+      `node cli.ts test/fixtures/passing-tests.ts --reporter=github --output=tmp/gh-${randomUUID()}`,
+      { ...moduleMetadata, ...testMetadata },
+    );
+    assert.outputContains(result, {
+      contains: ['3 passing'],
+      notContains: ['::error'],
+    });
   });
 });

--- a/test/helpers/deno-test-timeout.ts
+++ b/test/helpers/deno-test-timeout.ts
@@ -1,0 +1,83 @@
+/**
+ * Per-test deadline for the deno lane, injected via `deno test --preload`.
+ *
+ * The node lane passes `--test-timeout`, so a hung test fails by name and the worker moves on.
+ * Deno has no equivalent flag (still absent as of 2.9) and no per-test timeout in `Deno.test`
+ * options, so before this a hang consumed the entire GHA job — 25 minutes, cancelled, with no
+ * indication of *which* test was stuck beyond deno's "has been running for over (16m0s)"
+ * warnings. `--preload` runs before the main module in every test worker, which is the one hook
+ * available to wrap `Deno.test` and race each test against a deadline.
+ *
+ * Scope: this bounds test functions. A hang at module top-level, or between tests, is still on
+ * the job-level timeout — the runner's outer net.
+ *
+ * `Deno.test.ignore` / `.only` are copied through unwrapped: `ignore` never executes, and
+ * `only` is a local debugging affordance that never reaches CI.
+ */
+
+import { PER_TEST_TIMEOUT_MS } from './per-test-timeout.ts';
+
+type TestFn = (...args: unknown[]) => unknown;
+type TestOptions = { name?: string; fn?: TestFn };
+
+const originalTest = Deno.test;
+const register = originalTest.bind(Deno) as (...args: unknown[]) => unknown;
+
+/**
+ * Wraps a test fn so it rejects at the deadline instead of hanging forever. The rejection is
+ * what deno's reporter turns into a normal named failure, letting the rest of the file run.
+ */
+function withDeadline(name: string, fn: TestFn): TestFn {
+  return async function (this: unknown, ...args: unknown[]) {
+    let timer: number | undefined;
+    try {
+      return await Promise.race([
+        (async () => await fn.apply(this, args))(),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`qunitx: test exceeded ${PER_TEST_TIMEOUT_MS}ms — ${name}`)),
+            PER_TEST_TIMEOUT_MS,
+          );
+        }),
+      ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  };
+}
+
+/**
+ * Re-dispatches every `Deno.test` overload with the test fn wrapped:
+ * `(fn)`, `(name, fn)`, `(options)`, `(options, fn)`, `(name, options, fn)`.
+ * qunitx itself uses `(options)` with `options.fn`; the rest are covered so a hand-written
+ * `Deno.test` in this repo is bounded too. Anything unrecognised passes straight through —
+ * an unbounded test beats a harness that throws on a shape we didn't anticipate.
+ */
+function wrappedTest(...args: unknown[]): unknown {
+  const [first, second, third] = args;
+
+  if (typeof first === 'function') {
+    return register(withDeadline(first.name || 'anonymous', first as TestFn));
+  }
+  if (typeof first === 'string' && typeof second === 'function') {
+    return register(first, withDeadline(first, second as TestFn));
+  }
+  if (typeof first === 'string' && typeof third === 'function') {
+    return register(first, second, withDeadline(first, third as TestFn));
+  }
+  if (typeof first === 'object' && first !== null) {
+    const options = first as TestOptions;
+    const name = options.name ?? 'anonymous';
+    if (typeof second === 'function') {
+      return register(options, withDeadline(name, second as TestFn));
+    }
+    if (typeof options.fn === 'function') {
+      return register({ ...options, fn: withDeadline(name, options.fn) });
+    }
+  }
+  return register(...args);
+}
+
+// Carry over `ignore`/`only`/etc. so the namespace keeps its full surface.
+Object.assign(wrappedTest, originalTest);
+Deno.test = wrappedTest as unknown as typeof Deno.test;

--- a/test/helpers/per-test-timeout.ts
+++ b/test/helpers/per-test-timeout.ts
@@ -1,0 +1,25 @@
+/**
+ * The per-test deadline, shared by both lanes so a hung test costs the same wherever it runs.
+ *
+ * Node consumes it as `node --test --test-timeout=N`: node:test fails any test whose runtime
+ * exceeds this and force-completes its subtests, so a hung test surfaces by name in the spec
+ * output and the worker moves on cleanly — no zombies, no SIGKILL hammer, no whole-phase loss.
+ * Deno has no equivalent flag, so `test/helpers/deno-test-timeout.ts` enforces the same number
+ * by wrapping `Deno.test`. Both import this module rather than passing the value around: a
+ * second copy of the literal is exactly how the two lanes would drift apart unnoticed.
+ *
+ * Sized to comfortably exceed the slowest observed healthy test. Watch-rerun tests are the long
+ * tail: per-test wall clock has been observed up to 120 s on slow CI runners under contention
+ * (Windows + concurrent Chrome launches). Daemon tests' rapid-stop+start used to peak at 120 s
+ * pre-leak-fix; current healthy max is ~15 s. 300 s = 5 min ≈ 2.5× the observed slow tail leaves
+ * room for the runner's natural tail variance without misfiring on real-but-slow runs. Anything
+ * past 5 min is genuinely stuck.
+ *
+ * Below this the per-call `DEFAULT_EXEC_TIMEOUT_MS = 180_000` in test/helpers/shell.ts cuts off
+ * individual cli invocations; this is the outer safety net for the test itself.
+ *
+ * Above this, GitHub Actions' job-level `timeout-minutes` (15 on ubuntu, 25 on macos/windows in
+ * ci.yml) is the ultimate fallback for anything neither lane's deadline can see — a hang at
+ * module top-level, or between tests, rather than inside a test fn.
+ */
+export const PER_TEST_TIMEOUT_MS = 300_000;

--- a/test/helpers/runner-registry.ts
+++ b/test/helpers/runner-registry.ts
@@ -1,0 +1,181 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+/**
+ * Lets several test runners share one checkout.
+ *
+ * test/runner.ts wipes tmp/ at startup, and tmp/ holds everything the suite depends on:
+ * fixtures, per-run `--output` dirs, perf/junit artifacts. A second runner therefore used to
+ * delete the first's world mid-run — and the damage landed on the *innocent* run, as scattered
+ * ENOENT failures on files that existed moments earlier, while the culprit exited 0.
+ *
+ * Everything else about concurrent runners is already safe: fixtures and `--output` dirs are
+ * uuid-scoped, `--only-failed` tests give each project its own cwd (so their failure caches are
+ * isolated), and the semaphore port travels by env rather than a shared file. The wipe was the
+ * whole problem, so only the wipe is coordinated:
+ *
+ *   acquire mutex          (held for the wipe, not the run — nobody waits on anyone's tests)
+ *     no other live runner → wipe tmp/       (the solo case: identical to before)
+ *     otherwise            → skip the wipe   (nobody's world gets deleted)
+ *     register self
+ *   release mutex
+ *
+ * The mutex is what makes "am I alone?" and the wipe atomic: without it a runner could decide
+ * it was alone and start wiping at the exact moment another began creating files. Latecomers
+ * block only until the wipe finishes.
+ *
+ * Trade-off: while two runners are live nobody wipes, so tmp/ accrues garbage until the next
+ * solo run cleans it. tmp/ is gitignored and the wipe is hygiene, so this self-heals.
+ *
+ * Liveness is by pid, never by age: `npm run dev` holds a registration for as long as watch
+ * mode runs, so any age cutoff would eventually ignore a healthy runner. A crash leaves a dead
+ * entry that the next join reaps.
+ */
+
+const CACHE_DIR = path.resolve('node_modules/.cache/qunitx');
+const DEFAULT_REGISTRY_DIR = path.join(CACHE_DIR, 'runners');
+
+/** How long to wait for the wipe mutex before giving up and skipping the wipe. */
+const MUTEX_WAIT_MS = 60_000;
+const MUTEX_POLL_MS = 20;
+
+/** A live runner's registry entry. */
+export interface RunnerEntry {
+  /** OS pid; liveness of this pid is what makes the entry count. */
+  pid: number;
+  /** Epoch ms the runner joined. Diagnostics only — never used to judge liveness. */
+  startedAt: number;
+}
+
+/** Handle for this runner's membership in the registry. */
+export interface RunnerHandle {
+  /** Unique per live runner; scopes artifact filenames so concurrent runs don't clobber. */
+  runId: string;
+  /** True when this runner was alone at startup and therefore wiped tmp/. */
+  wasSolo: boolean;
+  /** Removes this runner's entry. */
+  release: () => Promise<void>;
+}
+
+/**
+ * Joins the registry, running `onSolo` (the tmp/ wipe) only if no other runner is live — and
+ * only while the mutex is held, so no one else can be mid-startup when it happens. `onSolo` may
+ * be sync or async; it is awaited either way.
+ */
+export async function joinRunnerRegistry(
+  onSolo: () => void | Promise<void>,
+  registryDir: string = DEFAULT_REGISTRY_DIR,
+): Promise<RunnerHandle> {
+  await fs.mkdir(registryDir, { recursive: true });
+  const entryPath = path.join(registryDir, String(process.pid));
+  const mutexPath = `${registryDir}.lock`;
+
+  const releaseMutex = await acquireMutex(mutexPath);
+  let wasSolo = false;
+  try {
+    wasSolo = (await liveRunners(registryDir)).length === 0;
+    // Skipping the wipe is always safe; wiping while someone else runs is the bug. So when the
+    // mutex could not be taken (releaseMutex === null) we simply don't wipe.
+    if (wasSolo && releaseMutex) await onSolo();
+    await fs.writeFile(entryPath, JSON.stringify({ pid: process.pid, startedAt: Date.now() }));
+  } finally {
+    await releaseMutex?.();
+  }
+
+  return {
+    runId: String(process.pid),
+    wasSolo,
+    release: () => fs.unlink(entryPath).catch(() => {}),
+  };
+}
+
+/**
+ * Live runners other than us, reaping entries whose pid is gone. A crashed runner must not make
+ * every later run think it has company and skip the wipe forever.
+ */
+export async function liveRunners(
+  registryDir: string = DEFAULT_REGISTRY_DIR,
+): Promise<RunnerEntry[]> {
+  const names = await fs.readdir(registryDir).catch(() => [] as string[]);
+  const live: RunnerEntry[] = [];
+  for (const name of names) {
+    const entryPath = path.join(registryDir, name);
+    const entry = await readEntry(entryPath);
+    if (!entry || entry.pid === process.pid) continue;
+    if (isAlive(entry.pid)) live.push(entry);
+    else await fs.unlink(entryPath).catch(() => {});
+  }
+  return live;
+}
+
+/**
+ * Takes the wipe mutex, waiting rather than refusing: it is held only for the wipe, so the wait
+ * is bounded by that. Returns null if it could not be taken in time — the caller then skips the
+ * wipe rather than doing it unprotected. A dead holder's mutex is reclaimed immediately.
+ */
+async function acquireMutex(mutexPath: string): Promise<(() => Promise<void>) | null> {
+  const deadline = Date.now() + MUTEX_WAIT_MS;
+  for (;;) {
+    if (await publish(mutexPath, { pid: process.pid, startedAt: Date.now() })) {
+      return () => releaseIfOwner(mutexPath);
+    }
+    const holder = await readEntry(mutexPath);
+    if (!holder || !isAlive(holder.pid)) {
+      await fs.unlink(mutexPath).catch(() => {});
+      continue;
+    }
+    if (Date.now() >= deadline) return null;
+    await sleep(MUTEX_POLL_MS);
+  }
+}
+
+/**
+ * Publishes atomically: write a temp file, then hardlink it into place. `link` either succeeds
+ * or fails EEXIST, and the content is already on disk when the name appears — unlike
+ * `writeFile(…, { flag: 'wx' })`, where the create is atomic but the write lands microseconds
+ * later, so a contender can read an empty file, parse pid as NaN, call it stale, and steal a
+ * *live* lock. (Same reasoning as `tryAcquireDaemonLock` in lib/commands/daemon/server.ts.)
+ */
+async function publish(lockPath: string, entry: RunnerEntry): Promise<boolean> {
+  const tmpPath = `${lockPath}.${process.pid}.tmp`;
+  await fs.writeFile(tmpPath, JSON.stringify(entry));
+  try {
+    await fs.link(tmpPath, lockPath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    return false;
+  } finally {
+    // Drop our second reference; on success the lock's own name keeps the inode alive.
+    await fs.unlink(tmpPath).catch(() => {});
+  }
+}
+
+async function readEntry(entryPath: string): Promise<RunnerEntry | null> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(entryPath, 'utf8')) as Partial<RunnerEntry>;
+    return typeof parsed.pid === 'number' && typeof parsed.startedAt === 'number'
+      ? (parsed as RunnerEntry)
+      : null;
+  } catch {
+    return null; // missing, torn, or written by an incompatible version
+  }
+}
+
+// EPERM means the pid exists under another user — alive, just not ours to signal.
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+// Only ever remove our own lock: a late release must not clear one someone else now holds.
+async function releaseIfOwner(lockPath: string): Promise<void> {
+  if ((await readEntry(lockPath))?.pid !== process.pid) return;
+  await fs.unlink(lockPath).catch(() => {});
+}

--- a/test/helpers/test-worker-preload.ts
+++ b/test/helpers/test-worker-preload.ts
@@ -1,6 +1,6 @@
 // Side-effect module imported via `node --import` into every test-worker process
-// (see test/runner.ts spawnTests). Two responsibilities, both observability-only —
-// nothing here changes test behaviour:
+// (see test/runner.ts spawnTests). Three responsibilities — (1) and (2) are
+// observability-only and change no test behaviour; (3) is worker teardown:
 //
 // 1. Widens util.inspect defaults so node:test's spec-reporter shows full
 //    assertion actuals instead of `[Object]` / truncated `'...'`.
@@ -15,7 +15,11 @@
 //    With it: every process.exit(non-zero), uncaughtException, and
 //    unhandledRejection is annotated with `# [worker-preload] ...` + stack
 //    so the surrounding context survives to the CI job stream.
+//
+// 3. Stops esbuild's service process once a worker's tests finish, so the worker
+//    can exit on its own (see the hook below).
 
+import { after } from 'node:test';
 import { inspect } from 'node:util';
 
 const o = inspect.defaultOptions;
@@ -23,6 +27,15 @@ o.breakLength = 240;
 o.depth = Infinity;
 o.maxStringLength = Infinity;
 o.maxArrayLength = Infinity;
+
+// esbuild keeps one long-lived `--service` child per process, ref'd along with its two
+// stdio sockets, so any worker that touched the esbuild API in-process never exits on its
+// own — the real "post-test hang" that --test-force-exit papered over at the cost of
+// killing workers mid-report. Lazy import: stop() no-ops if the service never started.
+after(async () => {
+  const { stop } = await import('esbuild');
+  await stop();
+});
 
 // process.stderr.write is synchronous when wired to a pipe/tty (the case under
 // node --test with stdio:'inherit'), so the diagnostic flushes before the

--- a/test/reporter/dot-test.ts
+++ b/test/reporter/dot-test.ts
@@ -1,0 +1,155 @@
+import { module, test } from 'qunitx';
+import { DotReporter } from '../../lib/reporter/dot.ts';
+import { updateCounter } from '../../lib/reporter/types.ts';
+import type { TestDetails } from '../../lib/reporter/types.ts';
+import type { Config } from '../../lib/types.ts';
+import '../helpers/custom-asserts.ts';
+import { captureStdout } from '../helpers/capture-stdout.ts';
+
+// Colors are disabled in a non-TTY (see lib/utils/color.ts), so these match plain characters.
+const makeConfig = (): Config =>
+  ({
+    projectRoot: '/proj',
+    reporter: 'dot',
+    COUNTER: {
+      testCount: 0,
+      failCount: 0,
+      skipCount: 0,
+      todoCount: 0,
+      passCount: 0,
+      errorCount: 0,
+    },
+  }) as unknown as Config;
+
+const feed = (reporter: DotReporter, config: Config, details: TestDetails): string =>
+  captureStdout(() => {
+    updateCounter(config.COUNTER, details);
+    reporter.onTestEnd(config, details);
+  });
+
+const passing = (name = 't'): TestDetails => ({
+  status: 'passed',
+  fullName: ['Mod', name],
+  runtime: 1,
+  assertions: [],
+});
+
+const failing = (name = 'bad'): TestDetails => ({
+  status: 'failed',
+  fullName: ['Mod', name],
+  runtime: 2,
+  assertions: [{ passed: false, todo: false, actual: 1, expected: 2, message: 'nope' }],
+});
+
+module('reporters | DotReporter', { concurrency: true }, () => {
+  test('emits one character per test, by status', (assert) => {
+    const config = makeConfig();
+    const reporter = new DotReporter();
+    assert.strictEqual(feed(reporter, config, passing()), '.', 'pass is a dot');
+    assert.strictEqual(feed(reporter, config, failing()), 'F', 'fail is F');
+    assert.strictEqual(
+      feed(reporter, config, { status: 'skipped', fullName: ['Mod', 's'], runtime: 0 }),
+      's',
+      'skip is s',
+    );
+    assert.strictEqual(
+      feed(reporter, config, { status: 'todo', fullName: ['Mod', 'w'], runtime: 0 }),
+      't',
+      'todo is t',
+    );
+  });
+
+  test('failure detail is buffered, not printed inline (keeps the matrix intact)', (assert) => {
+    const output = feed(new DotReporter(), makeConfig(), failing());
+    assert.strictEqual(output, 'F', 'no failure block interleaved with the dots');
+  });
+
+  test('wraps the matrix at 72 columns', (assert) => {
+    const config = makeConfig();
+    const reporter = new DotReporter();
+    let output = '';
+    for (let i = 0; i < 73; i++) output += feed(reporter, config, passing(`t${i}`));
+
+    const lines = output.split('\n');
+    assert.strictEqual(lines.length, 2, 'wrapped onto a second line');
+    assert.strictEqual(lines[0].length, 72, 'first line holds exactly 72 dots');
+    assert.strictEqual(lines[1], '.', '73rd dot starts the next line');
+  });
+
+  test('summary lists failures with their detail and location', (assert) => {
+    const config = makeConfig();
+    const reporter = new DotReporter();
+    reporter.onRunStart(config, { fileCount: null, groupCount: null });
+    feed(reporter, config, passing());
+    feed(
+      reporter,
+      config,
+      Object.assign(failing('divides'), {
+        assertions: [
+          {
+            passed: false,
+            todo: false,
+            actual: 3,
+            expected: 4,
+            message: 'sum should be 4',
+            stack: '    at Object.<anonymous> (http://localhost:1234/tests.js:10:5)',
+          },
+        ],
+      }),
+    );
+
+    const output = captureStdout(() => reporter.onRunEnd(config, { durationMs: 99 }));
+    assert.includes(output, '1 passing (99ms)');
+    assert.includes(output, '1 failing');
+    assert.includes(output, 'Failures:');
+    assert.includes(output, '1) Mod | divides');
+    assert.includes(output, 'sum should be 4', 'failure detail is shown at the end');
+    assert.includes(output, 'at http://localhost:1234/tests.js:10:5', 'location is shown');
+  });
+
+  test('a clean run prints no failure section', (assert) => {
+    const config = makeConfig();
+    const reporter = new DotReporter();
+    reporter.onRunStart(config, { fileCount: null, groupCount: null });
+    feed(reporter, config, passing());
+    const output = captureStdout(() => reporter.onRunEnd(config, { durationMs: 5 }));
+    assert.notIncludes(output, 'Failures:');
+    assert.notIncludes(output, 'skipped', 'zero-count categories omitted');
+  });
+
+  test('onRunStart resets the column and failures for watch reruns', (assert) => {
+    const config = makeConfig();
+    const reporter = new DotReporter();
+    feed(reporter, config, failing());
+
+    const rerun = makeConfig();
+    reporter.onRunStart(rerun, { fileCount: null, groupCount: null });
+    feed(reporter, rerun, passing());
+    const output = captureStdout(() => reporter.onRunEnd(rerun, { durationMs: 5 }));
+    assert.notIncludes(output, 'Failures:', 'previous run failures are not carried over');
+  });
+
+  test('run start announces counts; the empty case says so', (assert) => {
+    const config = makeConfig();
+    assert.includes(
+      captureStdout(() => new DotReporter().onRunStart(config, { fileCount: 2, groupCount: 2 })),
+      'Running 2 test files across 2 worker(s)',
+    );
+    assert.includes(
+      captureStdout(() => new DotReporter().onRunStart(config, { fileCount: 0, groupCount: 0 })),
+      'No test files found.',
+    );
+  });
+
+  test('never emits TAP syntax', (assert) => {
+    const config = makeConfig();
+    const reporter = new DotReporter();
+    const output =
+      captureStdout(() => reporter.onRunStart(config, { fileCount: 1, groupCount: 1 })) +
+      feed(reporter, config, passing()) +
+      captureStdout(() => reporter.onRunEnd(config, { durationMs: 1 }));
+    assert.notIncludes(output, 'TAP version 13');
+    assert.notIncludes(output, 'ok 1');
+    assert.notIncludes(output, '1..');
+  });
+});

--- a/test/reporter/failure-test.ts
+++ b/test/reporter/failure-test.ts
@@ -1,0 +1,121 @@
+import { module, test } from 'qunitx';
+import { extractStackAt, failedAssertions, parseAt } from '../../lib/reporter/failure.ts';
+
+module('reporters | extractStackAt', { concurrency: true }, () => {
+  test('Chrome style: extracts clean URL without parens', (assert) => {
+    const stack =
+      '    at Object.<anonymous> (http://localhost:1234/tests.js:42:15)\n    at test (http://localhost:1234/tests.js:10:3)';
+    assert.strictEqual(extractStackAt(stack), 'http://localhost:1234/tests.js:42:15');
+  });
+
+  test('Chrome style: strips file:// prefix from local paths', (assert) => {
+    const stack = '    at Object.<anonymous> (file:///home/user/project/tests.js:42:15)';
+    assert.strictEqual(extractStackAt(stack), '/home/user/project/tests.js:42:15');
+  });
+
+  test('Firefox/WebKit style: extracts URL after @', (assert) => {
+    const stack =
+      'Object.prototype.<anonymous>@http://localhost:1234/tests.js:42:15\n@http://localhost:1234/tests.js:10:3';
+    assert.strictEqual(extractStackAt(stack), 'http://localhost:1234/tests.js:42:15');
+  });
+
+  test('returns null for null', (assert) => {
+    assert.strictEqual(extractStackAt(null), null);
+  });
+
+  test('returns null for empty string', (assert) => {
+    assert.strictEqual(extractStackAt(''), null);
+  });
+
+  test('returns null for plain error message with no location', (assert) => {
+    assert.strictEqual(extractStackAt('Error: something went wrong'), null);
+  });
+});
+
+module('reporters | parseAt', { concurrency: true }, () => {
+  test('splits path:line:col', (assert) => {
+    assert.deepEqual(parseAt('src/app.ts:12:5'), { file: 'src/app.ts', line: 12, col: 5 });
+  });
+
+  test('keeps colons inside the path (e.g. a URL with a port)', (assert) => {
+    assert.deepEqual(parseAt('http://localhost:1234/tests.js:42:15'), {
+      file: 'http://localhost:1234/tests.js',
+      line: 42,
+      col: 15,
+    });
+  });
+
+  test('returns null for null or a non-location string', (assert) => {
+    assert.strictEqual(parseAt(null), null);
+    assert.strictEqual(parseAt('nope'), null);
+  });
+});
+
+module('reporters | failedAssertions', { concurrency: true }, () => {
+  test('returns only genuine failures, with 1-based indexes matching assertion order', (assert) => {
+    const failures = failedAssertions({
+      status: 'failed',
+      fullName: ['m', 't'],
+      runtime: 1,
+      assertions: [
+        { passed: true, todo: false, actual: 1, expected: 1 },
+        { passed: false, todo: true, actual: 2, expected: 3 },
+        { passed: false, todo: false, actual: 4, expected: 5, message: 'boom' },
+      ],
+    });
+    assert.strictEqual(failures.length, 1, 'passing and todo assertions are excluded');
+    assert.strictEqual(failures[0].index, 3, 'index reflects position in the original list');
+    assert.strictEqual(failures[0].message, 'boom');
+    assert.strictEqual(failures[0].actual, 4);
+    assert.strictEqual(failures[0].expected, 5);
+  });
+
+  test('without a decoder, at falls back to the raw stack location', (assert) => {
+    const failures = failedAssertions({
+      status: 'failed',
+      fullName: ['m', 't'],
+      runtime: 1,
+      assertions: [
+        {
+          passed: false,
+          todo: false,
+          actual: false,
+          expected: true,
+          stack: '    at Object.<anonymous> (http://localhost:1234/tests.js:42:15)',
+        },
+      ],
+    });
+    assert.strictEqual(failures[0].at, 'http://localhost:1234/tests.js:42:15');
+    assert.strictEqual(failures[0].source, null, 'no source text without a decoder');
+  });
+
+  test('empty message becomes null rather than an empty string', (assert) => {
+    const failures = failedAssertions({
+      status: 'failed',
+      fullName: ['m', 't'],
+      runtime: 1,
+      assertions: [{ passed: false, todo: false, actual: 1, expected: 2, message: '' }],
+    });
+    assert.strictEqual(failures[0].message, null);
+  });
+
+  test('circular actual/expected values are normalized rather than thrown on', (assert) => {
+    const circular: Record<string, unknown> = { name: 'root' };
+    circular.self = circular;
+    const failures = failedAssertions({
+      status: 'failed',
+      fullName: ['m', 't'],
+      runtime: 1,
+      assertions: [{ passed: false, todo: false, actual: circular, expected: true }],
+    });
+    assert.deepEqual(
+      failures[0].actual,
+      { name: 'root', self: '[Circular]' },
+      'circular refs collapse to [Circular]',
+    );
+  });
+
+  test('a test with no assertions array yields no failures', (assert) => {
+    assert.deepEqual(failedAssertions({ status: 'failed', fullName: ['m', 't'], runtime: 1 }), []);
+  });
+});

--- a/test/reporter/github-test.ts
+++ b/test/reporter/github-test.ts
@@ -1,0 +1,158 @@
+import { module, test } from 'qunitx';
+import { GithubReporter, annotation } from '../../lib/reporter/github.ts';
+import { updateCounter } from '../../lib/reporter/types.ts';
+import type { FailureInfo } from '../../lib/reporter/failure.ts';
+import type { TestDetails } from '../../lib/reporter/types.ts';
+import type { Config } from '../../lib/types.ts';
+import '../helpers/custom-asserts.ts';
+import { captureStdout } from '../helpers/capture-stdout.ts';
+
+const makeConfig = (): Config =>
+  ({
+    projectRoot: '/proj',
+    reporter: 'github',
+    COUNTER: {
+      testCount: 0,
+      failCount: 0,
+      skipCount: 0,
+      todoCount: 0,
+      passCount: 0,
+      errorCount: 0,
+    },
+  }) as unknown as Config;
+
+const failure = (overrides: Partial<FailureInfo> = {}): FailureInfo => ({
+  index: 1,
+  message: 'boom',
+  actual: 3,
+  expected: 4,
+  stack: null,
+  at: 'src/app.ts:12:5',
+  source: null,
+  ...overrides,
+});
+
+module('reporters | github annotation', { concurrency: true }, () => {
+  test('emits ::error with file, line, col and title', (assert) => {
+    const output = annotation('Math | adds', failure());
+    assert.true(
+      output.startsWith('::error file=src/app.ts,line=12,col=5,title=Math | adds::'),
+      `unexpected annotation: ${output}`,
+    );
+    assert.includes(output, 'boom');
+  });
+
+  test('includes expected/actual in the message', (assert) => {
+    const output = annotation('t', failure());
+    assert.includes(output, 'expected: 4');
+    assert.includes(output, 'actual:   3');
+  });
+
+  test('newlines are escaped so the command is not truncated', (assert) => {
+    const output = annotation('t', failure({ message: 'line one\nline two' }));
+    assert.includes(output, 'line one%0Aline two', 'newline becomes %0A');
+    assert.strictEqual(output.split('\n').length, 1, 'annotation stays on a single line');
+  });
+
+  test('percent and carriage return are escaped in the message', (assert) => {
+    const output = annotation(
+      't',
+      failure({ message: '100% done\rx', actual: undefined, expected: undefined }),
+    );
+    assert.includes(output, '100%25 done%0Dx');
+  });
+
+  test('property values escape the command delimiters : and ,', (assert) => {
+    // A URL location is the realistic case: it contains colons that would otherwise be read
+    // as property separators.
+    const output = annotation('a, b: c', failure({ at: null }));
+    assert.includes(output, 'title=a%2C b%3A c', 'comma and colon escaped in the title');
+  });
+
+  test('omits location properties when the failure has no resolvable location', (assert) => {
+    const output = annotation('t', failure({ at: null }));
+    assert.notIncludes(output, 'file=');
+    assert.notIncludes(output, 'line=');
+    assert.true(output.startsWith('::error title=t::'), `unexpected: ${output}`);
+  });
+
+  test('falls back to an assertion label when there is no message', (assert) => {
+    const output = annotation('t', failure({ message: null, index: 3 }));
+    assert.includes(output, 'Assertion #3 failed');
+  });
+
+  test('omits the values block when neither actual nor expected is present', (assert) => {
+    const output = annotation('t', failure({ actual: undefined, expected: undefined }));
+    assert.notIncludes(output, 'expected:');
+    assert.notIncludes(output, 'actual:');
+  });
+});
+
+module('reporters | GithubReporter', { concurrency: true }, () => {
+  const feed = (reporter: GithubReporter, config: Config, details: TestDetails): string =>
+    captureStdout(() => {
+      updateCounter(config.COUNTER, details);
+      reporter.onTestEnd(config, details);
+    });
+
+  test('passing tests render like spec and emit no annotation', (assert) => {
+    const output = feed(new GithubReporter(), makeConfig(), {
+      status: 'passed',
+      fullName: ['Math', 'adds'],
+      runtime: 2,
+      assertions: [],
+    });
+    assert.includes(output, '✔ adds (2ms)', 'spec output is preserved');
+    assert.notIncludes(output, '::error', 'no annotation for a passing test');
+  });
+
+  test('a failing test emits spec output plus one annotation per failing assertion', (assert) => {
+    const output = feed(new GithubReporter(), makeConfig(), {
+      status: 'failed',
+      fullName: ['Math', 'adds'],
+      runtime: 2,
+      assertions: [
+        {
+          passed: false,
+          todo: false,
+          actual: 1,
+          expected: 2,
+          message: 'first',
+          stack: '    at Object.<anonymous> (http://localhost:1234/tests.js:5:1)',
+        },
+        { passed: true, todo: false, actual: 1, expected: 1 },
+        { passed: false, todo: false, actual: 3, expected: 4, message: 'second' },
+      ],
+    });
+    assert.includes(output, '✖ adds (2ms)', 'spec line still printed');
+    assert.strictEqual(
+      (output.match(/::error /g) ?? []).length,
+      2,
+      'one annotation per failing assertion (passing one excluded)',
+    );
+    assert.includes(output, 'title=Math | adds');
+  });
+
+  test('skipped tests emit no annotation', (assert) => {
+    const output = feed(new GithubReporter(), makeConfig(), {
+      status: 'skipped',
+      fullName: ['Math', 'later'],
+      runtime: 0,
+    });
+    assert.notIncludes(output, '::error');
+  });
+
+  test('delegates run start and run end to the spec renderer', (assert) => {
+    const config = makeConfig();
+    const reporter = new GithubReporter();
+    assert.includes(
+      captureStdout(() => reporter.onRunStart(config, { fileCount: 1, groupCount: 1 })),
+      'Running 1 test file across 1 worker(s)',
+    );
+    feed(reporter, config, { status: 'passed', fullName: ['M', 't'], runtime: 1, assertions: [] });
+    assert.includes(
+      captureStdout(() => reporter.onRunEnd(config, { durationMs: 7 })),
+      '1 passing (7ms)',
+    );
+  });
+});

--- a/test/reporter/junit-test.ts
+++ b/test/reporter/junit-test.ts
@@ -1,0 +1,77 @@
+import { module, test } from 'qunitx';
+import { buildJUnitXML } from '../../lib/reporter/junit.ts';
+import type { JUnitCase } from '../../lib/types.ts';
+
+module('reporters | buildJUnitXML', { concurrency: true }, () => {
+  const cases: JUnitCase[] = [
+    { classname: 'Math', name: 'adds', time: 0.003, status: 'passed' },
+    { classname: 'Math', name: 'divides', time: 0.5, status: 'passed' },
+    {
+      classname: 'Strings',
+      name: 'reverses',
+      time: 0.01,
+      status: 'failed',
+      failureMessage: 'expected "cba"',
+      failureDetail: 'expected "cba" but got "abc"\nat src/strings.ts:4:2',
+    },
+    { classname: 'Strings', name: 'todo item', time: 0, status: 'todo' },
+    { classname: 'Strings', name: 'skipped item', time: 0, status: 'skipped' },
+  ];
+
+  test('emits an XML declaration and a testsuites root with rolled-up totals', (assert) => {
+    const xml = buildJUnitXML(cases);
+    assert.true(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>'), 'has XML declaration');
+    assert.true(
+      /<testsuites name="qunitx" tests="5" failures="1" skipped="2" time="0\.513">/.test(xml),
+      'testsuites totals (todo counts as skipped)',
+    );
+  });
+
+  test('groups test cases into one testsuite per classname', (assert) => {
+    const xml = buildJUnitXML(cases);
+    assert.true(
+      /<testsuite name="Math" tests="2" failures="0" skipped="0"/.test(xml),
+      'Math suite',
+    );
+    assert.true(
+      /<testsuite name="Strings" tests="3" failures="1" skipped="2"/.test(xml),
+      'Strings suite',
+    );
+  });
+
+  test('passing cases are self-closing; failed cases carry a <failure>', (assert) => {
+    const xml = buildJUnitXML(cases);
+    assert.true(
+      xml.includes('<testcase name="adds" classname="Math" time="0.003"/>'),
+      'passing testcase is self-closing',
+    );
+    assert.true(
+      xml.includes('<failure message="expected &quot;cba&quot;">'),
+      'failure message is attribute-escaped',
+    );
+    assert.true(xml.includes('at src/strings.ts:4:2'), 'failure detail included');
+  });
+
+  test('todo and skipped cases render a <skipped/> element', (assert) => {
+    const xml = buildJUnitXML(cases);
+    assert.equal((xml.match(/<skipped\/>/g) ?? []).length, 2, 'two skipped elements');
+  });
+
+  test('escapes XML metacharacters in names', (assert) => {
+    const xml = buildJUnitXML([
+      { classname: 'A & B', name: '<tag> "q"', time: 0, status: 'passed' },
+    ]);
+    assert.true(xml.includes('classname="A &amp; B"'), 'ampersand escaped in attribute');
+    assert.true(
+      xml.includes('name="&lt;tag&gt; &quot;q&quot;"'),
+      'angle brackets + quotes escaped',
+    );
+  });
+
+  test('root classname fallback for single-element fullNames', (assert) => {
+    const xml = buildJUnitXML([
+      { classname: '(root)', name: 'top level', time: 0, status: 'passed' },
+    ]);
+    assert.true(xml.includes('<testsuite name="(root)"'), 'root suite name used');
+  });
+});

--- a/test/reporter/reporter-test.ts
+++ b/test/reporter/reporter-test.ts
@@ -1,0 +1,119 @@
+import { module, test } from 'qunitx';
+import { updateCounter } from '../../lib/reporter/types.ts';
+import type { Counter } from '../../lib/types.ts';
+
+// updateCounter owns all counter math, split out of the TAP formatter so the numbers are
+// identical no matter which (or how many) reporters are attached. The exit code and the TAP
+// plan both read COUNTER, so these invariants are load-bearing.
+const newCounter = (): Counter => ({
+  testCount: 0,
+  failCount: 0,
+  skipCount: 0,
+  todoCount: 0,
+  passCount: 0,
+  errorCount: 0,
+});
+
+module('reporters | updateCounter', { concurrency: true }, () => {
+  test('passed status increments testCount and passCount only', (assert) => {
+    const COUNTER = newCounter();
+    updateCounter(COUNTER, { status: 'passed', fullName: ['m', 't'], runtime: 1, assertions: [] });
+    assert.strictEqual(COUNTER.testCount, 1);
+    assert.strictEqual(COUNTER.passCount, 1);
+    assert.strictEqual(COUNTER.failCount, 0);
+    assert.strictEqual(COUNTER.skipCount, 0);
+  });
+
+  test('skipped status increments testCount and skipCount only', (assert) => {
+    const COUNTER = newCounter();
+    updateCounter(COUNTER, { status: 'skipped', fullName: ['m', 't'], runtime: 0, assertions: [] });
+    assert.strictEqual(COUNTER.testCount, 1);
+    assert.strictEqual(COUNTER.skipCount, 1);
+    assert.strictEqual(COUNTER.passCount, 0);
+    assert.strictEqual(COUNTER.failCount, 0);
+  });
+
+  test('todo status increments testCount and todoCount only', (assert) => {
+    const COUNTER = newCounter();
+    updateCounter(COUNTER, { status: 'todo', fullName: ['m', 't'], runtime: 0, assertions: [] });
+    assert.strictEqual(COUNTER.testCount, 1);
+    assert.strictEqual(COUNTER.todoCount, 1);
+    assert.strictEqual(COUNTER.failCount, 0);
+    assert.strictEqual(COUNTER.skipCount, 0);
+    assert.strictEqual(COUNTER.passCount, 0);
+  });
+
+  test('failed status increments testCount and failCount; errorCount counts assertions', (assert) => {
+    const COUNTER = newCounter();
+    updateCounter(COUNTER, {
+      status: 'failed',
+      fullName: ['m', 't'],
+      runtime: 1,
+      assertions: [{ passed: false, todo: false, actual: false, expected: true }],
+    });
+    assert.strictEqual(COUNTER.testCount, 1);
+    assert.strictEqual(COUNTER.failCount, 1);
+    assert.strictEqual(COUNTER.passCount, 0);
+    assert.strictEqual(COUNTER.skipCount, 0);
+    assert.strictEqual(COUNTER.errorCount, 1);
+  });
+
+  test('errorCount counts each failing assertion, as a number (never NaN)', (assert) => {
+    const COUNTER = newCounter();
+    updateCounter(COUNTER, {
+      status: 'failed',
+      fullName: ['some module', 'some test'],
+      runtime: 10,
+      assertions: [
+        { passed: false, todo: false, actual: null, expected: true, message: 'fail', stack: '' },
+        { passed: false, todo: false, actual: 1, expected: 2, message: 'mismatch', stack: '' },
+      ],
+    });
+    assert.strictEqual(typeof COUNTER.errorCount, 'number', 'errorCount must be a number, not NaN');
+    assert.strictEqual(COUNTER.errorCount, 2, 'errorCount should count each failed assertion');
+  });
+
+  test('errorCount survives a COUNTER created without the key (no NaN)', (assert) => {
+    // Mirrors how COUNTER is built in run.ts / tests-in-browser.ts on older paths (no errorCount).
+    const COUNTER = {
+      testCount: 0,
+      failCount: 0,
+      skipCount: 0,
+      todoCount: 0,
+      passCount: 0,
+    } as Counter;
+    updateCounter(COUNTER, {
+      status: 'failed',
+      fullName: ['mod', 'test'],
+      runtime: 5,
+      assertions: [
+        { passed: false, todo: false, actual: false, expected: true, message: 'x', stack: '' },
+      ],
+    });
+    assert.strictEqual(isNaN(COUNTER.errorCount), false, 'errorCount must not be NaN');
+    assert.strictEqual(COUNTER.errorCount, 1);
+  });
+
+  test('passing and todo assertions inside a failed test do not raise errorCount', (assert) => {
+    const COUNTER = newCounter();
+    updateCounter(COUNTER, {
+      status: 'failed',
+      fullName: ['m', 't'],
+      runtime: 5,
+      assertions: [
+        { passed: true, todo: false, actual: true, expected: true },
+        { passed: false, todo: true, actual: false, expected: true },
+        { passed: false, todo: false, actual: 0, expected: 1 },
+      ],
+    });
+    assert.strictEqual(COUNTER.errorCount, 1, 'only the genuine failure counts');
+  });
+
+  test('a failed test with no assertions array still counts the test', (assert) => {
+    const COUNTER = newCounter();
+    updateCounter(COUNTER, { status: 'failed', fullName: ['m', 't'], runtime: 1 });
+    assert.strictEqual(COUNTER.testCount, 1);
+    assert.strictEqual(COUNTER.failCount, 1);
+    assert.strictEqual(COUNTER.errorCount, 0, 'no assertions to count');
+  });
+});

--- a/test/reporter/spec-test.ts
+++ b/test/reporter/spec-test.ts
@@ -1,0 +1,200 @@
+import { module, test } from 'qunitx';
+import { SpecReporter } from '../../lib/reporter/spec.ts';
+import { updateCounter } from '../../lib/reporter/types.ts';
+import type { TestDetails } from '../../lib/reporter/types.ts';
+import type { Config } from '../../lib/types.ts';
+import '../helpers/custom-asserts.ts';
+import { captureStdout } from '../helpers/capture-stdout.ts';
+
+// Colors are disabled in a non-TTY (see lib/utils/color.ts), so these assertions match plain text.
+const makeConfig = (): Config =>
+  ({
+    projectRoot: '/proj',
+    reporter: 'spec',
+    COUNTER: {
+      testCount: 0,
+      failCount: 0,
+      skipCount: 0,
+      todoCount: 0,
+      passCount: 0,
+      errorCount: 0,
+    },
+  }) as unknown as Config;
+
+// Drives the reporter the way reportTestEnd does: counter first, then the reporter.
+const feed = (reporter: SpecReporter, config: Config, details: TestDetails): string =>
+  captureStdout(() => {
+    updateCounter(config.COUNTER, details);
+    reporter.onTestEnd(config, details);
+  });
+
+const passing = (name: string, moduleName = 'Math'): TestDetails => ({
+  status: 'passed',
+  fullName: [moduleName, name],
+  runtime: 3,
+  assertions: [],
+});
+
+module('reporters | SpecReporter', { concurrency: true }, () => {
+  test('prints a module header once, then indents its tests under it', (assert) => {
+    const config = makeConfig();
+    const reporter = new SpecReporter();
+    const first = feed(reporter, config, passing('adds'));
+    const second = feed(reporter, config, passing('subtracts'));
+
+    assert.includes(first, 'Math\n', 'module header printed for the first test');
+    assert.includes(first, '  ✔ adds (3ms)\n', 'test indented under the module');
+    assert.notIncludes(second, 'Math\n', 'header not repeated for the same module');
+    assert.includes(second, '  ✔ subtracts (3ms)\n');
+  });
+
+  test('prints a new header when the module changes', (assert) => {
+    const config = makeConfig();
+    const reporter = new SpecReporter();
+    feed(reporter, config, passing('adds', 'Math'));
+    const output = feed(reporter, config, passing('trims', 'Strings'));
+    assert.includes(output, 'Strings\n', 'new module gets its own header');
+  });
+
+  test('nested modules render as a > b, root-level tests as (root)', (assert) => {
+    const config = makeConfig();
+    assert.includes(
+      feed(new SpecReporter(), config, {
+        status: 'passed',
+        fullName: ['outer', 'inner', 'test'],
+        runtime: 1,
+        assertions: [],
+      }),
+      'outer > inner\n',
+    );
+    assert.includes(
+      feed(new SpecReporter(), config, {
+        status: 'passed',
+        fullName: ['top level'],
+        runtime: 1,
+        assertions: [],
+      }),
+      '(root)\n',
+    );
+  });
+
+  test('failed tests show the message, values, and location inline', (assert) => {
+    const output = feed(new SpecReporter(), makeConfig(), {
+      status: 'failed',
+      fullName: ['Math', 'adds'],
+      runtime: 4,
+      assertions: [
+        {
+          passed: false,
+          todo: false,
+          actual: 3,
+          expected: 4,
+          message: 'sum should be 4',
+          stack: '    at Object.<anonymous> (http://localhost:1234/tests.js:10:5)',
+        },
+      ],
+    });
+    assert.includes(output, '  ✖ adds (4ms)\n', 'failed mark');
+    assert.includes(output, 'sum should be 4', 'assertion message');
+    assert.includes(output, 'expected: 4', 'expected value');
+    assert.includes(output, 'actual:   3', 'actual value');
+    assert.includes(output, 'at http://localhost:1234/tests.js:10:5', 'location');
+  });
+
+  test('skipped and todo tests use distinct marks and no duration', (assert) => {
+    const config = makeConfig();
+    const skipped = feed(new SpecReporter(), config, {
+      status: 'skipped',
+      fullName: ['Math', 'later'],
+      runtime: 0,
+      assertions: [],
+    });
+    const todo = feed(new SpecReporter(), config, {
+      status: 'todo',
+      fullName: ['Math', 'wip'],
+      runtime: 0,
+      assertions: [],
+    });
+    assert.includes(skipped, '  - later\n', 'skipped mark, no duration');
+    assert.includes(todo, '  ◌ wip\n', 'todo mark, no duration');
+  });
+
+  test('summary counts only non-zero categories, and lists failures', (assert) => {
+    const config = makeConfig();
+    const reporter = new SpecReporter();
+    reporter.onRunStart(config, { fileCount: null, groupCount: null });
+    feed(reporter, config, passing('adds'));
+    feed(reporter, config, {
+      status: 'failed',
+      fullName: ['Math', 'divides'],
+      runtime: 1,
+      assertions: [{ passed: false, todo: false, actual: 1, expected: 2, message: 'nope' }],
+    });
+
+    const output = captureStdout(() => reporter.onRunEnd(config, { durationMs: 120 }));
+    assert.includes(output, '1 passing (120ms)');
+    assert.includes(output, '1 failing');
+    assert.notIncludes(output, 'skipped', 'zero-count categories are omitted');
+    assert.notIncludes(output, 'todo', 'zero-count categories are omitted');
+    assert.includes(output, 'Failures:', 'failure recap is printed');
+    assert.includes(output, '1) Math | divides', 'recap names the failing test');
+  });
+
+  test('a clean run prints no failure recap', (assert) => {
+    const config = makeConfig();
+    const reporter = new SpecReporter();
+    reporter.onRunStart(config, { fileCount: null, groupCount: null });
+    feed(reporter, config, passing('adds'));
+    const output = captureStdout(() => reporter.onRunEnd(config, { durationMs: 10 }));
+    assert.notIncludes(output, 'Failures:');
+  });
+
+  test('onRunStart resets state so watch reruns do not accumulate', (assert) => {
+    const config = makeConfig();
+    const reporter = new SpecReporter();
+    feed(reporter, config, {
+      status: 'failed',
+      fullName: ['Math', 'divides'],
+      runtime: 1,
+      assertions: [{ passed: false, todo: false, actual: 1, expected: 2, message: 'nope' }],
+    });
+
+    // Second run: fresh counters + fresh reporter state.
+    const rerun = makeConfig();
+    reporter.onRunStart(rerun, { fileCount: null, groupCount: null });
+    const rerunOutput = feed(reporter, rerun, passing('adds'));
+    assert.includes(rerunOutput, 'Math\n', 'module header reprinted after the reset');
+
+    const output = captureStdout(() => reporter.onRunEnd(rerun, { durationMs: 5 }));
+    assert.notIncludes(output, 'Failures:', 'previous run failures are not carried over');
+  });
+
+  test('run start announces the file/worker counts, and the empty case', (assert) => {
+    const config = makeConfig();
+    assert.includes(
+      captureStdout(() => new SpecReporter().onRunStart(config, { fileCount: 3, groupCount: 2 })),
+      'Running 3 test files across 2 worker(s)',
+    );
+    assert.includes(
+      captureStdout(() => new SpecReporter().onRunStart(config, { fileCount: 1, groupCount: 1 })),
+      'Running 1 test file across 1 worker(s)',
+      'singular file',
+    );
+    assert.includes(
+      captureStdout(() => new SpecReporter().onRunStart(config, { fileCount: 0, groupCount: 0 })),
+      'No test files found.',
+    );
+  });
+
+  test('never emits TAP syntax', (assert) => {
+    const config = makeConfig();
+    const reporter = new SpecReporter();
+    const output =
+      captureStdout(() => reporter.onRunStart(config, { fileCount: 1, groupCount: 1 })) +
+      feed(reporter, config, passing('adds')) +
+      captureStdout(() => reporter.onRunEnd(config, { durationMs: 1 }));
+    assert.notIncludes(output, 'TAP version 13');
+    assert.notIncludes(output, 'ok 1');
+    assert.notIncludes(output, '1..');
+  });
+});

--- a/test/runner.ts
+++ b/test/runner.ts
@@ -27,6 +27,7 @@ import createSemaphoreServer from './helpers/semaphore-server.ts';
 import { killProcessGroup } from '../lib/utils/kill-process-group.ts';
 import { cleanupBrowserDir } from '../lib/utils/cleanup-browser-dir.ts';
 import { PER_TEST_TIMEOUT_MS } from './helpers/per-test-timeout.ts';
+import { joinRunnerRegistry } from './helpers/runner-registry.ts';
 
 // When invoked as `deno run -A test/runner.ts ...` (CI deno lanes), we spawn
 // `deno test` workers instead of `node --test`. Detection is one runtime
@@ -83,13 +84,16 @@ function isContentionLane(): boolean {
   return false;
 }
 
-// Clearing artifacts, starting the semaphore server, and discovering test files are all
-// independent — run them concurrently to cut startup time. tmp/ is recreated after the
-// rm so node:test can open the per-phase perf-reporter destination on phase 1 spawn.
-const [, semaphore, [fastFiles, watchReruns, leakFiles]] = await Promise.all([
-  fs
-    .rm('./tmp', { recursive: true, force: true })
-    .then(() => fs.mkdir('./tmp', { recursive: true })),
+// Joining the registry, starting the semaphore server, and discovering test files are all
+// independent — run them concurrently to cut startup time.
+//
+// The tmp/ wipe happens inside joinRunnerRegistry, and only when no other runner is live: tmp/
+// is shared, so wiping it while another run is using it deletes that run's fixtures mid-flight
+// (see the helper for why the mutex, not just the check, is what makes this safe). Solo runs —
+// the overwhelmingly common case — behave exactly as before. tmp/ is recreated below so
+// node:test can open the per-phase perf-reporter destination on phase 1 spawn.
+const [runner, semaphore, [fastFiles, watchReruns, leakFiles]] = await Promise.all([
+  joinRunnerRegistry(() => fs.rm('./tmp', { recursive: true, force: true })),
   createSemaphoreServer(CHROME_CAP),
   cliFiles.length > 0
     ? Promise.resolve([cliFiles, [], []] as [string[], string[], string[]])
@@ -107,6 +111,11 @@ const [, semaphore, [fastFiles, watchReruns, leakFiles]] = await Promise.all([
         Array.fromAsync(fs.glob('test/**/*-leak.ts')),
       ]),
 ]);
+await fs.mkdir('./tmp', { recursive: true });
+
+// Scopes this run's artifacts. Concurrent runners must not clobber each other's reporter
+// output; CI globs tmp/junit-*.xml, so the extra segment still matches.
+const RUN_ID = runner.runId;
 
 type PerfEntry = {
   name: string;
@@ -197,13 +206,13 @@ if (!watchMode) {
       `| phase | duration |\n|---|---|\n${rows}\n` +
       `| **total** | **${fmt(totalMs)}** |\n\n` +
       `_Per-test breakdown is in the live \`deno test --reporter=pretty\` output above; ` +
-      `junit XML is written to \`tmp/junit-<phase>.xml\` for dorny._\n`;
+      `junit XML is written to \`tmp/junit-<run>-<phase>.xml\` for dorny._\n`;
   } else {
     // Read perf JSONL per phase, generate junit XML alongside (consumed by
     // .github/workflows/test-report.yml → dorny). Reading and writing in parallel.
     const perfByPhase = await Promise.all(
       phaseResults.map(async (p) => {
-        const entries = await readPerf(`./tmp/perf-${p.slug}.jsonl`);
+        const entries = await readPerf(`./tmp/perf-${RUN_ID}-${p.slug}.jsonl`);
         await writeJunitFromPerf(p.slug, entries);
         return entries;
       }),
@@ -252,6 +261,7 @@ if (!watchMode) {
 }
 
 semaphore.close();
+await runner.release();
 process.exit(exitCode1 || exitCode2 || exitCode3);
 
 async function runPhase(name: string, slug: string, files: string[]): Promise<number> {
@@ -318,7 +328,7 @@ async function writeJunitFromPerf(slug: string, entries: PerfEntry[]): Promise<v
     .join('\n');
 
   const xml = `<?xml version="1.0" encoding="utf-8"?>\n<testsuites>\n${suites}\n</testsuites>\n`;
-  await fs.writeFile(`./tmp/junit-${slug}.xml`, xml);
+  await fs.writeFile(`./tmp/junit-${RUN_ID}-${slug}.xml`, xml);
 }
 
 function spawnTests(files: string[], slug?: string): Promise<number> {
@@ -380,7 +390,7 @@ function spawnTests(files: string[], slug?: string): Promise<number> {
         '--no-check',
         '--parallel',
         `--preload=${DENO_TEST_TIMEOUT_PRELOAD}`,
-        ...(slug ? [`--junit-path=./tmp/junit-${slug}.xml`] : []),
+        ...(slug ? [`--junit-path=./tmp/junit-${RUN_ID}-${slug}.xml`] : []),
         ...(watchMode ? ['--watch'] : []),
         ...files,
       ];
@@ -394,7 +404,7 @@ function spawnTests(files: string[], slug?: string): Promise<number> {
     //   spec   → stdout                        : compact, human/LLM-readable test output
     //                                            (no TAP YAML diagnostic blocks; ~80% less
     //                                             stdout noise on green runs).
-    //   ci-test-summary → tmp/perf-<slug>.jsonl: per-test {name, file, ms, status, error?}
+    //   ci-test-summary → tmp/perf-<run>-<slug>.jsonl: per-test {name, file, ms, status, error?}
     //                                            JSONL — drives both the local end-of-run
     //                                            summary AND the junit XML written via
     //                                            writeJunitFromPerf() for dorny consumption.
@@ -404,7 +414,7 @@ function spawnTests(files: string[], slug?: string): Promise<number> {
           '--test-reporter=spec',
           '--test-reporter-destination=stdout',
           `--test-reporter=${REPORTER_PATH}`,
-          `--test-reporter-destination=./tmp/perf-${slug}.jsonl`,
+          `--test-reporter-destination=./tmp/perf-${RUN_ID}-${slug}.jsonl`,
         ]
       : [];
     const child = spawn(

--- a/test/runner.ts
+++ b/test/runner.ts
@@ -26,6 +26,7 @@ import { spawn } from 'node:child_process';
 import createSemaphoreServer from './helpers/semaphore-server.ts';
 import { killProcessGroup } from '../lib/utils/kill-process-group.ts';
 import { cleanupBrowserDir } from '../lib/utils/cleanup-browser-dir.ts';
+import { PER_TEST_TIMEOUT_MS } from './helpers/per-test-timeout.ts';
 
 // When invoked as `deno run -A test/runner.ts ...` (CI deno lanes), we spawn
 // `deno test` workers instead of `node --test`. Detection is one runtime
@@ -41,32 +42,6 @@ const DENO_EXEC = IS_DENO ? (globalThis as { Deno: { execPath(): string } }).Den
 // doesn't enable compile cache — its module graph is small and doing so would
 // pollute process.env, overriding the project-local default below.
 const COMPILE_CACHE_DIR = path.resolve('node_modules/.cache/qunitx/v8');
-
-// Per-test deadline passed to `node --test --test-timeout=N`. node:test fails any
-// test whose runtime exceeds this and force-completes its subtests, so a hung
-// test surfaces by name in the spec output and the worker moves on cleanly —
-// no zombies, no SIGKILL hammer, no whole-phase loss.
-//
-// Sized to comfortably exceed the slowest observed healthy test. Watch-rerun
-// tests are the long tail: per-test wall clock has been observed up to 120 s
-// on slow CI runners under contention (Windows + concurrent Chrome launches).
-// Daemon tests' rapid-stop+start used to peak at 120 s pre-leak-fix; current
-// healthy max is ~15 s. 300 s = 5 min ≈ 2.5× the observed slow tail leaves
-// room for the runner's natural tail variance without misfiring on real-but-
-// slow runs. Anything past 5 min is genuinely stuck.
-//
-// Below this the per-call `DEFAULT_EXEC_TIMEOUT_MS = 180_000` in
-// test/helpers/shell.ts cuts off individual cli invocations; this is the
-// outer safety net for the test itself.
-//
-// Above this, GitHub Actions' job-level `timeout-minutes` (15 on ubuntu, 25
-// on macos/windows in ci.yml) is the ultimate fallback if --test-timeout
-// somehow fails to release a worker (rare: requires a worker stuck in a
-// non-interruptible syscall). We don't add a phase-level SIGKILL deadman of
-// our own because it'd leave orphan cli/daemon/Chrome processes the next run
-// would inherit, and `--test-timeout` already covers the case that actually
-// matters.
-const PER_TEST_TIMEOUT_MS = 300_000;
 
 const watchMode = process.argv.includes('--watch');
 // --watch is never mixed with explicit file paths (see package.json scripts), so when
@@ -157,6 +132,12 @@ const REPORTER_PATH = pathToFileURL(path.resolve('test/helpers/ci-test-summary-r
 // 26037993172) are diagnosable from the job log alone. See the file's
 // leading comment for details.
 const WORKER_PRELOAD = pathToFileURL(path.resolve('test/helpers/test-worker-preload.ts')).href;
+// Deno lane's equivalent of node's --test-timeout: preloaded into every test worker so it can
+// wrap Deno.test with PER_TEST_TIMEOUT_MS. See test/helpers/deno-test-timeout.ts for why this
+// has to be a preload rather than a flag.
+const DENO_TEST_TIMEOUT_PRELOAD = pathToFileURL(
+  path.resolve('test/helpers/deno-test-timeout.ts'),
+).href;
 const phaseResults: Array<{
   name: string;
   slug: string;
@@ -382,16 +363,23 @@ function spawnTests(files: string[], slug?: string): Promise<number> {
       //                  Caveat: deno's junit output emits a second <testsuite> per file
       //                  whose name points at qunitx's internal dist/deno/index.js (one
       //                  testcase per Deno.test.step). Dorny shows it; harmless but noisy.
-      // No --import preload: deno has no equivalent flag, and the silent-death diagnostic
-      // the preload provides is a node:test-specific symptom (whole file → single 'test
-      // failed' with no context). Deno's pretty reporter shows failures directly.
-      // No --test-timeout / --test-force-exit equivalents on deno; the outer GHA
-      // job-level timeout remains the safety net.
+      //   --preload    : DENO_TEST_TIMEOUT_PRELOAD wraps Deno.test with a per-test deadline.
+      //                  Deno has no --test-timeout (still absent as of 2.9) and no timeout in
+      //                  Deno.test's options, so a hung test used to consume the whole GHA job
+      //                  — 25 min, cancelled, naming nothing. This gives the lane the same
+      //                  fail-fast-by-name behaviour --test-timeout gives node. It does NOT
+      //                  carry WORKER_PRELOAD's silent-death diagnostic: that translates a
+      //                  node:test-specific symptom (whole file → one context-free 'test
+      //                  failed') which deno's reporter doesn't have.
+      // No --test-force-exit equivalent on deno; the outer GHA job-level timeout still backs
+      // up anything the per-test deadline can't see (a hang at module top-level, or between
+      // tests, rather than inside a test fn).
       const args = [
         'test',
         '--allow-all',
         '--no-check',
         '--parallel',
+        `--preload=${DENO_TEST_TIMEOUT_PRELOAD}`,
         ...(slug ? [`--junit-path=./tmp/junit-${slug}.xml`] : []),
         ...(watchMode ? ['--watch'] : []),
         ...files,

--- a/test/runner.ts
+++ b/test/runner.ts
@@ -104,8 +104,12 @@ const [runner, semaphore, [fastFiles, watchReruns, leakFiles]] = await Promise.a
         // *-leak.ts  — isolation tests; must run after the main suite + sweep because they
         //              check global state (/tmp dirs, /proc) and would see false orphans
         //              from concurrent watch-mode tests that legitimately SIGKILL node-cli.
+        // test/fixtures/** are inputs tests hand to the CLI — the coverage fixture is bundled
+        // for the browser by flags/coverage-test.ts — not node:test files; running one as a
+        // test crashes the worker on `import 'qunitx'`. The -test.ts suffix is part of the
+        // fixture's realism, so exclude by location rather than renaming it.
         Array.fromAsync(fs.glob('test/**/*-test.ts')).then((files) =>
-          files.filter((f) => !f.includes('watch-rerun')),
+          files.filter((f) => !f.includes('watch-rerun') && !/(^|[\\/])fixtures[\\/]/.test(f)),
         ),
         Array.fromAsync(fs.glob('test/**/watch-rerun-test.ts')),
         Array.fromAsync(fs.glob('test/**/*-leak.ts')),
@@ -425,7 +429,6 @@ function spawnTests(files: string[], slug?: string): Promise<number> {
             '--import',
             WORKER_PRELOAD,
             '--test',
-            '--test-force-exit',
             `--test-timeout=${PER_TEST_TIMEOUT_MS}`,
             ...reporterArgs,
             ...files,

--- a/test/setup/runner-registry-test.ts
+++ b/test/setup/runner-registry-test.ts
@@ -1,0 +1,107 @@
+import { module, test } from 'qunitx';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { joinRunnerRegistry, liveRunners } from '../helpers/runner-registry.ts';
+
+// Every test gets a private registry dir. The real one has this very runner registered in it,
+// so using the default would have the suite observe itself.
+const registryDir = () => path.join(process.cwd(), 'tmp', `runner-registry-${crypto.randomUUID()}`);
+const exists = (target: string) =>
+  fs
+    .stat(target)
+    .then(() => true)
+    .catch(() => false);
+
+// A pid that is definitely dead: spawn something trivial and wait for it to exit. Beats picking
+// an arbitrary high number, which could belong to a real process on a busy machine.
+async function deadPid(): Promise<number> {
+  const child = spawn(process.execPath, ['-e', '']);
+  await new Promise((resolve) => child.once('exit', resolve));
+  return child.pid!;
+}
+
+async function writeEntry(dir: string, pid: number): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, String(pid)), JSON.stringify({ pid, startedAt: Date.now() }));
+}
+
+const never = () => Promise.reject(new Error('onSolo must not run when another runner is live'));
+
+module('Setup | runner registry', { concurrency: true }, () => {
+  test('a solo runner wipes tmp/ and registers itself', async (assert) => {
+    const dir = registryDir();
+    let wiped = 0;
+    const runner = await joinRunnerRegistry(() => void wiped++, dir);
+
+    assert.true(runner.wasSolo, 'no other runner was live');
+    assert.strictEqual(wiped, 1, 'the solo runner performs the wipe');
+    assert.strictEqual(runner.runId, String(process.pid), 'runId identifies this runner');
+    assert.true(await exists(path.join(dir, String(process.pid))), 'entry registered');
+
+    await runner.release();
+    assert.false(await exists(path.join(dir, String(process.pid))), 'release removes the entry');
+  });
+
+  test('does NOT wipe while another runner is live — the whole point', async (assert) => {
+    const dir = registryDir();
+    // A live runner other than us. Its own pid is alive by construction.
+    await writeEntry(dir, process.ppid);
+
+    const runner = await joinRunnerRegistry(never, dir);
+    assert.false(runner.wasSolo, 'company detected');
+    // never() would have rejected; reaching here proves the wipe was skipped.
+    await runner.release();
+  });
+
+  test('a dead runner is reaped and does not suppress the wipe forever', async (assert) => {
+    const dir = registryDir();
+    await writeEntry(dir, await deadPid());
+
+    let wiped = 0;
+    const runner = await joinRunnerRegistry(() => void wiped++, dir);
+    assert.true(runner.wasSolo, 'a crashed runner must not count as company');
+    assert.strictEqual(wiped, 1, 'the wipe still happens');
+    await runner.release();
+  });
+
+  test('a torn entry is ignored rather than wedging the registry', async (assert) => {
+    const dir = registryDir();
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, '999999'), 'not json');
+
+    const runner = await joinRunnerRegistry(() => {}, dir);
+    assert.true(runner.wasSolo, 'unparseable entries do not count as live runners');
+    await runner.release();
+  });
+
+  test('the mutex is released, so a later runner is never blocked', async (assert) => {
+    const dir = registryDir();
+    const first = await joinRunnerRegistry(() => {}, dir);
+    await first.release();
+
+    // Would hang if the first join had kept the mutex.
+    const second = await joinRunnerRegistry(() => {}, dir);
+    assert.true(second.wasSolo, 'the released entry left no trace');
+    await second.release();
+  });
+
+  test('liveRunners reports others and reaps the dead', async (assert) => {
+    const dir = registryDir();
+    await writeEntry(dir, process.ppid);
+    const gone = await deadPid();
+    await writeEntry(dir, gone);
+
+    const live = await liveRunners(dir);
+    assert.strictEqual(live.length, 1, 'only the live entry is reported');
+    assert.strictEqual(live[0].pid, process.ppid);
+    assert.false(await exists(path.join(dir, String(gone))), 'the dead entry is reaped');
+  });
+
+  test('liveRunners excludes ourselves', async (assert) => {
+    const dir = registryDir();
+    await writeEntry(dir, process.pid);
+    assert.deepEqual(await liveRunners(dir), [], 'our own entry is not company');
+  });
+});

--- a/test/tap/display-test-result-test.ts
+++ b/test/tap/display-test-result-test.ts
@@ -1,56 +1,23 @@
 import { module, test } from 'qunitx';
-import TAPDisplayTestResult, { extractStackAt } from '../../lib/tap/display-test-result.ts';
+import TAPDisplayTestResult from '../../lib/tap/display-test-result.ts';
+import { failedAssertions } from '../../lib/reporter/failure.ts';
+import type { TestDetails } from '../../lib/reporter/types.ts';
 import '../helpers/custom-asserts.ts';
 import { captureStdout } from '../helpers/capture-stdout.ts';
 
-module('TAP | extractStackAt', { concurrency: true }, () => {
-  test('Chrome style: extracts clean URL without parens', (assert) => {
-    const stack =
-      '    at Object.<anonymous> (http://localhost:1234/tests.js:42:15)\n    at test (http://localhost:1234/tests.js:10:3)';
-    assert.strictEqual(extractStackAt(stack), 'http://localhost:1234/tests.js:42:15');
-  });
-
-  test('Chrome style: strips file:// prefix from local paths', (assert) => {
-    const stack = '    at Object.<anonymous> (file:///home/user/project/tests.js:42:15)';
-    assert.strictEqual(extractStackAt(stack), '/home/user/project/tests.js:42:15');
-  });
-
-  test('Firefox/WebKit style: extracts URL after @', (assert) => {
-    const stack =
-      'Object.prototype.<anonymous>@http://localhost:1234/tests.js:42:15\n@http://localhost:1234/tests.js:10:3';
-    assert.strictEqual(extractStackAt(stack), 'http://localhost:1234/tests.js:42:15');
-  });
-
-  test('returns null for null', (assert) => {
-    assert.strictEqual(extractStackAt(null), null);
-  });
-
-  test('returns null for empty string', (assert) => {
-    assert.strictEqual(extractStackAt(''), null);
-  });
-
-  test('returns null for plain error message with no location', (assert) => {
-    assert.strictEqual(extractStackAt('Error: something went wrong'), null);
-  });
-});
+// TAPDisplayTestResult is a pure formatter: the caller owns the TAP sequence number and
+// pre-resolves failures. This mirrors what TapReporter.onTestEnd does, so these tests still
+// exercise the real rendering path.
+const render = (details: TestDetails, testNumber = 1): string =>
+  captureStdout(() => TAPDisplayTestResult(testNumber, details, failedAssertions(details)));
 
 module('TAP | TAPDisplayTestResult | output', { concurrency: true }, () => {
   test('null message and stack are not printed in YAML block', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    const output = captureStdout(() => {
-      TAPDisplayTestResult(COUNTER, {
-        status: 'failed',
-        fullName: ['mod', 'test'],
-        runtime: 5,
-        assertions: [{ passed: false, todo: false, actual: false, expected: true }],
-      });
+    const output = render({
+      status: 'failed',
+      fullName: ['mod', 'test'],
+      runtime: 5,
+      assertions: [{ passed: false, todo: false, actual: false, expected: true }],
     });
     assert.notIncludes(output, 'message:', 'null message must not appear in output');
     assert.notIncludes(output, 'stack:', 'null stack must not appear in output');
@@ -65,72 +32,42 @@ module('TAP | TAPDisplayTestResult | output', { concurrency: true }, () => {
       [false, true, 'actual: false'],
       [null, true, 'actual: null'],
     ] as const) {
-      const COUNTER = {
-        testCount: 0,
-        failCount: 0,
-        skipCount: 0,
-        todoCount: 0,
-        passCount: 0,
-        errorCount: 0,
-      };
-      const output = captureStdout(() => {
-        TAPDisplayTestResult(COUNTER, {
-          status: 'failed',
-          fullName: ['mod', 'test'],
-          runtime: 0,
-          assertions: [{ passed: false, todo: false, actual, expected }],
-        });
+      const output = render({
+        status: 'failed',
+        fullName: ['mod', 'test'],
+        runtime: 0,
+        assertions: [{ passed: false, todo: false, actual, expected }],
       });
       assert.includes(output, expectedStr, `actual: ${actual} must not be coerced`);
     }
   });
 
   test('non-null message appears in YAML block', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    const output = captureStdout(() => {
-      TAPDisplayTestResult(COUNTER, {
-        status: 'failed',
-        fullName: ['mod', 'test'],
-        runtime: 5,
-        assertions: [
-          { passed: false, todo: false, actual: false, expected: true, message: 'custom message' },
-        ],
-      });
+    const output = render({
+      status: 'failed',
+      fullName: ['mod', 'test'],
+      runtime: 5,
+      assertions: [
+        { passed: false, todo: false, actual: false, expected: true, message: 'custom message' },
+      ],
     });
     assert.includes(output, 'message: custom message', 'non-null message must be printed');
   });
 
   test('Chrome stack: leading whitespace is trimmed so YAML renders "stack: at ..." not "stack:     at ..."', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    const output = captureStdout(() => {
-      TAPDisplayTestResult(COUNTER, {
-        status: 'failed',
-        fullName: ['mod', 'test'],
-        runtime: 5,
-        assertions: [
-          {
-            passed: false,
-            todo: false,
-            actual: false,
-            expected: true,
-            stack: '    at Object.<anonymous> (http://localhost:1234/tests.js:42:15)',
-          },
-        ],
-      });
+    const output = render({
+      status: 'failed',
+      fullName: ['mod', 'test'],
+      runtime: 5,
+      assertions: [
+        {
+          passed: false,
+          todo: false,
+          actual: false,
+          expected: true,
+          stack: '    at Object.<anonymous> (http://localhost:1234/tests.js:42:15)',
+        },
+      ],
     });
     // The indented YAML line should be "    stack: at Object..." (4-space block indent + "stack: at")
     // NOT "    stack:     at Object..." (extra leading spaces from Chrome's frame format)
@@ -139,330 +76,114 @@ module('TAP | TAPDisplayTestResult | output', { concurrency: true }, () => {
   });
 
   test('Chrome stack: at field is a clean URL without surrounding parens', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    const output = captureStdout(() => {
-      TAPDisplayTestResult(COUNTER, {
-        status: 'failed',
-        fullName: ['mod', 'test'],
-        runtime: 5,
-        assertions: [
-          {
-            passed: false,
-            todo: false,
-            actual: false,
-            expected: true,
-            stack: '    at Object.<anonymous> (http://localhost:1234/tests.js:42:15)',
-          },
-        ],
-      });
+    const output = render({
+      status: 'failed',
+      fullName: ['mod', 'test'],
+      runtime: 5,
+      assertions: [
+        {
+          passed: false,
+          todo: false,
+          actual: false,
+          expected: true,
+          stack: '    at Object.<anonymous> (http://localhost:1234/tests.js:42:15)',
+        },
+      ],
     });
     assert.includes(output, 'at: http://localhost:1234/tests.js:42:15\n', 'at must be a bare URL');
     assert.notIncludes(output, 'at: (', 'at must not start with opening paren');
   });
 
   test('YAML block is wrapped in --- / ... delimiters', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    const output = captureStdout(() => {
-      TAPDisplayTestResult(COUNTER, {
-        status: 'failed',
-        fullName: ['mod', 'test'],
-        runtime: 5,
-        assertions: [{ passed: false, todo: false, actual: false, expected: true }],
-      });
+    const output = render({
+      status: 'failed',
+      fullName: ['mod', 'test'],
+      runtime: 5,
+      assertions: [{ passed: false, todo: false, actual: false, expected: true }],
     });
     assert.includes(output, '  ---\n', 'YAML block must open with "  ---"');
     assert.includes(output, '  ...\n', 'YAML block must close with "  ..."');
   });
 
   test('passed assertion emits "ok N module | test # (Nms)" line', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    const output = captureStdout(() => {
-      TAPDisplayTestResult(COUNTER, {
-        status: 'passed',
-        fullName: ['myModule', 'my test'],
-        runtime: 12,
-        assertions: [],
-      });
+    const output = render({
+      status: 'passed',
+      fullName: ['myModule', 'my test'],
+      runtime: 12,
+      assertions: [],
     });
     assert.includes(output, 'ok 1 myModule | my test # (12 ms)\n');
   });
 
   test('skipped assertion emits "ok N ... # skip" line', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    const output = captureStdout(() => {
-      TAPDisplayTestResult(COUNTER, {
-        status: 'skipped',
-        fullName: ['myModule', 'my test'],
-        runtime: 0,
-        assertions: [],
-      });
+    const output = render({
+      status: 'skipped',
+      fullName: ['myModule', 'my test'],
+      runtime: 0,
+      assertions: [],
     });
     assert.includes(output, 'ok 1 myModule | my test # skip\n');
   });
 
   test('todo assertion emits "not ok N ... # TODO" line', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    const output = captureStdout(() => {
-      TAPDisplayTestResult(COUNTER, {
-        status: 'todo',
-        fullName: ['myModule', 'my test'],
-        runtime: 0,
-        assertions: [],
-      });
+    const output = render({
+      status: 'todo',
+      fullName: ['myModule', 'my test'],
+      runtime: 0,
+      assertions: [],
     });
     assert.includes(output, 'not ok 1 myModule | my test # TODO\n');
   });
 
+  test('the TAP sequence number comes from the caller', (assert) => {
+    const output = render(
+      { status: 'passed', fullName: ['m', 't'], runtime: 1, assertions: [] },
+      42,
+    );
+    assert.includes(output, 'ok 42 m | t # (1 ms)\n', 'caller-supplied test number is used');
+  });
+
   test('multiple failed assertions each produce their own YAML block', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    const output = captureStdout(() => {
-      TAPDisplayTestResult(COUNTER, {
-        status: 'failed',
-        fullName: ['mod', 'test'],
-        runtime: 10,
-        assertions: [
-          { passed: false, todo: false, actual: 1, expected: 2 },
-          { passed: false, todo: false, actual: 'a', expected: 'b' },
-        ],
-      });
+    const output = render({
+      status: 'failed',
+      fullName: ['mod', 'test'],
+      runtime: 10,
+      assertions: [
+        { passed: false, todo: false, actual: 1, expected: 2 },
+        { passed: false, todo: false, actual: 'a', expected: 'b' },
+      ],
     });
     assert.includes(output, "name: 'Assertion #1'", 'first assertion block must appear');
     assert.includes(output, "name: 'Assertion #2'", 'second assertion block must appear');
     assert.strictEqual((output.match(/ {2}---\n/g) || []).length, 2, 'two --- delimiters');
     assert.strictEqual((output.match(/ {2}\.\.\.\n/g) || []).length, 2, 'two ... delimiters');
-    assert.strictEqual(COUNTER.errorCount, 2, 'errorCount must reflect both failures');
   });
 
   test('passed assertion within a failed test does not produce a YAML block', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    const output = captureStdout(() => {
-      TAPDisplayTestResult(COUNTER, {
-        status: 'failed',
-        fullName: ['mod', 'test'],
-        runtime: 5,
-        assertions: [
-          { passed: true, todo: false, actual: true, expected: true },
-          { passed: false, todo: false, actual: false, expected: true },
-        ],
-      });
-    });
-    assert.includes(output, "name: 'Assertion #2'", 'the failing assertion must appear');
-    assert.notIncludes(output, "name: 'Assertion #1'", 'the passing assertion must not appear');
-    assert.strictEqual(COUNTER.errorCount, 1, 'only the failing assertion increments errorCount');
-  });
-
-  test('todo assertion within a failed test does not produce a YAML block', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    const output = captureStdout(() => {
-      TAPDisplayTestResult(COUNTER, {
-        status: 'failed',
-        fullName: ['mod', 'test'],
-        runtime: 5,
-        assertions: [
-          { passed: false, todo: true, actual: false, expected: true },
-          { passed: false, todo: false, actual: 0, expected: 1 },
-        ],
-      });
-    });
-    assert.includes(output, "name: 'Assertion #2'", 'the non-todo failure must appear');
-    assert.notIncludes(output, "name: 'Assertion #1'", 'the todo assertion must not appear');
-    assert.strictEqual(COUNTER.errorCount, 1, 'todo assertion must not increment errorCount');
-  });
-});
-
-module('TAP | TAPDisplayTestResult | COUNTER state', { concurrency: true }, () => {
-  test('passed status increments testCount and passCount only', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    captureStdout(() =>
-      TAPDisplayTestResult(COUNTER, {
-        status: 'passed',
-        fullName: ['m', 't'],
-        runtime: 1,
-        assertions: [],
-      }),
-    );
-    assert.strictEqual(COUNTER.testCount, 1);
-    assert.strictEqual(COUNTER.passCount, 1);
-    assert.strictEqual(COUNTER.failCount, 0);
-    assert.strictEqual(COUNTER.skipCount, 0);
-  });
-
-  test('skipped status increments testCount and skipCount only', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    captureStdout(() =>
-      TAPDisplayTestResult(COUNTER, {
-        status: 'skipped',
-        fullName: ['m', 't'],
-        runtime: 0,
-        assertions: [],
-      }),
-    );
-    assert.strictEqual(COUNTER.testCount, 1);
-    assert.strictEqual(COUNTER.skipCount, 1);
-    assert.strictEqual(COUNTER.passCount, 0);
-    assert.strictEqual(COUNTER.failCount, 0);
-  });
-
-  test('failed status increments testCount and failCount only (errorCount via assertions)', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    captureStdout(() =>
-      TAPDisplayTestResult(COUNTER, {
-        status: 'failed',
-        fullName: ['m', 't'],
-        runtime: 1,
-        assertions: [{ passed: false, todo: false, actual: false, expected: true }],
-      }),
-    );
-    assert.strictEqual(COUNTER.testCount, 1);
-    assert.strictEqual(COUNTER.failCount, 1);
-    assert.strictEqual(COUNTER.passCount, 0);
-    assert.strictEqual(COUNTER.skipCount, 0);
-    assert.strictEqual(COUNTER.errorCount, 1);
-  });
-
-  test('todo status increments testCount and todoCount only', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    captureStdout(() =>
-      TAPDisplayTestResult(COUNTER, {
-        status: 'todo',
-        fullName: ['m', 't'],
-        runtime: 0,
-        assertions: [],
-      }),
-    );
-    assert.strictEqual(COUNTER.testCount, 1);
-    assert.strictEqual(COUNTER.todoCount, 1);
-    assert.strictEqual(COUNTER.failCount, 0);
-    assert.strictEqual(COUNTER.skipCount, 0);
-    assert.strictEqual(COUNTER.passCount, 0);
-  });
-});
-
-module('TAP | TAPDisplayTestResult | COUNTER', { concurrency: true }, () => {
-  test('COUNTER.errorCount is initialized and incremented as a number', (assert) => {
-    const COUNTER = {
-      testCount: 0,
-      failCount: 0,
-      skipCount: 0,
-      todoCount: 0,
-      passCount: 0,
-      errorCount: 0,
-    };
-    TAPDisplayTestResult(COUNTER, {
-      status: 'failed',
-      fullName: ['some module', 'some test'],
-      runtime: 10,
-      assertions: [
-        { passed: false, todo: false, actual: null, expected: true, message: 'fail', stack: '' },
-        { passed: false, todo: false, actual: 1, expected: 2, message: 'mismatch', stack: '' },
-      ],
-    });
-
-    assert.strictEqual(typeof COUNTER.errorCount, 'number', 'errorCount must be a number, not NaN');
-    assert.strictEqual(COUNTER.errorCount, 2, 'errorCount should count each failed assertion');
-  });
-
-  test('COUNTER starts with no errorCount property and TAPDisplayTestResult leaves it as a valid number', (assert) => {
-    // Simulates how COUNTER is actually created in run.js / tests-in-browser.js (no errorCount key)
-    const COUNTER = { testCount: 0, failCount: 0, skipCount: 0, todoCount: 0, passCount: 0 };
-    TAPDisplayTestResult(COUNTER, {
+    const output = render({
       status: 'failed',
       fullName: ['mod', 'test'],
       runtime: 5,
       assertions: [
-        { passed: false, todo: false, actual: false, expected: true, message: 'x', stack: '' },
+        { passed: true, todo: false, actual: true, expected: true },
+        { passed: false, todo: false, actual: false, expected: true },
       ],
     });
+    assert.includes(output, "name: 'Assertion #2'", 'the failing assertion must appear');
+    assert.notIncludes(output, "name: 'Assertion #1'", 'the passing assertion must not appear');
+  });
 
-    assert.strictEqual(
-      isNaN(COUNTER.errorCount),
-      false,
-      'COUNTER.errorCount must not be NaN after incrementing an uninitialized property',
-    );
-    assert.strictEqual(COUNTER.errorCount, 1);
+  test('todo assertion within a failed test does not produce a YAML block', (assert) => {
+    const output = render({
+      status: 'failed',
+      fullName: ['mod', 'test'],
+      runtime: 5,
+      assertions: [
+        { passed: false, todo: true, actual: false, expected: true },
+        { passed: false, todo: false, actual: 0, expected: 1 },
+      ],
+    });
+    assert.includes(output, "name: 'Assertion #2'", 'the non-todo failure must appear');
+    assert.notIncludes(output, "name: 'Assertion #1'", 'the todo assertion must not appear');
   });
 });

--- a/test/utils/get-changed-file-paths-in-git-since-test.ts
+++ b/test/utils/get-changed-file-paths-in-git-since-test.ts
@@ -8,6 +8,7 @@ import {
   BLAST_RADIUS_FILES,
   BLAST_RADIUS_PATTERNS,
   getChangedFilePathsInGitSince,
+  runGit,
 } from '../../lib/utils/get-changed-file-paths-in-git-since.ts';
 
 const execFileAsync = promisify(execFile);
@@ -105,5 +106,42 @@ module('Utils | getChangedFilePathsInGitSince | git interaction', { concurrency:
       getChangedFilePathsInGitSince(root, 'no-such-ref'),
       'unknown ref bubbles as a rejection',
     );
+  });
+});
+
+// `--changed` degrades to "run all tests" whenever git fails, but before this bound git could
+// only ever *hang*: nothing killed a wedged child and nothing gave up waiting, so the CLI waited
+// forever. That surfaced as a CI job consumed to its 25-minute timeout with no diagnostic (deno
+// + Windows lane, where node:child_process can leave a spawned child's exit undelivered). An
+// unbounded subprocess in the run path is the bug; these pin the bound.
+//
+// `git hash-object --stdin` reads stdin until EOF and execFile leaves that pipe open, so it
+// never exits on its own — a real, deterministic wedged git, with no stubbing and no reliance on
+// timing luck.
+module('Utils | getChangedFilePathsInGitSince | bounded execution', { concurrency: true }, () => {
+  test('kills and rejects a git that never exits, rather than waiting forever', async (assert) => {
+    const root = await makeRepo({ 'src/app.ts': 'export const a = 1;\n' });
+    const startedAt = Date.now();
+    let error: Error | undefined;
+    try {
+      await runGit(['hash-object', '--stdin'], root, 300);
+    } catch (caught) {
+      error = caught as Error;
+    }
+    const elapsed = Date.now() - startedAt;
+
+    assert.ok(error, 'settles as a rejection instead of hanging forever');
+    assert.ok(elapsed < 10_000, `settles at the bound, not never (took ${elapsed}ms)`);
+    // getChangedFsTree funnels any git error into "run all test files" (covered in
+    // test/setup/get-changed-fs-tree-test.ts), so rejecting here is what converts an
+    // unrecoverable hang into the documented safe fallback.
+  });
+
+  test('a healthy git still resolves normally under the default bound', async (assert) => {
+    const root = await makeRepo({ 'src/app.ts': 'export const a = 1;\n' });
+    await fs.writeFile(path.join(root, 'src/app.ts'), 'export const a = 2;\n');
+    const changed = await getChangedFilePathsInGitSince(root, 'HEAD');
+    assert.ok(changed, 'the bound does not interfere with a normal lookup');
+    assert.ok(changed!.has(path.join(root, 'src/app.ts')), 'the modified file is reported');
   });
 });

--- a/test/utils/metafile-cache-test.ts
+++ b/test/utils/metafile-cache-test.ts
@@ -76,3 +76,66 @@ module('Utils | metafile-cache', { concurrency: true }, () => {
     assert.equal(await readMetafileCache(root), null);
   });
 });
+
+// The cache is written by a build and read by --changed, and in watch mode those happen in the
+// SAME run: run.ts fires buildTestBundle (which writes here) and then calls getChangedFsTree
+// (which reads). `fs.writeFile` truncates on open, so an in-place write leaves the cache empty
+// for the whole write window — a reader that lands there parses garbage, concludes "no metafile
+// cache yet", and silently runs every test file instead of the affected subset. That surfaced as
+// an intermittent CI failure of `--changed --watch scopes only the initial run`, worse under load
+// because a slower write widens the window. These pin the atomic-publish behaviour that fixes it.
+module('Utils | metafile-cache | atomic publish', { concurrency: true }, () => {
+  // Big enough that the write cannot plausibly complete between the calls below — an in-place
+  // write is observably torn here (19/20 reads before the fix), so this needs no timing luck.
+  const BIG: AffectedMetafile = {
+    inputs: Object.fromEntries(
+      Array.from({ length: 400 }, (_, i) => [
+        `src/f${i}.ts`,
+        { imports: [{ path: `src/d${i}.ts` }] },
+      ]),
+    ),
+  };
+
+  test('a read during an in-flight write never sees a torn cache', async (assert) => {
+    const root = await tempProjectRoot();
+    await writeMetafileCache(root, '/cwd', BIG);
+
+    let torn = 0;
+    for (let i = 0; i < 20; i++) {
+      writeMetafileCache(root, '/cwd', BIG); // in flight, exactly as watch mode leaves it
+      if (!(await readMetafileCache(root))) torn++;
+    }
+    assert.equal(torn, 0, 'every concurrent read saw a complete cache');
+  });
+
+  test('the previous cache stays readable until the new one is complete', async (assert) => {
+    const root = await tempProjectRoot();
+    await writeMetafileCache(root, '/first', SAMPLE);
+
+    writeMetafileCache(root, '/second', BIG); // in flight
+    const during = await readMetafileCache(root);
+    assert.ok(during, 'never a miss mid-write');
+    assert.ok(
+      during!.esbuildCwd === '/first' || during!.esbuildCwd === '/second',
+      'sees one whole cache or the other, never a blend',
+    );
+  });
+
+  test('concurrent writers cannot corrupt each other', async (assert) => {
+    const root = await tempProjectRoot();
+    await Promise.all(
+      Array.from({ length: 8 }, (_, i) => writeMetafileCache(root, `/cwd-${i}`, BIG)),
+    );
+    const got = await readMetafileCache(root);
+    assert.ok(got, 'the cache is valid after 8 racing writers');
+    assert.equal(Object.keys(got!.metafile.inputs).length, 400, 'and complete, not truncated');
+  });
+
+  test('publishing leaves no temp files behind', async (assert) => {
+    const root = await tempProjectRoot();
+    await writeMetafileCache(root, '/cwd', SAMPLE);
+    const dir = path.dirname(metafileCachePath(root));
+    const leftovers = (await fs.readdir(dir)).filter((f) => f.endsWith('.tmp'));
+    assert.deepEqual(leftovers, [], 'the temp file is renamed, not abandoned');
+  });
+});

--- a/test/utils/source-map-decoder-test.ts
+++ b/test/utils/source-map-decoder-test.ts
@@ -9,6 +9,7 @@ import {
   isBundleUrl,
   resolveFrame,
   resolveStack,
+  sourceAbsolutePath,
   type Segment,
   type SourceMapDecoder,
 } from '../../lib/utils/source-map-decoder.ts';
@@ -884,3 +885,69 @@ function bundleWithInlineMap(mapJson: object): string {
   const b64 = btoa(JSON.stringify(mapJson));
   return `console.log("bundle");\n//# sourceMappingURL=data:application/json;base64,${b64}`;
 }
+
+// This module is POSIX-only by design (it must run in the browser, so no node:path), but callers
+// hand it OS paths. On Windows an unconverted `outDir` stays one glued segment that a leading
+// `..` pops wholesale, yielding a *relative* path — which silently defeats the `/node_modules/`
+// and project-root prefix checks downstream. Windows shapes are simulated so this is provable
+// on any platform.
+module('Utils | source-map-decoder | Windows path handling', { concurrency: true }, () => {
+  const decoderFor = (outDir: string): SourceMapDecoder =>
+    parseSourceMap(
+      JSON.stringify({
+        version: 3,
+        sources: ['../../node_modules/qunitx/dist/browser/index.js', '../../src/app.ts'],
+        sourcesContent: [null, null],
+        mappings: '',
+      }),
+      outDir,
+    );
+
+  test('resolves sources to absolute paths from a POSIX outDir', (assert) => {
+    const decoder = decoderFor('/proj/tmp/run-x');
+    assert.strictEqual(
+      sourceAbsolutePath(decoder, 0),
+      '/proj/node_modules/qunitx/dist/browser/index.js',
+    );
+    assert.strictEqual(sourceAbsolutePath(decoder, 1), '/proj/src/app.ts');
+  });
+
+  test('resolves sources to absolute paths from a Windows outDir', (assert) => {
+    const decoder = decoderFor('D:\\a\\proj\\tmp\\run-x');
+    assert.strictEqual(
+      sourceAbsolutePath(decoder, 0),
+      'D:/a/proj/node_modules/qunitx/dist/browser/index.js',
+      'backslash outDir must not collapse into a relative path',
+    );
+    assert.strictEqual(sourceAbsolutePath(decoder, 1), 'D:/a/proj/src/app.ts');
+  });
+
+  test('a Windows-resolved dependency path still reads as node_modules', (assert) => {
+    // The consequence that matters: without normalization this path lost its leading segments,
+    // so `/node_modules/` never matched and dependencies leaked into coverage / user frames.
+    const dependency = sourceAbsolutePath(decoderFor('D:\\a\\proj\\tmp\\run-x'), 0)!;
+    assert.true(dependency.includes('/node_modules/'), 'dependency is detectable as a dependency');
+  });
+
+  test('resolveStack strips a Windows projectRoot prefix from user frames', (assert) => {
+    const decoder = parseSourceMap(
+      JSON.stringify({
+        version: 3,
+        sources: ['../src/app.ts'],
+        sourcesContent: ['const a = 1;\n'],
+        mappings: 'AAAA',
+      }),
+      'D:\\a\\proj\\tmp',
+    );
+    const { firstUserFrame } = resolveStack(
+      '    at fn (http://localhost:1234/tests.js:1:1)',
+      decoder,
+      'D:\\a\\proj',
+    );
+    assert.strictEqual(firstUserFrame, 'src/app.ts:1:1', 'display path is project-relative');
+  });
+
+  test('returns null for an out-of-range source index', (assert) => {
+    assert.strictEqual(sourceAbsolutePath(decoderFor('/proj/tmp'), 99), null);
+  });
+});


### PR DESCRIPTION
Rebased onto `main` (0.27.0). Seven commits, one per concern.

## The axis split (the important bit)

`--reporter=junit` originally kept TAP on stdout and *additionally* wrote a file. That's incompatible with what `--reporter` must mean once spec/dot/github exist — those **replace** stdout. One flag can't be both, and `--reporter=junit --reporter=dot` had no coherent reading. So the axes are split, matching what `--coverage=lcov,html` already did for artifacts:

```
--reporter=tap|spec|dot|github   # owns stdout, exactly one, default tap
--junit[=<path>]                 # additive artifact
--coverage[=lcov,html]           # additive artifact
```

`qunitx test/ --reporter=dot --junit=out.xml` is the canonical CI line.

**BREAKING:** `--reporter=junit` and `--junit-output` are gone — but neither ever shipped (both were added earlier on this same unmerged branch), so no released behavior changes.

## Reporters

| | |
|---|---|
| `tap` | default, unchanged — it's qunitx's identity and `assert.tapResult` parses it |
| `spec` | module-grouped, inline failures with source-mapped locations |
| `dot` | one char per test, failures detailed at the end; for large suites/CI logs |
| `github` | spec output + `::error file=,line=,col=` annotations on the PR diff |

`github` is the sleeper: annotations otherwise cost an artifact upload, a second workflow, a third-party action, and a fork-token dance (see `test-report.yml`). Here it's one flag, and it annotates your `.ts` — not the bundle — because the source map is already resolved.

## Also included (from the original PR)

- **`--junit`** — one `<testsuite>` per module, `<failure>` with a source-mapped stack, `<skipped/>` for skip/todo.
- **`--coverage`** — V8 line coverage over CDP (chromium only), mapped through the bundle source map. Terminal summary; `--coverage=lcov,html` adds `<output>/coverage/`. Excludes node_modules + test files.

## No plugin system — deliberately

The reporter interface is **internal**: not exported from the package entry, no stability promise. Two reasons:

1. **The payload is still moving.** This PR unified two *divergent* `TestDetails` copies that had already drifted between `display-test-result.ts` and `junit.ts`. Freezing QUnit's `testEnd` shape as third-party surface makes every QUnit upgrade a downstream break.
2. **The JS API on the TODO is the plugin system, done once.** If `runTests()` exposes the event stream, custom reporters fall out for free — one public contract instead of two overlapping ones. Node's `--reporter=./my.ts` model is purely additive, so it costs nothing to add later; Deno ships four reporters and no extension point, and nobody complains.

Four reporters landed without needing one. The interface earned its keep as a refactor, not as API.

## Notes

- The refactor commit is behavior-preserving: TAP output is byte-identical (verified against the full suite, unchanged).
- Counter math is split out of the TAP formatter — `COUNTER` drives the exit code and the TAP plan, so it must update exactly once per test regardless of how many reporters are attached.
- `# QUnitX running:` is now gated to tap/`--debug` (it's a TAP comment; it was noise in a non-TAP stream).
- Every commit passes `deno lint` + `lint:docs` individually (bisect-safe). Full suite green: **716 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)