### PR TITLE
Stream<T, E> — many outcomes over time, same failure vocabulary

### DIFF
--- a/lib/stream/index.ts
+++ b/lib/stream/index.ts
@@ -1,0 +1,21 @@
+// Barrel for the Stream leg of the error system.
+//
+//   import { Stream } from '.../lib/stream/index.ts';
+//
+// One system, three shapes, one failure vocabulary: `Result` is a settled outcome, `Task` a
+// future outcome, `Stream` many outcomes over time — elements are the bare `T | E` union,
+// terminal consumers return Tasks, and `Failure` is the single error currency throughout.
+export { Stream, type Source } from './stream.ts';
+
+export { Task } from '../task/task.ts';
+
+/**
+ * Structured, discriminable failures — the `E` elements of a Stream.
+ *
+ * ```ts
+ * import * as Failure from '../result/failure.ts';
+ * const Late = Failure.define('Late', (d: { ms: number }) => `arrived ${d.ms}ms late`);
+ * Late.is(Late({ ms: 250 })); // true
+ * ```
+ */
+export * as Failure from '../result/failure.ts';

--- a/lib/stream/stream.ts
+++ b/lib/stream/stream.ts
@@ -130,6 +130,94 @@ class StreamClass<T, E = never> implements AsyncIterable<T | E> {
     });
   }
 
+  /**
+   * Concatenates sources in order — Elixir's `Stream.concat`, variadic.
+   *
+   * ```ts
+   * await Stream.concat([1, 2], [3]).values(); // [1, 2, 3]
+   * ```
+   */
+  static concat<U>(
+    ...sources: Source<U>[]
+  ): StreamClass<Exclude<U, AnyFailure>, Extract<U, AnyFailure>> {
+    return new StreamClass(async function* () {
+      for (const source of sources) yield* iterate(source);
+    }) as never;
+  }
+
+  /**
+   * Repeats a re-iterable source forever — always bound it (`take`, `takeWhile`).
+   *
+   * ```ts
+   * await Stream.cycle([1, 2]).take(5).values(); // [1, 2, 1, 2, 1]
+   * ```
+   */
+  static cycle<U>(source: Source<U>): StreamClass<Exclude<U, AnyFailure>, Extract<U, AnyFailure>> {
+    return new StreamClass(async function* () {
+      for (;;) {
+        let yielded = false;
+        for await (const element of iterate(source)) {
+          yielded = true;
+          yield element;
+        }
+        if (!yielded) return; // an empty source must not spin forever
+      }
+    }) as never;
+  }
+
+  /**
+   * `seed, fn(seed), fn(fn(seed)), …` — Elixir's `Stream.iterate/2`, infinite.
+   *
+   * ```ts
+   * await Stream.iterate(1, (n) => n * 2).take(4).values(); // [1, 2, 4, 8]
+   * ```
+   */
+  static iterate<U>(seed: U, fn: (previous: U) => U): StreamClass<U> {
+    return new StreamClass<U, never>(async function* () {
+      for (let value = seed; ; value = fn(value)) yield value;
+    });
+  }
+
+  /**
+   * Calls `fn` for each pull, forever — Elixir's `Stream.repeatedly/1`.
+   *
+   * ```ts
+   * let n = 0;
+   * await Stream.repeatedly(() => ++n).take(3).values(); // [1, 2, 3]
+   * ```
+   */
+  static repeatedly<U>(fn: () => U | PromiseLike<U>): StreamClass<U> {
+    return new StreamClass<U, never>(async function* () {
+      for (;;) yield await fn();
+    });
+  }
+
+  /**
+   * `count` copies of one value.
+   *
+   * ```ts
+   * await Stream.duplicate('x', 3).values(); // ['x', 'x', 'x']
+   * ```
+   */
+  static duplicate<U>(value: U, count: number): StreamClass<U> {
+    return new StreamClass<U, never>(async function* () {
+      for (let i = 0; i < count; i++) yield value;
+    });
+  }
+
+  /**
+   * The infinite integers `offset, offset + 1, …` — Elixir's `Stream.from_index/1`.
+   *
+   * ```ts
+   * await Stream.fromIndex(10).take(3).values(); // [10, 11, 12]
+   * ```
+   */
+  static fromIndex(offset = 0): StreamClass<number> {
+    return new StreamClass<number, never>(async function* () {
+      for (let n = offset; ; n++) yield n;
+    });
+  }
+
   // ── Transforms — lazy, failures pass through untouched ──────────────────────
 
   /**
@@ -216,6 +304,325 @@ class StreamClass<T, E = never> implements AsyncIterable<T | E> {
         if (++taken >= count) return;
       }
     });
+  }
+
+  /**
+   * Drops the values `predicate` accepts — `filter`'s complement; failures pass through.
+   *
+   * ```ts
+   * await Stream.from([1, 2, 3, 4]).reject((n) => n % 2 === 0).values(); // [1, 3]
+   * ```
+   */
+  reject(predicate: (value: T, index: number) => boolean): StreamClass<T, E> {
+    return this.filter((value, index) => !predicate(value, index));
+  }
+
+  /**
+   * Ends the stream at the first value `predicate` refuses. Failures inside the window pass
+   * through and are never tested — the predicate speaks about values only.
+   *
+   * ```ts
+   * await Stream.from([1, 2, 9, 1]).takeWhile((n) => n < 5).values(); // [1, 2]
+   * ```
+   */
+  takeWhile(predicate: (value: T, index: number) => boolean): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      let index = 0;
+      for await (const element of open()) {
+        if (!isFailure(element) && !predicate(element as T, index++)) return;
+        yield element;
+      }
+    });
+  }
+
+  /**
+   * Discards the first `count` elements — positional like {@link StreamClass#take}, so
+   * values and failures both count (dropping a prefix is an explicit consumer decision).
+   *
+   * ```ts
+   * await Stream.from([1, 2, 3, 4]).drop(2).values(); // [3, 4]
+   * ```
+   */
+  drop(count: number): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      let dropped = 0;
+      for await (const element of open()) {
+        if (dropped < count) dropped++;
+        else yield element;
+      }
+    });
+  }
+
+  /**
+   * Discards values while `predicate` holds, then everything flows. Failures met during the
+   * dropping phase still pass through — a declared failure is never silently swallowed by a
+   * value predicate.
+   *
+   * ```ts
+   * await Stream.from([1, 2, 9, 1]).dropWhile((n) => n < 5).values(); // [9, 1]
+   * ```
+   */
+  dropWhile(predicate: (value: T, index: number) => boolean): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      let index = 0;
+      let dropping = true;
+      for await (const element of open()) {
+        if (dropping && !isFailure(element)) dropping = predicate(element as T, index++);
+        if (!dropping || isFailure(element)) yield element;
+      }
+    });
+  }
+
+  /**
+   * Keeps the values at positions `0, every, 2·every, …` (Elixir's `take_every/2`,
+   * counting values; failures pass through). `every` of 0 keeps nothing.
+   *
+   * ```ts
+   * await Stream.from([0, 1, 2, 3, 4]).takeEvery(2).values(); // [0, 2, 4]
+   * ```
+   */
+  takeEvery(every: number): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      if (every <= 0) return;
+      let index = 0;
+      for await (const element of open()) {
+        if (isFailure(element) || index++ % every === 0) yield element;
+      }
+    });
+  }
+
+  /**
+   * Drops the values at positions `0, every, 2·every, …` (Elixir's `drop_every/2`,
+   * counting values; failures pass through).
+   *
+   * ```ts
+   * await Stream.from([0, 1, 2, 3, 4]).dropEvery(2).values(); // [1, 3]
+   * ```
+   */
+  dropEvery(every: number): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      let index = 0;
+      for await (const element of open()) {
+        if (isFailure(element)) yield element;
+        else if (every <= 0 || index++ % every !== 0) yield element;
+      }
+    });
+  }
+
+  /**
+   * Transforms the values at positions `0, every, 2·every, …`, passing the rest — and every
+   * failure — through unchanged (Elixir's `map_every/3`).
+   *
+   * ```ts
+   * await Stream.from([1, 1, 1, 1]).mapEvery(2, (n) => n * 10).values(); // [10, 1, 10, 1]
+   * ```
+   */
+  mapEvery(every: number, fn: (value: T) => T | PromiseLike<T>): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      let index = 0;
+      for await (const element of open()) {
+        if (isFailure(element)) yield element;
+        else if (every > 0 && index++ % every === 0) yield (await fn(element as T)) as T;
+        else yield element;
+      }
+    });
+  }
+
+  /**
+   * Pairs each value with its index: `[value, index]`. Failures pass bare and consume no
+   * index — pairs stay contiguous.
+   *
+   * ```ts
+   * await Stream.from(['a', 'b']).withIndex(1).values(); // [['a', 1], ['b', 2]]
+   * ```
+   */
+  withIndex(offset = 0): StreamClass<readonly [T, number], E> {
+    const open = this.#open;
+    return new StreamClass<readonly [T, number], E>(async function* () {
+      let index = offset;
+      for await (const element of open()) {
+        if (isFailure(element)) yield element as never;
+        else yield [element as T, index++] as const;
+      }
+    });
+  }
+
+  /**
+   * Emits `separator` between every two elements — positional, so it also separates a value
+   * from a passing failure.
+   *
+   * ```ts
+   * await Stream.from([1, 2, 3]).intersperse(0).values(); // [1, 0, 2, 0, 3]
+   * ```
+   */
+  intersperse<S>(separator: S): StreamClass<T | S, E> {
+    const open = this.#open;
+    return new StreamClass<T | S, E>(async function* () {
+      let first = true;
+      for await (const element of open()) {
+        if (!first) yield separator;
+        first = false;
+        yield element;
+      }
+    });
+  }
+
+  /**
+   * Drops *consecutive* duplicate values by key — failures are transparent: they pass
+   * through without resetting the last-seen memory.
+   *
+   * ```ts
+   * await Stream.from([1, 1, 2, 2, 1]).dedupBy((n) => n).values(); // [1, 2, 1]
+   * ```
+   */
+  dedupBy(key: (value: T) => unknown): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      let last: unknown = Symbol();
+      for await (const element of open()) {
+        if (isFailure(element)) yield element;
+        else {
+          const seen = key(element as T);
+          if (seen !== last) yield element;
+          last = seen;
+        }
+      }
+    });
+  }
+
+  /**
+   * Drops consecutive duplicate values — `dedupBy` with identity.
+   *
+   * ```ts
+   * await Stream.from([1, 1, 2, 1]).dedup().values(); // [1, 2, 1]
+   * ```
+   */
+  dedup(): StreamClass<T, E> {
+    return this.dedupBy((value) => value);
+  }
+
+  /**
+   * Keeps the first occurrence of each value by key, stream-wide (holds a Set of seen keys —
+   * bound infinite streams). Failures pass through.
+   *
+   * ```ts
+   * await Stream.from([1, 2, 1, 3, 2]).uniqBy((n) => n).values(); // [1, 2, 3]
+   * ```
+   */
+  uniqBy(key: (value: T) => unknown): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      const seen = new Set<unknown>();
+      for await (const element of open()) {
+        if (isFailure(element)) yield element;
+        else {
+          const k = key(element as T);
+          if (!seen.has(k)) {
+            seen.add(k);
+            yield element;
+          }
+        }
+      }
+    });
+  }
+
+  /**
+   * Keeps the first occurrence of each value — `uniqBy` with identity.
+   *
+   * ```ts
+   * await Stream.from([1, 2, 1, 2, 3]).uniq().values(); // [1, 2, 3]
+   * ```
+   */
+  uniq(): StreamClass<T, E> {
+    return this.uniqBy((value) => value);
+  }
+
+  /**
+   * Emits the running fold of the values — Elixir's `Stream.scan`; without `initial` the
+   * first value seeds the accumulator. Failures pass through and leave the accumulator
+   * untouched.
+   *
+   * ```ts
+   * await Stream.from([1, 2, 3]).scan((acc, n) => acc + n).values(); // [1, 3, 6]
+   * ```
+   */
+  scan(fn: (accumulator: T, value: T) => T | PromiseLike<T>): StreamClass<T, E>;
+  scan<A>(fn: (accumulator: A, value: T) => A | PromiseLike<A>, initial: A): StreamClass<A, E>;
+  scan<A>(
+    fn: (accumulator: A, value: T) => A | PromiseLike<A>,
+    ...initial: A[]
+  ): StreamClass<A, E> {
+    const open = this.#open;
+    return new StreamClass<A, E>(async function* () {
+      let hasAccumulator = initial.length > 0;
+      let accumulator = initial[0];
+      for await (const element of open()) {
+        if (isFailure(element)) yield element as never;
+        else {
+          // Unseeded, the first value seeds the fold — overload 1 pins A = T there.
+          accumulator = hasAccumulator ? await fn(accumulator, element as T) : (element as never);
+          hasAccumulator = true;
+          yield accumulator;
+        }
+      }
+    });
+  }
+
+  /**
+   * Groups values into arrays of `count` (a trailing partial chunk is emitted). Failures
+   * pass through **between** chunks without breaking the one being assembled — a bad row
+   * never voids the batch around it.
+   *
+   * ```ts
+   * await Stream.from([1, 2, 3, 4, 5]).chunkEvery(2).values(); // [[1, 2], [3, 4], [5]]
+   * ```
+   */
+  chunkEvery(count: number): StreamClass<T[], E> {
+    const open = this.#open;
+    return new StreamClass<T[], E>(async function* () {
+      let chunk: T[] = [];
+      for await (const element of open()) {
+        if (isFailure(element)) yield element as never;
+        else {
+          chunk.push(element as T);
+          if (chunk.length >= count) {
+            yield chunk;
+            chunk = [];
+          }
+        }
+      }
+      if (chunk.length > 0) yield chunk;
+    });
+  }
+
+  /**
+   * The general engine — Elixir's `Stream.transform`, JS-shaped: hand the raw element flow
+   * to your own async generator and yield whatever you want. The one transform where
+   * failures do **not** auto-pass: your generator sees them and owns the ruling. Every
+   * missing combinator is three lines away through this.
+   *
+   * ```ts
+   * const pairs = Stream.from([1, 2, 3, 4]).through(async function* (elements) {
+   *   let previous: number | undefined;
+   *   for await (const n of elements) {
+   *     if (previous !== undefined) yield [previous, n] as const;
+   *     previous = n;
+   *   }
+   * });
+   * await pairs.values(); // [[1, 2], [2, 3], [3, 4]]
+   * ```
+   */
+  through<U>(
+    fn: (elements: AsyncIterable<T | E>) => Source<U>,
+  ): StreamClass<Exclude<U, AnyFailure>, Extract<U, AnyFailure>> {
+    const open = this.#open;
+    return new StreamClass(() => iterate(fn(open()))) as never;
   }
 
   // ── Consumers — each returns a Task, completing the shared vocabulary ────────

