### PR TITLE
fix(run): fail a timed-out browser run instead of silently exiting 0

### DIFF
--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -790,6 +790,10 @@ async function runTestInsideHTMLFile(
   config: Config,
 ): Promise<void> {
   let QUNIT_RESULT: QUnitResult | null | undefined;
+  // Whether the browser sent a WS 'done' message. QUnit fires done even for an empty file, so
+  // this is what tells a genuinely-empty run (done, 0 tests) apart from a timeout that never ran
+  // tests (no done, but the runtime pre-initialised window.QUNIT_RESULT to a 0 tally).
+  let doneReceived = false;
   let targetError: unknown;
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   // wsConnected is set by config.state.group.signals.onWsOpen when Chrome's WS socket opens (< 1s after navigation,
@@ -923,6 +927,7 @@ async function runTestInsideHTMLFile(
     // Prefer the QUNIT_RESULT piggy-backed on the WS 'done' message — zero extra latency.
     // Fall back to page.evaluate() only when the run timed out without a WS 'done' arriving
     // (config.state.group.lastQUnitResult is null), so we still get partial results for diagnostics.
+    doneReceived = config.state.group.lastQUnitResult != null;
     QUNIT_RESULT =
       config.state.group.lastQUnitResult ??
       (await page.evaluate(() => (globalThis as { QUNIT_RESULT?: QUnitResult }).QUNIT_RESULT));
@@ -954,7 +959,21 @@ async function runTestInsideHTMLFile(
     }
   }
 
-  if (!QUNIT_RESULT) {
+  const outcome = classifyRunOutcome(QUNIT_RESULT, doneReceived);
+  const failRun = () =>
+    failOnNonWatchMode(
+      config.watch,
+      { server, browser, page },
+      config.state.group.groupMode,
+      config.state.group.pendingConsoleHandlers,
+      !!config.state.daemon,
+    );
+
+  if (outcome.kind === 'no-tests-ran') {
+    // No 'done' arrived: either no QUnit tally at all, or a zero tally the runtime pre-initialised
+    // before tests.js ran (a CPU-starved page load whose race timer fired first). Both mean the
+    // tests never executed — a timeout, not a green run. This used to slip through as a silent
+    // exit-0 when the pre-initialised {totalTests:0} looked like a genuinely empty file.
     if (targetError) console.log(targetError);
     const wsReason = !wsConnected
       ? 'WebSocket connection never received — Chrome may be CPU-starved or the page failed to load'
@@ -962,31 +981,19 @@ async function runTestInsideHTMLFile(
     console.log(`# TIMEOUT: ${wsReason}`);
     console.log('BROWSER: runtime error thrown during executing tests');
     console.error('BROWSER: runtime error thrown during executing tests');
-    await failOnNonWatchMode(
-      config.watch,
-      { server, browser, page },
-      config.state.group.groupMode,
-      config.state.group.pendingConsoleHandlers,
-      !!config.state.daemon,
-    );
-  } else if (QUNIT_RESULT.totalTests === 0) {
-    // QUnit ran but no tests were registered (or QUnit was not present in the bundle).
-    // This is not a failure — handled at the runTestsInBrowser level as a warning.
+    await failRun();
+  } else if (outcome.kind === 'empty') {
+    // QUnit fired 'done' with zero registered tests — a genuinely empty file (e.g. a helper).
+    // Not a failure — handled at the runTestsInBrowser level as a warning.
     return;
-  } else if (QUNIT_RESULT.totalTests > QUNIT_RESULT.finishedTests) {
+  } else if (outcome.kind === 'stalled') {
     if (targetError) console.log(targetError);
     console.log(
-      `# TIMEOUT: test stalled after ${QUNIT_RESULT.finishedTests}/${QUNIT_RESULT.totalTests} finished — last active: ${QUNIT_RESULT.currentTest}`,
+      `# TIMEOUT: test stalled after ${QUNIT_RESULT!.finishedTests}/${QUNIT_RESULT!.totalTests} finished — last active: ${QUNIT_RESULT!.currentTest}`,
     );
-    console.log(`BROWSER: TEST TIMED OUT: ${QUNIT_RESULT.currentTest}`);
-    console.error(`BROWSER: TEST TIMED OUT: ${QUNIT_RESULT.currentTest}`);
-    await failOnNonWatchMode(
-      config.watch,
-      { server, browser, page },
-      config.state.group.groupMode,
-      config.state.group.pendingConsoleHandlers,
-      !!config.state.daemon,
-    );
+    console.log(`BROWSER: TEST TIMED OUT: ${QUNIT_RESULT!.currentTest}`);
+    console.error(`BROWSER: TEST TIMED OUT: ${QUNIT_RESULT!.currentTest}`);
+    await failRun();
   } else if (config.state.groupCount === 1) {
     // Every registered test finished. The WebSocket testEnd stream is the only channel that
     // feeds the counter, and under load (a CPU-starved CI runner, a dropped or duplicated
@@ -996,7 +1003,7 @@ async function runTestInsideHTMLFile(
     // authoritative, so trust it. Single-group only: the shared counter is this run's own
     // count here; with several concurrent groups it aggregates all of them, so one group's
     // tally cannot safely rewrite it (the multi-group failure safety net below still applies).
-    const undelivered = reconcileUndeliveredResults(config.state.results.counter, QUNIT_RESULT);
+    const undelivered = reconcileUndeliveredResults(config.state.results.counter, QUNIT_RESULT!);
     if (undelivered > 0) {
       const warning =
         `# [qunitx] WARNING: ${undelivered} test result(s) finished in the browser but never ` +
@@ -1006,12 +1013,39 @@ async function runTestInsideHTMLFile(
       process.stdout.write(warning);
       process.stderr.write(warning);
     }
-  } else if (QUNIT_RESULT.failedTests > config.state.results.counter.failCount) {
+  } else if (QUNIT_RESULT!.failedTests > config.state.results.counter.failCount) {
     // Multi-group safety net: the shared counter aggregates every group, so we cannot rewrite
     // its total from one group's tally — but a failure the WS stream dropped must still count,
     // and only bumping failCount up is always safe. Keeps the exit code correct.
-    config.state.results.counter.failCount = QUNIT_RESULT.failedTests;
+    config.state.results.counter.failCount = QUNIT_RESULT!.failedTests;
   }
+}
+
+/** How a browser run ended, decided from QUnit's tally plus whether a WS `done` arrived. */
+export type RunOutcome =
+  | { kind: 'completed' } // every registered test finished; the caller reconciles the counter
+  | { kind: 'empty' } // QUnit fired `done` with zero registered tests — a genuinely empty file
+  | { kind: 'no-tests-ran' } // no `done`: a timeout that never executed tests (fail, not green)
+  | { kind: 'stalled' }; // registered tests started but not all finished before the timer
+
+/**
+ * Classifies a finished browser run.
+ *
+ * `doneReceived` is the load-bearing signal. QUnit fires `done` even for a file with no tests, so
+ * a zero-test tally *with* a `done` is a genuinely empty file. But the injected runtime
+ * pre-initialises `window.QUNIT_RESULT` to a zero tally at page load, so a run that timed out
+ * before `tests.js` executed also reads `totalTests === 0` — *without* a `done`. Treating those
+ * two identically is what let a CPU-starved timeout on CI pass silently as an empty, exit-0 run
+ * (v0.31.0 windows-latest --coverage). The `done` flag tells them apart.
+ */
+export function classifyRunOutcome(
+  result: QUnitResult | null | undefined,
+  doneReceived: boolean,
+): RunOutcome {
+  if (!result) return { kind: 'no-tests-ran' };
+  if (result.totalTests === 0) return doneReceived ? { kind: 'empty' } : { kind: 'no-tests-ran' };
+  if (result.totalTests > result.finishedTests) return { kind: 'stalled' };
+  return { kind: 'completed' };
 }
 
 /**

--- a/lib/setup/web-server.ts
+++ b/lib/setup/web-server.ts
@@ -988,7 +988,10 @@ function testRuntimeToInject(config: Config, groupId?: number): string {
           // waiting for the inactivity timeout. The runner treats totalTests === 0 as a
           // "no tests registered" warning (not a failure), so this gives a fast, clean result.
           window.QUNIT_RESULT = { totalTests: 0, finishedTests: 0, failedTests: 0, currentTest: null };
-          window.socket.send(JSON.stringify({ event: 'done', details: { passed: 0, failed: 0, runtime: 0 } }));
+          // Carry qunitResult so Node records a real 'done' (lastQUnitResult set). Without it,
+          // a no-QUnit file is indistinguishable from a timeout that never ran tests — both leave
+          // lastQUnitResult null — and the run would fail instead of reporting an empty file.
+          window.socket.send(JSON.stringify({ event: 'done', details: { passed: 0, failed: 0, runtime: 0 }, qunitResult: window.QUNIT_RESULT }));
         }
         return;
       }

--- a/test/commands/run/classify-outcome-test.ts
+++ b/test/commands/run/classify-outcome-test.ts
@@ -1,0 +1,57 @@
+import { module, test } from 'qunitx';
+import { classifyRunOutcome } from '../../../lib/commands/run/tests-in-browser.ts';
+import type { QUnitResult } from '../../../lib/types.ts';
+
+// Regression coverage for the silent exit-0 flake on v0.31.0 windows-latest (--coverage). The
+// injected runtime pre-initialises window.QUNIT_RESULT to a zero tally at page load, so a run
+// that timed out before tests.js executed reads `totalTests === 0` — identical to a genuinely
+// empty file. Treating them the same let a CPU-starved timeout pass silently as green. QUnit
+// fires `done` even for an empty file, so the presence of a `done` is what separates them.
+
+const result = (over: Partial<QUnitResult> = {}): QUnitResult => ({
+  totalTests: 4,
+  finishedTests: 4,
+  failedTests: 0,
+  currentTest: null,
+  ...over,
+});
+
+module('Commands | run | classifyRunOutcome', { concurrency: true }, () => {
+  test('zero tests WITH a done is a genuinely empty file (benign)', (assert) => {
+    assert.deepEqual(classifyRunOutcome(result({ totalTests: 0, finishedTests: 0 }), true), {
+      kind: 'empty',
+    });
+  });
+
+  test('zero tests WITHOUT a done is a timeout, not empty — the flake', (assert) => {
+    // The runtime pre-initialised the tally; the race timer fired before tests.js ran.
+    assert.deepEqual(classifyRunOutcome(result({ totalTests: 0, finishedTests: 0 }), false), {
+      kind: 'no-tests-ran',
+    });
+  });
+
+  test('no result object at all is a timeout regardless of the done flag', (assert) => {
+    assert.deepEqual(classifyRunOutcome(undefined, false), { kind: 'no-tests-ran' });
+    assert.deepEqual(classifyRunOutcome(null, true), { kind: 'no-tests-ran' });
+  });
+
+  test('all registered tests finished is a completed run', (assert) => {
+    assert.deepEqual(classifyRunOutcome(result({ totalTests: 4, finishedTests: 4 }), true), {
+      kind: 'completed',
+    });
+  });
+
+  test('a completed run is reported even when done was lost (transport, not execution)', (assert) => {
+    // finished === total means the tests ran; a missing done is a delivery problem the caller
+    // reconciles, not a timeout. Must NOT be misread as no-tests-ran.
+    assert.deepEqual(classifyRunOutcome(result({ totalTests: 4, finishedTests: 4 }), false), {
+      kind: 'completed',
+    });
+  });
+
+  test('fewer finished than registered is a stall', (assert) => {
+    assert.deepEqual(classifyRunOutcome(result({ totalTests: 4, finishedTests: 2 }), true), {
+      kind: 'stalled',
+    });
+  });
+});


### PR DESCRIPTION
## The bug

v0.31.0's release CI failed on **windows-latest / --coverage**: the run printed the header, produced **no test output, and exited 0** — a silent green on a run that never executed its tests.

## Root cause

The injected runtime pre-initialises `window.QUNIT_RESULT = { totalTests: 0, … }` at page load (`web-server.ts`). On a CPU-starved CI runner the page can commit and load the runtime, but the race timer fires before `tests.js` executes. The runner then reads a **truthy `{ totalTests: 0 }`** — indistinguishable from a genuinely empty file — and took the benign *"0 tests registered", exit 0* path.

Same family as the earlier line-target flake; the reconciliation fix (`f96ae4e`) closed the `finishedTests > testCount` case, this closes the `totalTests === 0`-via-timeout case.

## The fix — a signal that already exists

QUnit sends a WS `done` for **every** completed run, including an empty file. A timeout sends **none**. That flag separates the two:

- **`classifyRunOutcome(result, doneReceived)`** → `completed` / `empty` / `no-tests-ran` / `stalled`, extracted and **unit-tested (6 cases)**, no browser needed.
- `no-tests-ran` (zero tests with no `done`, or no result at all) now **fails with the existing TIMEOUT diagnostic** instead of returning benign.

One supporting fix: the *"QUnit not found"* runtime path (a bundle that never imports qunitx) sent `done` **without** `qunitResult`, leaving `lastQUnitResult` null — indistinguishable from a timeout. It now carries the zero tally, so a genuinely empty file is classified `empty` and **still exits 0** (the `no-tests` suite proves it).

## Guarantees

- **No timeout widened, no retry added** — this makes a lost run *report* what happened, per the repo's flake philosophy.
- Genuinely empty files still exit 0 (`test/inputs/no-tests-test.ts` green).
- Full suite green on **node (958)** and **deno** (all phases, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)