### PR TITLE
refactor(chrome): collapse earlyChrome / earlyChromeProc into one (closes #50)

### DIFF
--- a/lib/chrome/prelaunch.ts
+++ b/lib/chrome/prelaunch.ts
@@ -5,6 +5,7 @@ import { killProcessGroup } from '../utils/kill-process-group.ts';
 import { CHROMIUM_ARGS } from './args.ts';
 import { perfLog } from '../utils/perf-logger.ts';
 import { daemonInfoPath } from '../commands/daemon/socket-path.ts';
+import type { ChromeHandle } from '../types.ts';
 
 // This module is statically imported by cli.ts so its module-level code runs
 // at the very start of the process — before the IIFE, before playwright-core loads.
@@ -62,20 +63,17 @@ const isDaemonClientRun =
 // With --open alone, qunitx exits after tests complete; the detached browser is opened separately.
 const openWatchMode = openFromArgv && watchFromArgv;
 
-// Stored so the process.on('exit') safety net and shutdownPrelaunch() can reach Chrome.
-let earlyChrome: import('../types.ts').EarlyChrome | null = null;
-// Tracked synchronously the moment Chrome is spawned (before CDP-ready) so the
-// process.on('exit') fallback can SIGKILL the Chrome process even if the daemon
-// exits mid-launch. Without this the decoupled-launch daemon path leaks Chrome
-// when shutdown happens during the gap between spawn and CDP-ready, because
-// `detached: true` keeps the Chrome process group alive after the parent dies.
-let earlyChromeProc: import('node:child_process').ChildProcess | null = null;
+// The pre-launched Chrome's handle, reachable by the process.on('exit') safety net and
+// shutdownPrelaunch(). Set synchronously the instant Chrome is spawned (via onSpawn below), so it
+// is never partial: null before spawn, or a complete handle with a callable shutdown. That
+// invariant is load-bearing — shutdownPrelaunch()'s guard depends on it — and it closes the leak
+// window where a parent process.exit() between spawn and CDP-ready would orphan Chrome (the
+// detached process group outlives the parent).
+let earlyChrome: ChromeHandle | null = null;
 
 if (!openWatchMode) {
   process.on('exit', () => {
-    // Prefer the fully-realised earlyChrome (it points to the same proc); fall back
-    // to the synchronously-tracked proc when CDP-ready hasn't fired yet.
-    const proc = earlyChrome?.proc ?? earlyChromeProc;
+    const proc = earlyChrome?.proc;
     if (proc?.pid == null) return;
     // Last-resort kill: fires in edge cases where process.exit() is called without going
     // through shutdownPrelaunch() (e.g. buildFSTree ENOENT, signal kills, daemon
@@ -118,18 +116,15 @@ export const prelaunchPromise =
     ? findChrome()
         .then((chromePath) => {
           perfLog('chrome-prelaunch.ts: findChrome resolved', chromePath);
-          // onSpawn fires synchronously inside preLaunchChrome the instant Chrome
-          // is `spawn()`d, before the CDP-ready stderr match. Tracking the proc
-          // here closes the leak window during which a parent process.exit()
-          // would otherwise leave Chrome orphaned (the on('exit') hook above
-          // only had access to `earlyChrome` post-CDP-ready before this change).
-          return preLaunchChrome(chromePath, CHROMIUM_ARGS, !openWatchMode, (proc) => {
-            earlyChromeProc = proc;
+          // onSpawn fires synchronously inside preLaunchChrome the instant Chrome is spawned,
+          // before the CDP-ready stderr match — so earlyChrome holds a fully-callable handle for
+          // the entire process lifetime, including the spawn→CDP-ready gap.
+          return preLaunchChrome(chromePath, CHROMIUM_ARGS, !openWatchMode, (handle) => {
+            earlyChrome = handle;
           });
         })
         .then((info) => {
           perfLog('chrome-prelaunch.ts: Chrome CDP ready', info?.cdpEndpoint ?? null);
-          if (info) earlyChrome = info;
           return info;
         })
     : Promise.resolve(null);

--- a/lib/chrome/spawn.ts
+++ b/lib/chrome/spawn.ts
@@ -5,7 +5,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import type { Socket } from 'node:net';
-import type { EarlyChrome } from '../types.ts';
+import type { ChromeHandle, EarlyChrome } from '../types.ts';
 
 const CDP_URL_REGEX = /DevTools listening on (ws:\/\/[^\s]+)/;
 
@@ -18,7 +18,7 @@ export async function preLaunchChrome(
   chromePath: string | null | undefined,
   args: string[],
   headless = true,
-  onSpawn?: (proc: import('node:child_process').ChildProcess) => void,
+  onSpawn?: (handle: ChromeHandle) => void,
 ): Promise<EarlyChrome | null> {
   if (!chromePath) return null;
 
@@ -33,17 +33,16 @@ export async function preLaunchChrome(
     // subprocesses from accumulating inotify watches across test runs.
     { stdio: ['ignore', 'ignore', 'pipe'], detached: true },
   );
-  // Notify the caller of the spawned proc synchronously, BEFORE the CDP-ready
-  // wait below resolves. The caller (chrome-prelaunch.ts) uses this to track
-  // the Chrome PID immediately so its process.on('exit') fallback can SIGKILL
-  // Chrome even if the process exits while CDP is still negotiating —
-  // important for the daemon's decoupled-launch path where the daemon can
-  // shut down with Chrome still mid-launch and otherwise leak the process.
-  onSpawn?.(proc);
+  // Hand the caller a full handle — proc AND shutdown — synchronously, BEFORE the CDP-ready
+  // wait below resolves. `shutdown` is a hoisted declaration closing over just `proc` and
+  // `userDataDir`, so it is fully callable this early. The caller (chrome-prelaunch.ts) stores
+  // it so both its process.on('exit') reaper and shutdownPrelaunch() can act on a Chrome that
+  // dies while CDP is still negotiating — the decoupled-launch daemon path, or any early crash.
+  onSpawn?.({ proc, shutdown });
 
-  // Cleanup runs exactly one path: rm() here when Chrome never connected (shutdown() won't
-  // be called), or cleanupBrowserDir() in shutdown() when it did. The cdpConnected flag
-  // ensures only one path ever touches userDataDir.
+  // userDataDir is cleaned exactly once. On a dead-on-arrival Chrome the `close` handler below
+  // rm()s it; on a normal run shutdown()'s cleanupBrowserDir() does. Both use rm({ force: true }),
+  // so if shutdown() is now called in the pre-CDP window as well, the second removal is a no-op.
   let cdpConnected = false;
 
   proc.on('close', () => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -477,11 +477,21 @@ export interface Connections {
  * A Chrome process started via CDP pre-launch before `playwright-core` has loaded.
  * Stored in a module-level promise in `chrome-prelaunch.ts` and consumed by `browser.ts`.
  */
-export interface EarlyChrome {
+/**
+ * Handles to a pre-launched Chrome, available **synchronously** the moment it is spawned —
+ * before the CDP endpoint is known. Enough to reap the process and its temp dir, which is all
+ * the `process.on('exit')` safety net and `shutdownPrelaunch()` need.
+ */
+export interface ChromeHandle {
   /** The spawned Chrome child process. */
   proc: ChildProcess;
+  /** Kills Chrome and awaits async temp-dir cleanup. Safe to call before CDP is ready, and
+   * idempotent with Chrome's own dead-on-arrival cleanup. Call before `process.exit()`. */
+  shutdown: () => Promise<void>;
+}
+
+/** A {@link ChromeHandle} plus the CDP endpoint, resolved once Chrome is listening. */
+export interface EarlyChrome extends ChromeHandle {
   /** The `ws://` URL exposed by Chrome's CDP remote debugging endpoint. */
   cdpEndpoint: string;
-  /** Kills Chrome and awaits async temp-dir cleanup. Call before `process.exit()`. */
-  shutdown: () => Promise<void>;
 }

--- a/test/chrome/spawn-shutdown-test.ts
+++ b/test/chrome/spawn-shutdown-test.ts
@@ -1,0 +1,53 @@
+import { module, test } from 'qunitx';
+import { preLaunchChrome } from '../../lib/chrome/spawn.ts';
+import type { ChromeHandle } from '../../lib/types.ts';
+
+// Regression coverage for issue #50. `shutdown` closes over only proc + userDataDir, both known at
+// spawn, so preLaunchChrome hands back a FULL handle synchronously via onSpawn — before the CDP
+// endpoint is known. That is what lets chrome-prelaunch.ts keep one `earlyChrome` variable with a
+// null-or-realized invariant instead of two. The failure mode this guards: a Chrome that dies
+// before CDP-ready must still yield a callable `shutdown` that reaps without throwing. A naive
+// collapse (earlyChrome partial, shutdown absent in that window) would `undefined()` here.
+//
+// A real Chrome binary is not needed: `process.execPath` (node) spawned with Chrome's flags
+// rejects them and exits immediately, never printing a "DevTools listening on ws://" line — a
+// faithful, deterministic stand-in for "spawned, then died before CDP-ready".
+const FAKE_CHROME = process.execPath;
+
+module('Chrome | preLaunchChrome shutdown handle', { concurrency: true }, () => {
+  test('delivers a complete, callable handle synchronously at spawn', async (assert) => {
+    let handleAtSpawn: ChromeHandle | undefined;
+    const result = await preLaunchChrome(FAKE_CHROME, [], true, (handle) => {
+      handleAtSpawn = handle;
+    });
+
+    assert.ok(handleAtSpawn, 'onSpawn fired before preLaunchChrome resolved');
+    assert.ok(handleAtSpawn!.proc, 'the handle carries the spawned process');
+    assert.equal(typeof handleAtSpawn!.shutdown, 'function', 'and a callable shutdown — pre-CDP');
+    assert.equal(result, null, 'a Chrome that never prints a CDP endpoint resolves null');
+  });
+
+  test('shutdown() on a Chrome that died before CDP-ready resolves without throwing', async (assert) => {
+    let handle: ChromeHandle | undefined;
+    await preLaunchChrome(FAKE_CHROME, [], true, (h) => {
+      handle = h;
+    });
+
+    // The exact footgun the naive one-variable collapse would reintroduce: shutdown missing here.
+    await handle!.shutdown();
+    assert.ok(true, 'shutdown completed cleanly on an already-dead process');
+
+    // Idempotent: the exit-handler safety net may also fire, so a second call must be harmless.
+    await handle!.shutdown();
+    assert.ok(true, 'a second shutdown is a no-op, not a crash');
+  });
+
+  test('returns null immediately when no chrome path is given', async (assert) => {
+    let spawned = false;
+    const result = await preLaunchChrome(null, [], true, () => {
+      spawned = true;
+    });
+    assert.equal(result, null, 'no path → no launch');
+    assert.notOk(spawned, 'onSpawn never fires when nothing is spawned');
+  });
+});

--- a/test/flags/watch-rerun-test.ts
+++ b/test/flags/watch-rerun-test.ts
@@ -506,9 +506,20 @@ module('--watch re-run tests', { concurrency: true }, () => {
       const newId = randomUUID();
       await fs.writeFile(symlink, testContent.replace(id, newId)); // writes through symlink to target
 
-      await waitForRunComplete(session, 2, 'symlink write-through re-run to start');
+      // A write-through fires more than one fs event, and a mid-write one can trigger a re-run
+      // that reads the target before its bytes settle — a stale rebuild without newId. The
+      // content-hash gate then rebuilds once more on the settled write. Wait for the re-run that
+      // actually reflects the new content rather than asserting on whichever run happened to be
+      // second: in CI run 29790598868 a stale second run reached the assertion first and failed
+      // it. Waiting for the settled content tests the guarantee a user cares about (the watcher
+      // eventually shows the new bytes) and stays deterministic; a watcher that never converges
+      // still fails here on the waitFor timeout.
+      const rerunBuf = await session.waitFor((buf) => {
+        const latest = buf.slice(buf.lastIndexOf('QUnitX running:'));
+        return latest.includes(newId) && latest.includes('# duration');
+      }, 'symlink write-through re-run reflecting the new content');
 
-      const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
+      const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
       assert.includes(rerunOutput, newId);
       assert.includes(rerunOutput, '# fail 0');
     } finally {


### PR DESCRIPTION
Closes #50.

## Before

`chrome-prelaunch.ts` tracked the pre-launched Chrome with **two** module-level variables:

```ts
let earlyChrome: EarlyChrome | null = null;      // full handle, set post-CDP-ready (~t=370ms)
let earlyChromeProc: ChildProcess | null = null; // raw proc, set synchronously at spawn (~t=5ms)
```

and the `process.on('exit')` reaper read `earlyChrome?.proc ?? earlyChromeProc` to cover the ~365ms gap between spawn and CDP-ready.

## After

`shutdown` closes over only `proc` + `userDataDir`, both known at spawn — so `preLaunchChrome` now hands the caller a complete `ChromeHandle { proc, shutdown }` **synchronously** via `onSpawn`, and adds `cdpEndpoint` only on the resolved `EarlyChrome`. `earlyChrome` is set once, at spawn, and is **never partial**: null, or a realized handle with a callable `shutdown`.

That restores the invariant `shutdownPrelaunch()`'s `if (!earlyChrome) return` guard depends on, and lets `earlyChromeProc` and the `?? earlyChromeProc` fallback go away.

## Why not the obvious collapse

The naive version — `earlyChrome = { proc }` at spawn, upgraded to the full handle post-CDP — was **rejected in the issue** and here: it leaves `earlyChrome` truthy-but-`shutdown`-less if Chrome dies before CDP-ready, so `shutdownPrelaunch` would call `undefined()`. Delivering the whole handle up front avoids that partial state entirely, keeping the guard a simple `!earlyChrome`.

## Behavior note

`shutdownPrelaunch` is now functional in the pre-CDP window (it was a no-op). No caller invokes it that early, so it is dormant-but-correct. `userDataDir` cleanup stays single-path in practice and is `rm({ force: true })`-idempotent if it ever isn't.

## Test

`test/chrome/spawn-shutdown-test.ts` covers the **spawn-then-die-before-CDP** path the issue required: the handle arrives synchronously with a callable `shutdown`, and `shutdown()` reaps without throwing (and is idempotent) — the exact footgun the naive collapse would reintroduce. `process.execPath` spawned with Chrome's flags is a deterministic stand-in (exits immediately, never prints a CDP line), so no real Chrome binary is needed.

## Verified

- Full suite green on **node (961)** and **deno** (all phases, 0 failed), including `test/resource-leak.ts` (no orphaned Chrome dirs/processes) and the daemon suite (the decoupled-launch path this touches).
- Zero leaked `qunitx-chrome-*` dirs after real e2e runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)