--- a/lib/stream/stream.ts
+++ b/lib/stream/stream.ts
@@ -218,6 +218,124 @@ class StreamClass<T, E = never> implements AsyncIterable<T | E> {
     });
   }
 
+  /**
+   * Zips sources in lockstep, ending at the shortest (Elixir's `Stream.zip`) and closing
+   * the longer sources so their cleanup runs. JS divergences: sources are pulled
+   * sequentially per slot, and a failure element passes through bare **without consuming**
+   * from the other sources — failures cannot pair.
+   *
+   * ```ts
+   * await Stream.zip([1, 2, 3], ['a', 'b']).values(); // [[1, 'a'], [2, 'b']]
+   * ```
+   */
+  static zip<U extends readonly unknown[]>(
+    ...sources: { [K in keyof U]: Source<U[K]> }
+  ): StreamClass<{ [K in keyof U]: Exclude<U[K], AnyFailure> }, Extract<U[number], AnyFailure>> {
+    return new StreamClass(async function* () {
+      const iterators = sources.map((source) => iterate(source));
+      try {
+        for (;;) {
+          const tuple: unknown[] = [];
+          for (const iterator of iterators) {
+            for (;;) {
+              const { value, done } = await iterator.next();
+              if (done) return;
+              if (!isFailure(value)) {
+                tuple.push(value);
+                break;
+              }
+              yield value as never;
+            }
+          }
+          yield tuple as never;
+        }
+      } finally {
+        for (const iterator of iterators) await iterator.return(undefined);
+      }
+    }) as never;
+  }
+
+  /**
+   * `zip` plus a combiner — Elixir's `Stream.zip_with`; the tuple arrives spread.
+   *
+   * ```ts
+   * await Stream.zipWith([[1, 2], [10, 20]], (a, b) => a + b).values(); // [11, 22]
+   * ```
+   */
+  static zipWith<U extends readonly unknown[], R>(
+    sources: { [K in keyof U]: Source<U[K]> },
+    fn: (...values: { [K in keyof U]: Exclude<U[K], AnyFailure> }) => R,
+  ): StreamClass<Exclude<R, AnyFailure>, Extract<U[number] | R, AnyFailure>> {
+    return StreamClass.zip<U>(...sources).map((tuple) => fn(...tuple)) as never;
+  }
+
+  /**
+   * Emits `0, 1, 2, …` every `ms` milliseconds, forever — Elixir's `Stream.interval/1`,
+   * on `setTimeout` (universal). Infinite: always bound it.
+   *
+   * ```ts
+   * await Stream.interval(1).take(3).values(); // [0, 1, 2]
+   * ```
+   */
+  static interval(ms: number): StreamClass<number> {
+    return new StreamClass<number, never>(async function* () {
+      for (let n = 0; ; n++) {
+        await new Promise((resolve) => setTimeout(resolve, ms));
+        yield n;
+      }
+    });
+  }
+
+  /**
+   * Emits a single `0` after `ms` milliseconds, then ends — Elixir's `Stream.timer/1`.
+   *
+   * ```ts
+   * await Stream.timer(1).values(); // [0]
+   * ```
+   */
+  static timer(ms: number): StreamClass<number> {
+    return StreamClass.interval(ms).take(1);
+  }
+
+  /**
+   * `unfold` with lifecycle hooks — Elixir's `Stream.resource/3`: `start` runs on first
+   * pull, `next` is unfold's step, and `after` ALWAYS runs — normal end, early `take`, or a
+   * throw. (Plain generators already get this via `try`/`finally`; `resource` is for when
+   * the setup/teardown pair deserves to be explicit.)
+   *
+   * ```ts
+   * const opened: string[] = [];
+   * const rows = Stream.resource(
+   *   () => (opened.push('open'), { cursor: 0 }),
+   *   (db) => (db.cursor < 2 ? ([`row-${db.cursor}`, { cursor: db.cursor + 1 }] as const) : null),
+   *   () => void opened.push('close'),
+   * );
+   * await rows.values(); // ['row-0', 'row-1'] — and opened is ['open', 'close']
+   * ```
+   */
+  static resource<S, U>(
+    start: () => S | PromiseLike<S>,
+    next: (state: S) => Promise<readonly [U, S | null] | null> | readonly [U, S | null] | null,
+    after: (state: S) => void | PromiseLike<void>,
+  ): StreamClass<Exclude<U, AnyFailure>, Extract<U, AnyFailure>> {
+    return new StreamClass(async function* () {
+      const initial = await start();
+      let state: S | null = initial;
+      let last: S = initial;
+      try {
+        while (state !== null) {
+          const step = await next(state);
+          if (step === null) return;
+          yield step[0];
+          if (step[1] !== null) last = step[1];
+          state = step[1];
+        }
+      } finally {
+        await after(last);
+      }
+    }) as never;
+  }
+
   // ── Transforms — lazy, failures pass through untouched ──────────────────────
 
   /**
@@ -575,29 +693,162 @@ class StreamClass<T, E = never> implements AsyncIterable<T | E> {
   }
 
   /**
-   * Groups values into arrays of `count` (a trailing partial chunk is emitted). Failures
-   * pass through **between** chunks without breaking the one being assembled — a bad row
-   * never voids the batch around it.
+   * Runs `fn` per value as a lazy side effect and passes everything through unchanged —
+   * Elixir's *lazy* `Stream.each/2`, under the idiomatic JS name. Nothing runs until a
+   * consumer pulls; pair with {@link StreamClass#run} for side effects alone.
+   *
+   * ```ts
+   * const seen: number[] = [];
+   * await Stream.from([1, 2]).tap((n) => void seen.push(n)).values(); // [1, 2]
+   * seen; // [1, 2]
+   * ```
+   */
+  tap(fn: (value: T, index: number) => void | PromiseLike<void>): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      let index = 0;
+      for await (const element of open()) {
+        if (!isFailure(element)) await fn(element as T, index++);
+        yield element;
+      }
+    });
+  }
+
+  /**
+   * Tees every value into a web `WritableStream` while passing all elements through —
+   * Elixir's `Stream.into/2`, with the platform's own sink as the Collectable. The sink is
+   * closed on normal completion and released on early exit; failures pass the tee but are
+   * **not** written (the sink types `T`, not `T | E`).
+   *
+   * ```ts
+   * const written: number[] = [];
+   * const sink = new WritableStream<number>({ write: (n) => void written.push(n) });
+   * await Stream.from([1, 2, 3]).into(sink).values(); // [1, 2, 3]
+   * written; // [1, 2, 3]
+   * ```
+   */
+  into(sink: WritableStream<T>): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      const writer = sink.getWriter();
+      try {
+        for await (const element of open()) {
+          if (!isFailure(element)) await writer.write(element as T);
+          yield element;
+        }
+        await writer.close();
+      } finally {
+        writer.releaseLock();
+      }
+    });
+  }
+
+  /**
+   * Groups values into arrays of `count`, sliding by `step` (Elixir's full
+   * `chunk_every/4`): `step < count` overlaps windows, `step > count` skips between them.
+   * `leftover` rules the trailing partial chunk: emitted as-is by default, `'discard'`
+   * drops it, an array pads it up to `count`. Failures pass through **between** chunks
+   * without breaking the one being assembled — a bad row never voids the batch around it.
    *
    * ```ts
    * await Stream.from([1, 2, 3, 4, 5]).chunkEvery(2).values(); // [[1, 2], [3, 4], [5]]
+   * await Stream.from([1, 2, 3, 4, 5]).chunkEvery(3, 2, 'discard').values(); // [[1, 2, 3], [3, 4, 5]]
+   * await Stream.from([1, 2, 3, 4]).chunkEvery(3, 3, [0, 0]).values(); // [[1, 2, 3], [4, 0, 0]]
    * ```
    */
-  chunkEvery(count: number): StreamClass<T[], E> {
+  chunkEvery(count: number, step = count, leftover: T[] | 'discard' = []): StreamClass<T[], E> {
     const open = this.#open;
     return new StreamClass<T[], E>(async function* () {
-      let chunk: T[] = [];
+      let window: T[] = [];
+      let skip = 0;
       for await (const element of open()) {
         if (isFailure(element)) yield element as never;
+        else if (skip > 0) skip--;
         else {
-          chunk.push(element as T);
-          if (chunk.length >= count) {
-            yield chunk;
-            chunk = [];
+          window.push(element as T);
+          if (window.length === count) {
+            yield [...window];
+            if (step >= count) {
+              window = [];
+              skip = step - count;
+            } else window = window.slice(step);
           }
         }
       }
+      // The trailing partial: only a window that never filled (or the overlap remainder
+      // shorter than a full chunk) reaches here.
+      if (window.length > 0 && window.length < count) {
+        if (leftover === 'discard') return;
+        const padded = [...window, ...leftover].slice(0, count);
+        yield padded;
+      }
+    });
+  }
+
+  /**
+   * Chunks *consecutive* values sharing a key — Elixir's `chunk_by/2`; a key change closes
+   * the chunk. Failures are transparent: they pass through without closing the chunk
+   * around them, consistent with `dedup`.
+   *
+   * ```ts
+   * await Stream.from([1, 3, 2, 4, 5]).chunkBy((n) => n % 2).values(); // [[1, 3], [2, 4], [5]]
+   * ```
+   */
+  chunkBy(key: (value: T) => unknown): StreamClass<T[], E> {
+    const open = this.#open;
+    return new StreamClass<T[], E>(async function* () {
+      let chunk: T[] = [];
+      let current: unknown = Symbol();
+      for await (const element of open()) {
+        if (isFailure(element)) yield element as never;
+        else {
+          const k = key(element as T);
+          if (chunk.length > 0 && k !== current) {
+            yield chunk;
+            chunk = [];
+          }
+          chunk.push(element as T);
+          current = k;
+        }
+      }
       if (chunk.length > 0) yield chunk;
+    });
+  }
+
+  /**
+   * The general chunker — Elixir's `chunk_while/4`, object-shaped for JS: `step` returns
+   * `{ acc }` to keep accumulating, `{ acc, emit }` to emit a chunk, plus `halt: true` to
+   * end the stream; `flush` may emit one last chunk from the final accumulator. Values
+   * only; failures pass through.
+   *
+   * ```ts
+   * const batchesOfTwo = Stream.from([1, 2, 3, 4, 5]).chunkWhile(
+   *   [] as number[],
+   *   (n, acc) => (acc.length === 1 ? { acc: [], emit: [...acc, n] } : { acc: [...acc, n] }),
+   *   (acc) => (acc.length > 0 ? acc : undefined),
+   * );
+   * await batchesOfTwo.values(); // [[1, 2], [3, 4], [5]]
+   * ```
+   */
+  chunkWhile<A, C>(
+    initial: A,
+    step: (value: T, accumulator: A) => { acc: A; emit?: C; halt?: boolean },
+    flush?: (accumulator: A) => C | undefined,
+  ): StreamClass<C, E> {
+    const open = this.#open;
+    return new StreamClass<C, E>(async function* () {
+      let accumulator = initial;
+      for await (const element of open()) {
+        if (isFailure(element)) yield element as never;
+        else {
+          const result = step(element as T, accumulator);
+          accumulator = result.acc;
+          if (result.emit !== undefined) yield result.emit;
+          if (result.halt) break;
+        }
+      }
+      const last = flush?.(accumulator);
+      if (last !== undefined) yield last;
     });
   }
 
@@ -712,6 +963,20 @@ class StreamClass<T, E = never> implements AsyncIterable<T | E> {
         await fn(element as T, index++);
       }
     });
+  }
+
+  /**
+   * Forces the stream for its side effects alone — Elixir's `Stream.run/1`. Fail-fast like
+   * {@link StreamClass#each}: pair with {@link StreamClass#tap} for the effects.
+   *
+   * ```ts
+   * const seen: number[] = [];
+   * await Stream.from([1, 2]).tap((n) => void seen.push(n)).run();
+   * seen; // [1, 2]
+   * ```
+   */
+  run(): Task<void, E> {
+    return this.each(() => {});
   }
 
   /**

--- a/lib/stream/stream.ts
+++ b/lib/stream/stream.ts
@@ -1,0 +1,349 @@
+/**
+ * `Stream<T, E>` — the third leg of the error system: many outcomes over time, where
+ * `Result` is one settled outcome and `Task` is one future outcome (Elixir's Stream/Flow to
+ * Task's Task). The failure vocabulary is shared, not new:
+ *
+ *  - **Elements are the bare union `T | E`** — a declared per-element failure flows through
+ *    the pipeline as a value, exactly like a `Result`.
+ *  - **Transforms act on values and let failures pass untouched** — the railway, per element.
+ *  - **A bug (any throw) rejects the consuming Task** — the two-tier rule holds: nothing
+ *    boxes a `TypeError` into the element flow.
+ *  - **Terminal consumers return Tasks**, so completion plugs into `result()`/`match` and the
+ *    observation seam like every other async outcome.
+ *
+ * Streams are lazy and pull-based: nothing runs until a consumer iterates, and sources are
+ * only pulled as fast as the consumer takes elements (natural backpressure). A Stream built
+ * `from` a re-iterable source (array, generator *function*) can be consumed again; one built
+ * from a one-shot source (a `ReadableStream`, a live generator) is one-shot itself.
+ *
+ * ```ts
+ * import * as Failure from '../result/failure.ts';
+ *
+ * const BadRow = Failure.define('BadRow', (d: { line: number }) => `bad row ${d.line}`);
+ * const parsed = Stream.from(['{"id":1}', 'nope', '{"id":3}']).map((raw, n) => {
+ *   try {
+ *     return JSON.parse(raw) as { id: number };
+ *   } catch {
+ *     return BadRow({ line: n + 1 });
+ *   }
+ * });
+ *
+ * const { values, errors } = await parsed.partition();
+ * values.map((row) => row.id); // [1, 3]
+ * errors.map((failure) => failure.data.line); // [2]
+ * ```
+ */
+import { isFailure, observed, type Any as AnyFailure } from '../result/failure.ts';
+import { Task } from '../task/task.ts';
+import { partition, type Result } from '../result/result.ts';
+
+/** Anything a Stream can be built from or flattened into: sync or async iterables (a web `ReadableStream` is async-iterable on every modern runtime). */
+export type Source<T> = AsyncIterable<T> | Iterable<T>;
+
+async function* iterate<T>(source: Source<T>): AsyncGenerator<T> {
+  yield* source as AsyncIterable<T>;
+}
+
+/**
+ * The stream pipeline: build with a static (`from`/`unfold`/`lines`), shape with lazy
+ * transforms (`map`/`filter`/`flatMap`/`take`), finish with a Task-returning consumer
+ * (`values`/`results`/`partition`/`each`) — or `for await` the bare elements directly.
+ *
+ * ```ts
+ * const evens = Stream.from([1, 2, 3, 4]).filter((n) => n % 2 === 0);
+ * await evens.map((n) => n * 10).values(); // [20, 40]
+ * ```
+ */
+class StreamClass<T, E = never> implements AsyncIterable<T | E> {
+  /** A thunk, not an iterator: each consumer opens its own pass over the source. */
+  #open: () => AsyncGenerator<T | E>;
+
+  private constructor(open: () => AsyncGenerator<T | E>) {
+    this.#open = open;
+  }
+
+  // ── Builders ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Lifts a source into a Stream. Elements that are Failures are the `E` channel from the
+   * start; everything else is `T`.
+   *
+   * ```ts
+   * const doubled = await Stream.from([1, 2, 3]).map((n) => n * 2).values();
+   * doubled; // [2, 4, 6]
+   * ```
+   */
+  static from<U>(source: Source<U>): StreamClass<Exclude<U, AnyFailure>, Extract<U, AnyFailure>> {
+    return new StreamClass(() => iterate(source)) as StreamClass<
+      Exclude<U, AnyFailure>,
+      Extract<U, AnyFailure>
+    >;
+  }
+
+  /**
+   * Elixir's `Stream.unfold/2`: grow a lazy stream from a seed. `next(state)` returns
+   * `[element, nextState]` to emit and continue, or `null` to end; return `[failure, null]`
+   * to emit a declared failure and stop. Nothing runs until a consumer pulls — pagination
+   * only fetches the pages the consumer actually reaches.
+   *
+   * ```ts
+   * const countdown = Stream.unfold(3, (n) => (n === 0 ? null : [n, n - 1] as const));
+   * await countdown.values(); // [3, 2, 1]
+   * ```
+   */
+  static unfold<S, U>(
+    seed: S,
+    next: (state: S) => Promise<readonly [U, S | null] | null> | readonly [U, S | null] | null,
+  ): StreamClass<Exclude<U, AnyFailure>, Extract<U, AnyFailure>> {
+    return new StreamClass(async function* () {
+      for (let state: S | null = seed; state !== null;) {
+        const step = await next(state);
+        if (step === null) return;
+        yield step[0];
+        state = step[1];
+      }
+    }) as StreamClass<Exclude<U, AnyFailure>, Extract<U, AnyFailure>>;
+  }
+
+  /**
+   * Decodes a byte stream into text lines — the front door for NDJSON, logs, and SSE-ish
+   * feeds. Handles multi-byte characters and lines split across chunk boundaries; the final
+   * unterminated line is flushed.
+   *
+   * ```ts
+   * const bytes = [new TextEncoder().encode('a\nb'), new TextEncoder().encode('c\nd')];
+   * await Stream.lines(bytes).values(); // ['a', 'bc', 'd']
+   * ```
+   */
+  static lines(bytes: Source<Uint8Array>): StreamClass<string> {
+    return new StreamClass<string, never>(async function* () {
+      const decoder = new TextDecoder();
+      let tail = '';
+      for await (const chunk of iterate(bytes)) {
+        const text = tail + decoder.decode(chunk, { stream: true });
+        const lines = text.split('\n');
+        tail = lines.pop()!;
+        yield* lines;
+      }
+      tail += decoder.decode();
+      if (tail !== '') yield tail;
+    });
+  }
+
+  // ── Transforms — lazy, failures pass through untouched ──────────────────────
+
+  /**
+   * Transforms each **value**; failure elements flow past untouched (the railway, per
+   * element). `fn` may itself return a Failure — that widens the stream's `E`, which is how
+   * a parse step turns raw input into `Row | BadRow` without a wrapper per element. A throw
+   * inside `fn` is a bug and rejects the consumer.
+   *
+   * ```ts
+   * const tagged = await Stream.from([1, 2]).map((n, i) => `${i}:${n}`).values();
+   * tagged; // ['0:1', '1:2']
+   * ```
+   */
+  map<U>(
+    fn: (value: T, index: number) => U | PromiseLike<U>,
+  ): StreamClass<Exclude<U, AnyFailure>, E | Extract<U, AnyFailure>> {
+    const open = this.#open;
+    return new StreamClass(async function* () {
+      let index = 0;
+      for await (const element of open()) {
+        yield isFailure(element) ? element : ((await fn(element as T, index++)) as never);
+      }
+    }) as never;
+  }
+
+  /**
+   * Keeps the values `predicate` accepts; failure elements always pass through — dropping a
+   * declared failure is a decision for a consumer (`partition`), never a side effect of
+   * filtering values.
+   *
+   * ```ts
+   * await Stream.from([1, 2, 3, 4]).filter((n) => n % 2 === 0).values(); // [2, 4]
+   * ```
+   */
+  filter(predicate: (value: T, index: number) => boolean): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      let index = 0;
+      for await (const element of open()) {
+        if (isFailure(element) || predicate(element as T, index++)) yield element;
+      }
+    });
+  }
+
+  /**
+   * Expands each value into a source and flattens it in order — pages into rows, rows into
+   * cells. Failure elements pass through unexpanded.
+   *
+   * ```ts
+   * await Stream.from([[1, 2], [3]]).flatMap((page) => page).values(); // [1, 2, 3]
+   * ```
+   */
+  flatMap<U>(
+    fn: (value: T, index: number) => Source<U>,
+  ): StreamClass<Exclude<U, AnyFailure>, E | Extract<U, AnyFailure>> {
+    const open = this.#open;
+    return new StreamClass(async function* () {
+      let index = 0;
+      for await (const element of open()) {
+        if (isFailure(element)) yield element;
+        else yield* iterate(fn(element as T, index++));
+      }
+    }) as never;
+  }
+
+  /**
+   * Ends the stream after `count` elements (values and failures both count — `take` bounds
+   * work, it does not editorialize). The source is never pulled past the cut, which is the
+   * whole point over an eager slice: `unfold` pagination stops fetching.
+   *
+   * ```ts
+   * let pulled = 0;
+   * const firstTwo = Stream.unfold(0, (n) => ((pulled += 1), [n, n + 1] as const)).take(2);
+   * await firstTwo.values(); // [0, 1] — and pulled is 2, not ∞
+   * ```
+   */
+  take(count: number): StreamClass<T, E> {
+    const open = this.#open;
+    return new StreamClass<T, E>(async function* () {
+      if (count <= 0) return;
+      let taken = 0;
+      for await (const element of open()) {
+        yield element;
+        if (++taken >= count) return;
+      }
+    });
+  }
+
+  // ── Consumers — each returns a Task, completing the shared vocabulary ────────
+
+  /**
+   * Collects every value, **fail-fast**: the first failure element rejects the Task with it
+   * (declared — so `.result()` reflects it bare and typed). The `Result.all` of streams.
+   *
+   * ```ts
+   * await Stream.from(['a', 'b']).values(); // ['a', 'b']
+   * ```
+   */
+  values(): Task<T[], E> {
+    const open = this.#open;
+    return Task(async () => {
+      const collected: T[] = [];
+      for await (const element of open()) {
+        if (isFailure(element)) throw element;
+        collected.push(element as T);
+      }
+      return collected;
+    });
+  }
+
+  /**
+   * Collects every element, positionally, failures included — the `Task.results` of streams.
+   * Each failure is reported to the observation seam as it is classified into the value
+   * world, so tracing sees per-element failures a consumer chose to keep.
+   *
+   * ```ts
+   * import * as Failure from '../result/failure.ts';
+   *
+   * const Odd = Failure.define('Odd', (d: { n: number }) => `${d.n} is odd`);
+   * const outcomes = await Stream.from([2, Odd({ n: 3 }), 4]).results();
+   * outcomes.length; // 3 — nothing lost, order kept
+   * ```
+   */
+  results(): Task<Result<T, E>[], never> {
+    const open = this.#open;
+    return Task(async () => {
+      const collected: Result<T, E>[] = [];
+      for await (const element of open()) {
+        if (isFailure(element)) observed(element);
+        collected.push(element as Result<T, E>);
+      }
+      return collected;
+    });
+  }
+
+  /**
+   * Splits the stream into `{ values, errors }`, keeping both — `Result.partition`, fed by
+   * the stream. Literally `results()` piped through `partition`: the three modules share one
+   * vocabulary, so the composition is one line.
+   *
+   * ```ts
+   * import * as Failure from '../result/failure.ts';
+   *
+   * const Bad = Failure.define('Bad', 'bad element');
+   * const { values, errors } = await Stream.from([1, Bad(), 2]).partition();
+   * values; // [1, 2]
+   * errors.length; // 1
+   * ```
+   */
+  partition(): Task<{ values: T[]; errors: E[] }, never> {
+    return this.results().map((outcomes) => partition(outcomes)) as Task<
+      { values: T[]; errors: E[] },
+      never
+    >;
+  }
+
+  /**
+   * Drains the stream, running `fn` per value — **fail-fast** like {@link StreamClass#values}.
+   * The Task resolves when the source ends; use it when the work is the side effect.
+   *
+   * ```ts
+   * const seen: number[] = [];
+   * await Stream.from([1, 2, 3]).each((n) => void seen.push(n));
+   * seen; // [1, 2, 3]
+   * ```
+   */
+  each(fn: (value: T, index: number) => void | PromiseLike<void>): Task<void, E> {
+    const open = this.#open;
+    return Task(async () => {
+      let index = 0;
+      for await (const element of open()) {
+        if (isFailure(element)) throw element;
+        await fn(element as T, index++);
+      }
+    });
+  }
+
+  /**
+   * Streams are `for await`-able; elements arrive bare (`T | E`), so a hand-rolled loop
+   * discriminates with `Failure.is` exactly like any other union consumer.
+   *
+   * ```ts
+   * const seen: number[] = [];
+   * for await (const element of Stream.from([1, 2])) seen.push(element);
+   * seen; // [1, 2]
+   * ```
+   */
+  [Symbol.asyncIterator](): AsyncIterator<T | E> {
+    return this.#open();
+  }
+}
+
+// The class is `StreamClass` for the same reason Task's is `TaskClass`: one identifier
+// cannot be both the class binding and the exported type name below.
+Object.defineProperty(StreamClass, 'name', { value: 'Stream' });
+
+/**
+ * The exported value: builders (`Stream.from`, `Stream.unfold`, `Stream.lines`) are the only
+ * entry points — there is no public constructor and no call form.
+ *
+ * ```ts
+ * const stream = Stream.from([1, 2, 3]);
+ * await stream.map((n) => n + 1).values(); // [2, 3, 4]
+ * ```
+ */
+export const Stream = StreamClass;
+
+/**
+ * The type spelling: a signature says `Stream<Row, BadRow>` while the same identifier
+ * builds one — the Task naming pattern, applied to the third shape.
+ *
+ * ```ts
+ * const rows = (): Stream<number> => Stream.from([1, 2, 3]);
+ * await rows().values(); // [1, 2, 3]
+ * ```
+ */
+export type Stream<T, E = never> = StreamClass<T, E>;

--- a/test/result/portability-test.ts
+++ b/test/result/portability-test.ts
@@ -15,18 +15,22 @@ module('Result | portability', { concurrency: true }, () => {
     }
     const resultBarrel = new URL('../../lib/result/index.ts', import.meta.url).href;
     const taskBarrel = new URL('../../lib/task/index.ts', import.meta.url).href;
+    const streamBarrel = new URL('../../lib/stream/index.ts', import.meta.url).href;
     const script =
       `delete globalThis.process;` +
       `const Result = await import(${JSON.stringify(resultBarrel)});` +
       `const { Task, Failure } = await import(${JSON.stringify(taskBarrel)});` +
+      `const { Stream } = await import(${JSON.stringify(streamBarrel)});` +
       `const parsed = Result.try(JSON.parse, '{"n":1}');` +
       `const FileMissing = Failure.define('FileMissing', (d) => 'no ' + d.path);` +
       `const doubled = await Task(() => 21).map((n) => n * 2);` +
       `const failed = await Task(() => { throw FileMissing({ path: 'a.ts' }); }).result();` +
+      `const streamed = await Stream.from([1, FileMissing({ path: 'b.ts' }), 3]).partition();` +
       `Failure.setDebug(true);` + // debug line must fall back to console.error, not crash
       `Task(() => Promise.reject(new Error('gone'))).ignore('browser cleanup');` +
       `await new Promise((res) => setTimeout(res, 10));` +
-      `console.log('OK', parsed.value.n, doubled, Failure.is(failed), failed.code);`;
+      `console.log('OK', parsed.value.n, doubled, Failure.is(failed), failed.code,` +
+      `  streamed.values.length, streamed.errors.length);`;
     const child = spawn(process.execPath, ['--input-type=module', '-e', script]);
     let stdout = '';
     let stderr = '';
@@ -34,7 +38,7 @@ module('Result | portability', { concurrency: true }, () => {
     child.stderr.on('data', (chunk) => (stderr += chunk));
     const code = await new Promise<number | null>((resolve) => child.on('close', resolve));
     assert.strictEqual(code, 0, `clean exit, got stderr: ${stderr}`);
-    assert.true(stdout.includes('OK 1 42 true FileMissing'), 'the full surface worked');
+    assert.true(stdout.includes('OK 1 42 true FileMissing 2 1'), 'the full surface worked');
     assert.true(
       stderr.includes('ignored (browser cleanup)'),
       'the debug line reached console.error without a process.stderr',

--- a/test/stream/stream-test.ts
+++ b/test/stream/stream-test.ts
@@ -1,0 +1,144 @@
+import { module, test } from 'qunitx';
+import { Stream, Failure } from '../../lib/stream/index.ts';
+
+const BadRow = Failure.define('BadRow', (d: { line: number }) => `bad row ${d.line}`);
+
+// ── Laziness and sources ──────────────────────────────────────────────────────
+
+module('Stream | lazy', { concurrency: true }, () => {
+  test('nothing is pulled until a consumer iterates', async (assert) => {
+    let pulled = 0;
+    const stream = Stream.from(
+      (function* () {
+        for (;;) yield ++pulled;
+      })(),
+    ).map((n) => n * 10);
+    assert.strictEqual(pulled, 0, 'building a pipeline pulls nothing');
+    assert.deepEqual(await stream.take(2).values(), [10, 20]);
+    assert.strictEqual(pulled, 2, 'only the taken elements were pulled — backpressure');
+  });
+
+  test('a Stream from a re-iterable source is re-consumable', async (assert) => {
+    const stream = Stream.from([1, 2]);
+    assert.deepEqual(await stream.values(), [1, 2]);
+    assert.deepEqual(await stream.values(), [1, 2], 'arrays re-open per consumer');
+  });
+
+  test('unfold grows lazily from a seed and stops on null', async (assert) => {
+    let fetches = 0;
+    const pages = Stream.unfold(1, (page) => {
+      fetches += 1;
+      return page > 3 ? null : ([`page-${page}`, page + 1] as const);
+    });
+    assert.deepEqual(await pages.values(), ['page-1', 'page-2', 'page-3']);
+    assert.deepEqual(await pages.take(1).values(), ['page-1']);
+    assert.strictEqual(fetches, 5, 'take(1) fetched one page, not all');
+  });
+
+  test('lines splits across chunk boundaries and flushes the tail', async (assert) => {
+    const encode = (s: string) => new TextEncoder().encode(s);
+    const chunks = [encode('alpha\nbe'), encode('ta\nga'), encode('mma')];
+    assert.deepEqual(await Stream.lines(chunks).values(), ['alpha', 'beta', 'gamma']);
+  });
+});
+
+// ── The per-element railway ───────────────────────────────────────────────────
+
+module('Stream | railway', { concurrency: true }, () => {
+  const mixed = () =>
+    Stream.from(['1', 'x', '3']).map((raw, n) => {
+      const parsed = Number(raw);
+      return Number.isNaN(parsed) ? BadRow({ line: n + 1 }) : parsed;
+    });
+
+  test('map widens E when fn returns a Failure, and later maps skip failures', async (assert) => {
+    const doubled = mixed().map((n) => n * 2); // BadRow must flow PAST this untouched
+    const { values, errors } = await doubled.partition();
+    assert.deepEqual(values, [2, 6]);
+    assert.deepEqual(
+      errors.map((e) => e.data.line),
+      [2],
+    );
+  });
+
+  test('filter never drops failures — only values are filtered', async (assert) => {
+    const { errors } = await mixed()
+      .filter(() => false)
+      .partition();
+    assert.strictEqual(errors.length, 1, 'the failure survived a reject-everything filter');
+  });
+
+  test('flatMap expands values and passes failures through unexpanded', async (assert) => {
+    const { values, errors } = await mixed()
+      .flatMap((n) => [n, n])
+      .partition();
+    assert.deepEqual(values, [1, 1, 3, 3]);
+    assert.strictEqual(errors.length, 1);
+  });
+
+  test('a bug thrown inside map rejects the consumer — never boxed into the flow', async (assert) => {
+    const buggy = Stream.from([1]).map(() => {
+      throw new TypeError('boom');
+    });
+    await assert.rejects(buggy.values(), TypeError);
+    await assert.rejects(buggy.results(), TypeError, 'even the keep-everything consumer');
+  });
+});
+
+// ── Consumers ─────────────────────────────────────────────────────────────────
+
+module('Stream | consumers', { concurrency: true }, () => {
+  const withFailure = () => Stream.from([1, BadRow({ line: 9 }), 3]);
+
+  test('values() fail-fasts on the first failure element, as a declared rejection', async (assert) => {
+    const outcome = await withFailure().values().result(); // number[] | BadRow — bare
+    assert.true(BadRow.is(outcome));
+    assert.strictEqual((outcome as Failure.Of<typeof BadRow>).data.line, 9);
+  });
+
+  test('results() keeps everything positionally, failures included', async (assert) => {
+    const outcomes = await withFailure().results();
+    assert.strictEqual(outcomes.length, 3);
+    assert.true(Failure.is(outcomes[1]));
+  });
+
+  test('each() drains with side effects and fail-fasts like values()', async (assert) => {
+    const seen: number[] = [];
+    await Stream.from([1, 2]).each((n) => void seen.push(n));
+    assert.deepEqual(seen, [1, 2]);
+    await assert.rejects(
+      withFailure().each(() => {}),
+      /bad row 9/,
+    );
+  });
+
+  test('for await yields bare elements, discriminated by Failure.is', async (assert) => {
+    const codes: string[] = [];
+    for await (const element of withFailure()) {
+      if (Failure.is(element)) codes.push(element.code);
+    }
+    assert.deepEqual(codes, ['BadRow']);
+  });
+
+  test('take counts every element, values and failures alike', async (assert) => {
+    const { values, errors } = await withFailure().take(2).partition();
+    assert.deepEqual(values, [1]);
+    assert.strictEqual(errors.length, 1, 'the cut lands after the failure, not around it');
+  });
+});
+
+// Serial on purpose: onObserved is a process-wide single slot, and concurrent siblings that
+// consume failures (values().result(), partition()) would report into this test's collector.
+module('Stream | observation seam', () => {
+  test('results() reports each kept failure to Failure.onObserved exactly once', async (assert) => {
+    const seen: string[] = [];
+    Failure.onObserved((failure) => seen.push(failure.code));
+    try {
+      const outcomes = await Stream.from([1, BadRow({ line: 9 }), 3]).results();
+      assert.strictEqual(outcomes.length, 3);
+      assert.deepEqual(seen, ['BadRow'], 'the kept failure was observed exactly once');
+    } finally {
+      Failure.onObserved(null);
+    }
+  });
+});

--- a/test/stream/stream-test.ts
+++ b/test/stream/stream-test.ts
@@ -142,3 +142,154 @@ module('Stream | observation seam', () => {
     }
   });
 });
+
+// ── Tier-1 sweep: builders ────────────────────────────────────────────────────
+
+module('Stream | builders', { concurrency: true }, () => {
+  test('concat, duplicate and fromIndex compose in order', async (assert) => {
+    assert.deepEqual(await Stream.concat([1], [2, 3]).values(), [1, 2, 3]);
+    assert.deepEqual(await Stream.duplicate('x', 2).values(), ['x', 'x']);
+    assert.deepEqual(await Stream.fromIndex(5).take(2).values(), [5, 6]);
+  });
+
+  test('cycle, iterate and repeatedly are infinite until bounded', async (assert) => {
+    assert.deepEqual(await Stream.cycle([1, 2]).take(5).values(), [1, 2, 1, 2, 1]);
+    assert.deepEqual(
+      await Stream.iterate(1, (n) => n * 3)
+        .take(3)
+        .values(),
+      [1, 3, 9],
+    );
+    let calls = 0;
+    assert.deepEqual(
+      await Stream.repeatedly(() => ++calls)
+        .take(2)
+        .values(),
+      [1, 2],
+    );
+    assert.deepEqual(await Stream.cycle([]).values(), [], 'an empty cycle ends, never spins');
+  });
+});
+
+// ── Tier-1 sweep: the positional/value rule per transform ────────────────────
+
+module('Stream | tier-1 transforms', { concurrency: true }, () => {
+  const withFailure = () => Stream.from([1, BadRow({ line: 1 }), 2, 3]);
+
+  test('drop is positional — values and failures both count, like take', async (assert) => {
+    const { values, errors } = await withFailure().drop(2).partition();
+    assert.deepEqual(values, [2, 3]);
+    assert.strictEqual(errors.length, 0, 'the dropped prefix included the failure — explicit');
+  });
+
+  test('takeWhile ends at the first refused value; failures pass untested', async (assert) => {
+    const { values, errors } = await withFailure()
+      .takeWhile((n) => n < 2)
+      .partition();
+    assert.deepEqual(values, [1]);
+    assert.strictEqual(errors.length, 1, 'the failure inside the window passed through');
+  });
+
+  test('dropWhile emits failures even during the dropping phase', async (assert) => {
+    const { values, errors } = await withFailure()
+      .dropWhile((n) => n < 3)
+      .partition();
+    assert.deepEqual(values, [3]);
+    assert.strictEqual(errors.length, 1, 'a value predicate never swallows a failure');
+  });
+
+  test('takeEvery/dropEvery/mapEvery count values only', async (assert) => {
+    assert.deepEqual(await Stream.from([0, 1, 2, 3, 4]).takeEvery(2).values(), [0, 2, 4]);
+    assert.deepEqual(await Stream.from([0, 1, 2, 3, 4]).dropEvery(2).values(), [1, 3]);
+    const everied = await withFailure()
+      .mapEvery(2, (n) => n * 10)
+      .partition();
+    assert.deepEqual(everied.values, [10, 2, 30], 'failure did not advance the value counter');
+  });
+
+  test('reject, intersperse and withIndex', async (assert) => {
+    assert.deepEqual(
+      await Stream.from([1, 2, 3])
+        .reject((n) => n === 2)
+        .values(),
+      [1, 3],
+    );
+    assert.deepEqual(await Stream.from([1, 2]).intersperse(0).values(), [1, 0, 2]);
+    const indexed = await withFailure().withIndex().partition();
+    assert.deepEqual(
+      indexed.values,
+      [
+        [1, 0],
+        [2, 1],
+        [3, 2],
+      ],
+      'failures consume no index',
+    );
+  });
+
+  test('dedup is failure-transparent; uniq is stream-wide', async (assert) => {
+    const deduped = await Stream.from([1, BadRow({ line: 2 }), 1, 2])
+      .dedup()
+      .partition();
+    assert.deepEqual(deduped.values, [1, 2], 'equal values around a failure stay consecutive');
+    assert.strictEqual(deduped.errors.length, 1);
+    assert.deepEqual(await Stream.from([1, 2, 1, 3]).uniq().values(), [1, 2, 3]);
+  });
+
+  test('scan folds values, seeded or seeded-by-first, and passes failures', async (assert) => {
+    assert.deepEqual(
+      await Stream.from([1, 2, 3])
+        .scan((a, n) => a + n)
+        .values(),
+      [1, 3, 6],
+    );
+    const seeded = await withFailure()
+      .scan((a, n) => a + n, 10)
+      .partition();
+    assert.deepEqual(seeded.values, [11, 13, 16], 'the failure left the accumulator untouched');
+  });
+});
+
+// ── Tier-2: chunkEvery + through ──────────────────────────────────────────────
+
+module('Stream | chunking and the general engine', { concurrency: true }, () => {
+  test('chunkEvery emits full chunks, a trailing partial, and never breaks a chunk on a failure', async (assert) => {
+    const { values, errors } = await Stream.from([1, BadRow({ line: 7 }), 2, 3])
+      .chunkEvery(2)
+      .partition();
+    assert.deepEqual(values, [[1, 2], [3]], 'the failure passed BETWEEN chunks, batch intact');
+    assert.strictEqual(errors.length, 1);
+  });
+
+  test('through hands the raw flow over — failures included, the ruling is yours', async (assert) => {
+    const codes: string[] = [];
+    const cleaned = Stream.from([1, BadRow({ line: 3 }), 2]).through(async function* (elements) {
+      for await (const element of elements) {
+        if (Failure.is(element))
+          codes.push(element.code); // absorbed by THIS generator
+        else yield element * 10;
+      }
+    });
+    assert.deepEqual(await cleaned.values(), [10, 20]);
+    assert.deepEqual(codes, ['BadRow'], 'through saw the failure raw — no auto-pass');
+  });
+});
+
+// ── Tier-3 pin: early exit runs source cleanup (Elixir resource/3's `after`) ──
+
+module('Stream | cleanup', { concurrency: true }, () => {
+  test('breaking early runs the source generator finally block', async (assert) => {
+    let cleaned = false;
+    const resource = Stream.from(
+      (async function* () {
+        try {
+          for (let n = 0; ; n++) yield n;
+        } finally {
+          cleaned = true; // resource/3's `after`, natively: for-await break → generator.return()
+        }
+      })(),
+    );
+    assert.deepEqual(await resource.take(2).values(), [0, 1]);
+    assert.true(cleaned, 'take() closed the source — no leaked handle');
+  });
+});

--- a/test/stream/stream-test.ts
+++ b/test/stream/stream-test.ts
@@ -293,3 +293,137 @@ module('Stream | cleanup', { concurrency: true }, () => {
     assert.true(cleaned, 'take() closed the source — no leaked handle');
   });
 });
+
+// ── Full parity: zip, timers, resource, tee, chunk family, tap/run ───────────
+
+module('Stream | zip', { concurrency: true }, () => {
+  test('zips in lockstep, ends at the shortest, and closes the longer source', async (assert) => {
+    let cleaned = false;
+    const longer = (async function* () {
+      try {
+        for (let n = 0; ; n++) yield n;
+      } finally {
+        cleaned = true;
+      }
+    })();
+    assert.deepEqual(await Stream.zip(['a', 'b'], longer).values(), [
+      ['a', 0],
+      ['b', 1],
+    ]);
+    assert.true(cleaned, 'the infinite side was closed, not leaked');
+  });
+
+  test('a failure element passes bare without consuming from the other sources', async (assert) => {
+    const { values, errors } = await Stream.zip(
+      [1, BadRow({ line: 4 }), 2],
+      ['a', 'b'],
+    ).partition();
+    assert.deepEqual(
+      values,
+      [
+        [1, 'a'],
+        [2, 'b'],
+      ],
+      'pairs stayed aligned around the failure',
+    );
+    assert.strictEqual(errors.length, 1);
+  });
+
+  test('zipWith combines the tuple spread', async (assert) => {
+    assert.deepEqual(
+      await Stream.zipWith(
+        [
+          [1, 2],
+          [10, 20],
+        ],
+        (a, b) => a + b,
+      ).values(),
+      [11, 22],
+    );
+  });
+});
+
+module('Stream | timers and resource', { concurrency: true }, () => {
+  test('interval ticks and timer emits once', async (assert) => {
+    assert.deepEqual(await Stream.interval(1).take(3).values(), [0, 1, 2]);
+    assert.deepEqual(await Stream.timer(1).values(), [0]);
+  });
+
+  test('resource runs after() on normal end AND on early exit', async (assert) => {
+    const events: string[] = [];
+    const make = () =>
+      Stream.resource(
+        () => (events.push('open'), 0),
+        (n) => (n < 3 ? ([n, n + 1] as const) : null),
+        () => void events.push('close'),
+      );
+    assert.deepEqual(await make().values(), [0, 1, 2]);
+    assert.deepEqual(await make().take(1).values(), [0], 'early exit');
+    assert.deepEqual(events, ['open', 'close', 'open', 'close']);
+  });
+});
+
+module('Stream | tee and chunk family', { concurrency: true }, () => {
+  test('into writes values to the sink, passes failures through unwritten', async (assert) => {
+    const written: number[] = [];
+    const sink = new WritableStream<number>({ write: (n) => void written.push(n) });
+    const { values, errors } = await Stream.from([1, BadRow({ line: 2 }), 3])
+      .into(sink)
+      .partition();
+    assert.deepEqual(values, [1, 3]);
+    assert.strictEqual(errors.length, 1, 'the failure passed the tee');
+    assert.deepEqual(written, [1, 3], 'only values reached the sink');
+  });
+
+  test('chunkEvery full arity: sliding windows, skipping steps, leftover rules', async (assert) => {
+    const src = () => Stream.from([1, 2, 3, 4, 5]);
+    assert.deepEqual(await src().chunkEvery(3, 2).values(), [[1, 2, 3], [3, 4, 5], [5]]);
+    assert.deepEqual(await src().chunkEvery(3, 2, 'discard').values(), [
+      [1, 2, 3],
+      [3, 4, 5],
+    ]);
+    assert.deepEqual(
+      await src().chunkEvery(2, 3).values(),
+      [
+        [1, 2],
+        [4, 5],
+      ],
+      'step > count skips',
+    );
+    assert.deepEqual(
+      await Stream.from([1, 2, 3, 4]).chunkEvery(3, 3, [0, 0]).values(),
+      [
+        [1, 2, 3],
+        [4, 0, 0],
+      ],
+      'pad from the leftover array',
+    );
+  });
+
+  test('chunkBy closes on key change; failures are transparent to the chunk', async (assert) => {
+    const { values, errors } = await Stream.from([1, 3, BadRow({ line: 1 }), 5, 2])
+      .chunkBy((n) => n % 2)
+      .partition();
+    assert.deepEqual(values, [[1, 3, 5], [2]], 'the failure did not close the odd chunk');
+    assert.strictEqual(errors.length, 1);
+  });
+
+  test('chunkWhile emits on demand, halts on demand, and flushes', async (assert) => {
+    const untilNegative = Stream.from([1, 2, -1, 9]).chunkWhile(
+      [] as number[],
+      (n, acc) => (n < 0 ? { acc, halt: true } : { acc: [...acc, n] }),
+      (acc) => (acc.length > 0 ? acc : undefined),
+    );
+    assert.deepEqual(await untilNegative.values(), [[1, 2]], 'halted before 9, flushed the acc');
+  });
+});
+
+module('Stream | tap and run', { concurrency: true }, () => {
+  test('tap is lazy and passes everything; run forces for effects alone', async (assert) => {
+    const seen: number[] = [];
+    const tapped = Stream.from([1, 2]).tap((n) => void seen.push(n));
+    assert.deepEqual(seen, [], 'tap ran nothing eagerly');
+    await tapped.run();
+    assert.deepEqual(seen, [1, 2]);
+  });
+});


### PR DESCRIPTION
The third leg of the error system, stacked on #56: `Result` is one settled outcome, `Task` is one future outcome, **`Stream<T, E>` is many outcomes over time** — Elixir's Stream/Flow to Task's Task. No new failure vocabulary: elements are the bare `T | E` union, transforms are a railway per element, terminal consumers return Tasks, and `Failure` stays the single error currency.

|            |                                                                        |
| ---------- | ---------------------------------------------------------------------- |
| new module | `lib/stream/` — builders `from/unfold/lines/concat/cycle/iterate/repeatedly/duplicate/fromIndex/zip/zipWith/interval/timer/resource`, transforms `map/filter/reject/flatMap/take/drop/takeWhile/dropWhile/takeEvery/dropEvery/mapEvery/withIndex/intersperse/dedup(By)/uniq(By)/scan/tap/into/chunkEvery/chunkBy/chunkWhile/through`, consumers `values/results/partition/each/run` + `for await` |
| Elixir parity | **complete** — every hexdocs `Stream` function has a member here, JS-idiom-adjusted; see "Divergences from Elixir" below |
| tests      | 36 new (`test/stream/`), both lanes; portability guard extended to the Stream graph |
| doctests   | 49 new fenced examples, all executing (390 total)                       |
| deps       | 0 — universal graph: no `node:` imports, no platform globals (browser-safe, proven by the extended portability test) |

## The two moments this module exists for

**1 — stream millions of `PaymentTransaction` records over HTTP: one server script serving BOTH consumer classes, plus the resumable ingest job.** The transport is boring on purpose: NDJSON (`application/x-ndjson`) over a streamed response body. `fetch()` settles at **status + headers** — connection open, zero body bytes pulled — so the two HTTP phases map exactly onto the two shapes: Task settles the envelope, Stream consumes the flow. The connection closes when the body is read to its end (terminal chunk / `END_STREAM`, socket back to the keep-alive pool), when the consumer cancels early (`take`/`break` → `ReadableStream.cancel()` → the pinned cleanup chain), or when the transfer dies mid-body — which is *expected*, so it gets classified once, at the consumption boundary.

```ts
// transactions-server.ts — the producer, both consumer classes in one script.
// Run: deno run --allow-net --allow-env transactions-server.ts
// Minimal Deno + Hono (express-like) + porsager/postgres. Public traffic gets bounded keyset
// pages a CDN can absorb; the trusted cluster gets the long-lived cursor stream, whose
// Response body is PULL-based — the cursor advances only as fast as the reader, memory flat.
import { Hono } from 'npm:hono';
import postgres from 'npm:postgres';

const sql = postgres(Deno.env.get('DATABASE_URL')!);
const app = new Hono();

// ── PUBLIC, ungated: one keyset page per request — bounded work, stateless, and no
// connection outlives the request, so anonymous slow readers can never pin the pool.
// Keyset (`id > after`), never OFFSET: O(log n) via the pk index, resumable by construction.
app.get('/payment-transactions', async (c) => {
  const after = Number(c.req.query('after') ?? 0);
  const limit = Math.min(Number(c.req.query('limit') ?? 10_000), 10_000); // hard cap per request
  const rows = await sql`
    SELECT * FROM payment_transactions WHERE id > ${after} ORDER BY id LIMIT ${limit}
  `;
  const full = rows.length === limit;
  return c.body(rows.map((tx) => JSON.stringify(tx) + '\n').join(''), 200, {
    'content-type': 'application/x-ndjson',
    // Append-only ledger + keyset range ⇒ a FULL page is immutable: let the CDN keep it
    // forever — the database never meets the same anonymous range twice. The growing tail
    // page is the one thing that must not be cached.
    'cache-control': full ? 'public, max-age=31536000, immutable' : 'no-store',
    ...(rows.length > 0 && { 'x-next-after': String(rows.at(-1)!.id) }), // the resume cursor, explicit
  });
});

// ── INTERNAL, trusted (cluster-only — gate with NetworkPolicy/mTLS, not app auth): the
// long-lived cursor stream. Connection lifetime = client read time, fine among friends.
app.get('/internal/payment-transactions', (c) => {
  const after = Number(c.req.query('after') ?? 0);
  async function* ndjson() {
    // .cursor(100): a real server-side portal — the driver Executes 100 rows per
    // round-trip, only when the stream pulls. One query, no OFFSET re-scans.
    for await (const rows of sql`
      SELECT * FROM payment_transactions WHERE id > ${after} ORDER BY id
    `.cursor(100)) {
      yield rows.map((tx) => JSON.stringify(tx) + '\n').join('');
    }
  }
  return new Response(ReadableStream.from(ndjson()).pipeThrough(new TextEncoderStream()), {
    headers: { 'content-type': 'application/x-ndjson' },
  });
});

Deno.serve(app.fetch);
```

```ts
// ingest-transactions.ts — the consumer, a k8s job. Run: node ingest-transactions.ts
// (Node 24 runs TS natively.) fetch() settles at STATUS + HEADERS — connection open, zero
// body bytes pulled — so Task settles the envelope and Stream consumes the flow. The
// connection closes when the body is read to the end, cancelled early, or dies mid-body.
import { Task, Failure, Stream, Result } from '@izelnakri/task';
import { commitBatch, deadLetter, lastCheckpoint, saveCheckpoint } from './ledger.ts';
import type { PaymentTransaction } from './ledger.ts';

const ExportRejected = Failure.define('ExportRejected', (d: { status: number }) => `export rejected: HTTP ${d.status}`);
const TransferInterrupted = Failure.define('TransferInterrupted', (d: { records: number }) => `connection lost after ${d.records} records`);
const BadRecord = Failure.define('BadRecord', (d: { line: number }) => `unparseable record at line ${d.line}`,
  { trace: (d) => ({ 'export.line': d.line }) });

const openExport = (after: number) =>
  Task(() => fetch(`${process.env.LEDGER_URL}/internal/payment-transactions?after=${after}`, {
    headers: { accept: 'application/x-ndjson' },
  }))
    .mapErr((cause) => ExportRejected({ status: 0 }, { cause }))                 // DNS/TLS/refused — before headers
    .ensure((res) => res.ok, (res) => ExportRejected({ status: res.status }))    // the envelope check, one line
    .map((res) => res.body!);

// Resume point: the highest id we durably committed on any earlier run of this job.
// The server's keyset `?after=` + idempotent batch upserts turn k8s's at-least-once
// restarts into effectively exactly-once ingestion.
const checkpoint = await lastCheckpoint();            // 0 on the first ever run

const body = await openExport(checkpoint).result();   // ReadableStream | ExportRejected — bare
if (Failure.is(body)) {
  console.error(Failure.format(body));                // the envelope said no: zero bytes were pulled
  process.exit(1);                                    // permanent — let the operator look
}

let line = 0;
const outcome = await Stream.lines(body)              // pull-based: the server is asked for bytes
  .map((raw) =>                                       // only as fast as this pipeline consumes them
    Result.rescue(JSON.parse, (cause) => BadRecord({ line: ++line }, { cause }), raw) as
      PaymentTransaction | Failure.Of<typeof BadRecord>)
  .through(async function* (elements) {               // dead-letter bad records AS THEY PASS —
    for await (const el of elements) {                // nothing accumulates, nothing is dropped
      if (Failure.is(el)) await deadLetter(el);
      else yield el;
    }
  })
  .chunkEvery(1_000)                                  // flat memory: one batch in flight, ever
  .each(async (batch) => {
    await commitBatch(batch);                         // idempotent upsert (ON CONFLICT DO NOTHING)
    await saveCheckpoint(batch.at(-1)!.id);           // durable resume point — only AFTER the batch landed
  })
  .mapErr((cause) => TransferInterrupted({ records: line }, { cause })) // mid-body death OR a failed
  .result();                                          // commit — both temporary, classified ONCE

if (Failure.is(outcome)) {
  console.error(Failure.format(outcome));             // committed batches are already checkpointed
  process.exit(75);                                   // EX_TEMPFAIL — k8s restarts, we resume ?after=checkpoint
}
console.log(`ingest complete from id ${checkpoint}`);
```

**2 — cursor-paginate an API lazily, Elixir's `Stream.unfold`: pages fetch only as consumed.** The client never constructs a URL beyond the first request: the **server hands back the next cursor** in each page (the GitHub/Stripe pagination shape), and `unfold`'s state *is* that cursor — seed in, server-issued cursor out, `null` ends. `take(50)` means the third page is never requested:

```ts
// first-50-followers.ts — Run: node first-50-followers.ts
import { Task, Failure, Stream } from '@izelnakri/task';

type User = { id: number; login: string };
type FollowerPage = { followers: User[]; nextCursor: string | null }; // the server's pagination shape

const PageFailed = Failure.define('PageFailed', (d: { status: number }) => `followers page failed: HTTP ${d.status}`);
type PageFailure = Failure.Of<typeof PageFailed>;

const getPage = (cursor: string | null): Task<FollowerPage, PageFailure> =>
  Task(() => fetch(cursor ? `${process.env.API_URL}/followers?cursor=${cursor}` : `${process.env.API_URL}/followers`))
    .mapErr((cause) => PageFailed({ status: 0 }, { cause }))
    .ensure((res) => res.ok, (res) => PageFailed({ status: res.status })) // the envelope check, one line
    .map((res) => res.json() as Promise<FollowerPage>);

// unfold(seed, step): the seed is the first cursor (null = "first page"); each step returns
// [whatToEmit, nextState] where nextState is the cursor the server JUST issued — null ends.
const followers = Stream.unfold(null as string | null, async (cursor) => {
  const page = await getPage(cursor).result();          // FollowerPage | PageFailure — bare
  if (Failure.is(page)) return [page, null] as const;   // surface the failure as data, stop paging
  return [page.followers, page.nextCursor] as const;    // emit the page, advance to the server's cursor
}).flatMap((page) => page);                              // pages → users; failures flow past untouched

const first50 = await followers.take(50).values().result(); // User[] | PageFailure — fail-fast, bare
if (Failure.is(first50)) {
  console.error(Failure.format(first50));
  process.exit(75); // a page died mid-walk — temporary, retry
}
console.table(first50);
```

## The rules, in one table

| point            | behavior                                                                 | analogue            |
| ---------------- | ------------------------------------------------------------------------ | ------------------- |
| element          | bare `T \| E` — a declared failure is a value in the flow                | `Result<T, E>`      |
| `map/filter/flatMap` | act on values; **failures pass through untouched** (railway per element); `fn` returning a Failure widens `E` | `Task.map`          |
| a throw anywhere | a **bug** — rejects the consuming Task, never boxed into the flow        | the two-tier rule   |
| `values()` / `each()` | fail-fast: first failure element rejects, declared and typed         | `Result.all`        |
| `results()`      | keeps everything positionally; kept failures report to the observation seam (`Failure.onObserved` / the `qunitx.failure.observed` channel) | `Task.results`      |
| `partition()`    | `{ values, errors }` — literally `results()` piped through `Result.partition`, one line | `Result.partition`  |
| `take(n)`        | bounds the *pull*: upstream is never iterated past the cut (unfold stops fetching) | backpressure        |

## Design notes

- **Lazy, pull-based, backpressured by construction**: a Stream holds a thunk that opens a fresh async generator per consumer; nothing runs until iteration, and sources are pulled only as fast as elements are taken (`take(2)` over an infinite generator pulls exactly 2 — pinned by test).
- **Re-iterability follows the source**: `from([...])` streams can be consumed repeatedly; a `ReadableStream`-backed one is one-shot, honestly.
- **`Stream.lines`** is the one codec included — bytes → text lines (NDJSON/logs), multi-byte- and chunk-boundary-safe via streaming `TextDecoder`, universal.
- **The observation seam extends naturally**: `values()`/`each()` reject with the declared failure (the downstream Task consumer reports it); `results()`/`partition()` classify failures into the value world themselves, so they report — same semantics `task.result()` has.
- **Universal graph**: `lib/stream/` imports only `lib/result/` and `lib/task/` — the extended portability test loads all three barrels with `globalThis.process` deleted and runs a partition end-to-end.
- **The railway generalizes to a two-rule taxonomy** (each pinned by test): *positional* transforms (`take`, `drop`, `intersperse`) count every element — discarding a prefix is an explicit consumer decision; *value* transforms (`filter`, `reject`, `*While`, `*Every`, `dedup`, `uniq`, `scan`) speak only about values — failures pass untested, transparent to `dedup`'s memory and `scan`'s accumulator.
- **`through()` is the general engine** — Elixir's `Stream.transform`, JS-shaped as a generator-to-generator hand-off, and the one transform where failures do *not* auto-pass: the user's generator sees the raw `T | E` flow and owns the ruling. Every future "missing combinator" is three lines through it.
- **`chunkEvery(n)`** batches values and passes failures *between* chunks — a bad row never voids the batch around it.
- **Cleanup is native** (Elixir `resource/3`'s `after`): early exit (`take`, `break`) triggers the source generator's `finally` via `generator.return()` — pinned by test, no API needed.
- Deliberately absent (not Elixir surface): concurrency knobs (Flow's `max_demand` — a `mapConcurrent(n)` is the natural next member), `Stream.restart` lineage (sources are often one-shot; Task owns retry), and any Node-stream coupling (web `ReadableStream` is async-iterable on every modern runtime, which keeps the graph universal).

## Divergences from Elixir, each deliberate

| Elixir | here | why |
| --- | --- | --- |
| `each/2` is a *lazy* tap; `run/1` forces | `tap(fn)` is the lazy tap (the idiomatic JS name); `each(fn)` and `run()` are terminal drains returning Tasks | JS callers overwhelmingly expect `each` to *do the thing*; the lazy variant gets the name JS gave it (`Array#tap` conventions, RxJS `tap`) |
| `transform/3..5` (acc + halt tuples) | `through(async function* (elements) { … })` | generators ARE the JS shape of "stateful element rewriter": acc is a local, halt is `return`, and it needs no tuple grammar. Also the one transform where failures do **not** auto-pass — your generator owns the ruling |
| `into/2` targets any Collectable | `into(sink)` targets a web `WritableStream` | the platform's own sink type; values are written, failures pass the tee unwritten (the sink types `T`, not `T \| E`), closed on completion, released on early exit |
| `resource/3` returns `{[items], acc}` lists | `resource(start, next, after)` with `unfold`-shaped `next` | one step grammar for both `unfold` and `resource`; `after` always runs (normal end, early `take`, throw) — and plain generator sources get the same guarantee free via `try/finally` (pinned by test) |
| `zip` on sync enumerables | lockstep sequential pull; ends at shortest and **closes** the longer sources; a failure element passes bare without consuming from the other sources | async sources forced the alignment policy Elixir never needed; failures cannot pair, so they ride past |
| `chunk_every/4` leftover `[]` \| `:discard` | `leftover: T[] \| 'discard'`, default emit-partial | same semantics, JS-typed |
| `chunk_while/4` `{:cont, chunk, acc}` tuples | `step` returns `{ acc, emit?, halt? }`, `flush(acc)` may emit last | objects over tagged tuples — the JS grammar for the same three outcomes |
| `with_index/2` takes offset *or* function | offset only | the function form is exactly `map((v, i) => …)`, which every transform already provides |
| snake_case | camelCase (`flatMap`, `takeWhile`, `chunkBy`, …) | the host language's convention |
| terms are lossless everywhere | the two-rule failure taxonomy: *positional* ops (`take`/`drop`/`intersperse`) count every element; *value* ops (predicates, folds, chunkers, `zip`) act on values while failures pass untested | Elixir has no per-element error channel — this is the union design extended to many-values, and it needed a ruling per member (each pinned by test) |

## How to verify

```bash
node --test test/stream/stream-test.ts        # 36 tests, node lane
npx deno test --allow-all --no-check test/stream/stream-test.ts
npm run test:doctest                          # 390 doc examples execute, 49 of them Stream's
npm run lint:docs && npm run typecheck        # example-presence + doc typechecking gates
npm test                                      # full suite
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
