### PR TITLE
Resources release themselves: explicit resource management

### DIFF
--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -12,6 +12,7 @@ import * as Config from '../../setup/config.ts';
 import * as Browser from '../../setup/browser.ts';
 import { DaemonRunError } from '../run/tests-in-browser.ts';
 import { run } from '../run.ts';
+import { borrowArgv, borrowEnv } from '../../utils/borrowed-globals.ts';
 import * as Result from '../../result/index.ts';
 import { Failure } from '../../result/index.ts';
 import type { Request, ResponseChunk, RunRequest, DaemonInfo } from './protocol.ts';
@@ -222,14 +223,8 @@ export async function serve(): Promise<void> {
   // Config.setup reads process.argv directly; the daemon's actual argv is `daemon _serve`
   // which would be parsed as test paths. Strip it for the startup config — we only need
   // the browser type here. Per-run argv comes from the client via runOnce.
-  const argvSnapshot = process.argv;
-  process.argv = [argvSnapshot[0], argvSnapshot[1] ?? 'cli.ts'];
-  let configured;
-  try {
-    configured = await Config.setup();
-  } finally {
-    process.argv = argvSnapshot;
-  }
+  using _argv = borrowArgv([process.argv[0], process.argv[1] ?? 'cli.ts']);
+  const configured = await Config.setup();
   // Startup, not a client run: argv is stripped to nothing here, so the only way this fails is
   // a broken QUNITX_BROWSER or a plugin the project cannot load — in both cases the daemon has
   // nothing valid to serve, and refusing to start beats accepting runs it will fail.
@@ -740,26 +735,18 @@ async function runOnce(
   env: Record<string, string | undefined>,
   state: DaemonState,
 ): Promise<number> {
-  // Snapshot env + argv, swap in client values, restore on exit. Snapshot is also the
-  // baseline so before-hook env mutations don't bleed across runs.
-  const envSnapshot = { ...process.env };
-  for (const [key, value] of Object.entries(env)) {
-    if (value !== undefined) process.env[key] = value;
-  }
-  const argvSnapshot = process.argv;
-  process.argv = ['node', argvSnapshot[1] ?? 'cli.ts', ...argv];
+  // Both globals are lent for the whole call and given back however it ends. They used to be
+  // restored by two separate mechanisms at three separate places, and `env` was not among them
+  // when `Config.setup()` THREW — the argv `finally` ran, the exception left runOnce, and that
+  // client's environment stayed on the daemon for every later run.
+  using _env = borrowEnv(env);
+  using _argv = borrowArgv(['node', process.argv[1] ?? 'cli.ts', ...argv]);
 
-  let configured: Result.Result<ResolvedConfig, Config.ConfigFailure>;
-  try {
-    configured = (await Config.setup()) as Result.Result<ResolvedConfig, Config.ConfigFailure>;
-  } finally {
-    process.argv = argvSnapshot;
-  }
+  const configured = (await Config.setup()) as Result.Result<ResolvedConfig, Config.ConfigFailure>;
   // A bad flag from one client is that client's problem, not the daemon's. This is the whole
   // reason config assembly returns instead of exiting: `process.exit(1)` inside `Args.parse`
   // would have taken down a daemon serving every other invocation in the project.
   if (Failure.is(configured)) {
-    process.env = envSnapshot;
     process.stderr.write(`${Failure.format(configured)}\n`);
     return 1;
   }
@@ -788,12 +775,6 @@ async function runOnce(
   } catch (err) {
     if (err instanceof DaemonRunError) return err.exitCode;
     throw err;
-  } finally {
-    // Restore env: drop keys added during the run, restore changed values.
-    for (const key of Object.keys(process.env)) {
-      if (!(key in envSnapshot)) delete process.env[key];
-    }
-    Object.assign(process.env, envSnapshot);
   }
 }
 

--- a/lib/utils/borrowed-globals.ts
+++ b/lib/utils/borrowed-globals.ts
@@ -1,0 +1,73 @@
+import process from 'node:process';
+
+// Process-wide globals, lent for the duration of a scope and given back on the way out.
+//
+// The daemon is the reason this exists: it serves many clients from one process, and each run
+// needs `process.argv` and `process.env` to look like that client's invocation. Clobbering a
+// global you must put back is a resource, so these hand back a `Disposable` and let the language
+// do the putting back:
+//
+//   using _argv = borrowArgv(['node', 'cli.ts', ...clientArgv]);
+//   const config = await Config.setup();   // restored on return, throw, or early return
+//
+// A `try`/`finally` says the same thing, but it says it at the call site — which is where two
+// snapshots taken together and only one restored is an easy thing to write and a very hard thing
+// to see. Disposal runs in reverse order of acquisition, so nested borrows unwind like a stack.
+
+/**
+ * Replaces `process.argv` for the scope and restores the previous value on exit.
+ *
+ * ```ts
+ * import { borrowArgv } from './borrowed-globals.ts';
+ *
+ * const before = process.argv;
+ * {
+ *   using _argv = borrowArgv(['node', 'cli.ts', '--watch']);
+ *   process.argv[2]; // '--watch'
+ * }
+ * process.argv === before; // true — restored at the closing brace
+ * ```
+ */
+export function borrowArgv(argv: string[]): Disposable {
+  const previous = process.argv;
+  process.argv = argv;
+
+  return {
+    [Symbol.dispose]() {
+      process.argv = previous;
+    },
+  };
+}
+
+/**
+ * Applies `overrides` over `process.env` for the scope, then restores it exactly: keys added
+ * during the scope are dropped and changed values are put back.
+ *
+ * Key-by-key rather than `process.env = snapshot`, because assigning the object wholesale
+ * replaces the live binding other modules may already hold a reference to.
+ *
+ * ```ts
+ * import { borrowEnv } from './borrowed-globals.ts';
+ *
+ * {
+ *   using _env = borrowEnv({ QUNITX_BORROW_EXAMPLE: '1' });
+ *   process.env.QUNITX_BORROW_EXAMPLE; // '1'
+ * }
+ * process.env.QUNITX_BORROW_EXAMPLE; // undefined — the key never existed, so it is dropped
+ * ```
+ */
+export function borrowEnv(overrides: Record<string, string | undefined>): Disposable {
+  const snapshot = { ...process.env };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value !== undefined) process.env[key] = value;
+  }
+
+  return {
+    [Symbol.dispose]() {
+      for (const key of Object.keys(process.env)) {
+        if (!(key in snapshot)) delete process.env[key];
+      }
+      Object.assign(process.env, snapshot);
+    },
+  };
+}

--- a/test/flags/watch-rerun-test.ts
+++ b/test/flags/watch-rerun-test.ts
@@ -17,48 +17,46 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
   test('changing a file in watched directory triggers a re-run', async (assert) => {
     const { dir, id, testFile, testContent } = await makeWatchProject();
     // Watch the `tests/` directory so the file watcher resolves paths correctly.
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id });
 
-      // Modify the file (append a harmless comment to trigger a 'change' event).
-      await fs.writeFile(testFile, testContent + '\n// re-run trigger');
+    // Modify the file (append a harmless comment to trigger a 'change' event).
+    await fs.writeFile(testFile, testContent + '\n// re-run trigger');
 
-      const rerunBuf = await waitForRunComplete(session, 2, 're-run to start');
+    const rerunBuf = await waitForRunComplete(session, 2, 're-run to start');
 
-      assert.includes(session.stdout, 'CHANGED:');
-      const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
-      assert.includes(rerunOutput, '# pass 3');
-      assert.includes(rerunOutput, '# fail 0');
-    });
+    assert.includes(session.stdout, 'CHANGED:');
+    const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
+    assert.includes(rerunOutput, '# pass 3');
+    assert.includes(rerunOutput, '# fail 0');
   });
 
   test('adding a new file to the watched directory triggers a filtered re-run', async (assert) => {
     const { dir, id, testsDir, testContent } = await makeWatchProject();
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id });
 
-      // Add a second test file with its own unique module name.
-      const newId = randomUUID();
-      const newContent = testContent.replace(id, newId);
-      await fs.writeFile(`${testsDir}/extra-tests.ts`, newContent);
+    // Add a second test file with its own unique module name.
+    const newId = randomUUID();
+    const newContent = testContent.replace(id, newId);
+    await fs.writeFile(`${testsDir}/extra-tests.ts`, newContent);
 
-      const rerunBuf = await waitForRunComplete(session, 2, 're-run to start');
+    const rerunBuf = await waitForRunComplete(session, 2, 're-run to start');
 
-      const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
-      // Pass `{ stdout, fullStdout }`: the assertion checks the latest-run slice for
-      // correctness (older runs may also contain "# pass 3" and would be a false positive),
-      // but on failure surfaces the full session buffer including every "QUnitX running:"
-      // marker and the watcher event log — needed to root-cause flakes like the change-after-add
-      // race that lib/setup/file-watcher.ts ADD_SUPPRESS_WINDOW_MS now suppresses.
-      const ctx = { stdout: rerunOutput, fullStdout: rerunBuf };
-      // Filtered run only executes the newly added file (3 tests).
-      assert.includes(ctx, '# pass 3');
-      assert.includes(ctx, '# fail 0');
-      // The new file's module name appears in the filtered re-run output.
-      assert.includes(ctx, newId);
-    });
+    const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
+    // Pass `{ stdout, fullStdout }`: the assertion checks the latest-run slice for
+    // correctness (older runs may also contain "# pass 3" and would be a false positive),
+    // but on failure surfaces the full session buffer including every "QUnitX running:"
+    // marker and the watcher event log — needed to root-cause flakes like the change-after-add
+    // race that lib/setup/file-watcher.ts ADD_SUPPRESS_WINDOW_MS now suppresses.
+    const ctx = { stdout: rerunOutput, fullStdout: rerunBuf };
+    // Filtered run only executes the newly added file (3 tests).
+    assert.includes(ctx, '# pass 3');
+    assert.includes(ctx, '# fail 0');
+    // The new file's module name appears in the filtered re-run output.
+    assert.includes(ctx, newId);
   });
 
   test('deleting a file from the watched directory triggers a full re-run without it', async (assert) => {
@@ -68,26 +66,25 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
     const id2 = randomUUID();
     await fs.writeFile(`${testsDir}/extra-tests.ts`, testContent.replace(id, id2));
 
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      // Initial run: both files → 6 passing tests (all bundled together in watch mode).
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id });
-      assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    // Initial run: both files → 6 passing tests (all bundled together in watch mode).
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id });
+    assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
 
-      // Delete the first test file.
-      await fs.unlink(`${testsDir}/passing-tests.ts`);
+    // Delete the first test file.
+    await fs.unlink(`${testsDir}/passing-tests.ts`);
 
-      const rerunBuf = await waitForRunComplete(session, 2, 're-run to start');
+    const rerunBuf = await waitForRunComplete(session, 2, 're-run to start');
 
-      assert.includes(session.stdout, 'REMOVED:');
-      const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
-      // Only the second file's 3 tests run because the cache was cleared and rebuilt.
-      assert.includes(rerunOutput, '# pass 3');
-      assert.includes(rerunOutput, '# fail 0');
-      // The deleted file's module name is absent; the remaining file's is present.
-      assert.false(rerunOutput.includes(id), 'deleted file module absent from re-run output');
-      assert.includes(rerunOutput, id2);
-    });
+    assert.includes(session.stdout, 'REMOVED:');
+    const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
+    // Only the second file's 3 tests run because the cache was cleared and rebuilt.
+    assert.includes(rerunOutput, '# pass 3');
+    assert.includes(rerunOutput, '# fail 0');
+    // The deleted file's module name is absent; the remaining file's is present.
+    assert.false(rerunOutput.includes(id), 'deleted file module absent from re-run output');
+    assert.includes(rerunOutput, id2);
   });
 
   test('renaming a file triggers remove+add and the renamed file is re-run', async (assert) => {
@@ -97,28 +94,27 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
     const id2 = randomUUID();
     await fs.writeFile(`${testsDir}/extra-tests.ts`, testContent.replace(id, id2));
 
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id });
-      assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id });
+    assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
 
-      await fs.rename(`${testsDir}/passing-tests.ts`, `${testsDir}/renamed-tests.ts`);
+    await fs.rename(`${testsDir}/passing-tests.ts`, `${testsDir}/renamed-tests.ts`);
 
-      // REMOVED: and ADDED: are logged before the _building guard so they always appear.
-      await session.waitFor(
-        (buf) => buf.includes('REMOVED:') && buf.includes('ADDED:'),
-        'REMOVED and ADDED events',
-      );
+    // REMOVED: and ADDED: are logged before the _building guard so they always appear.
+    await session.waitFor(
+      (buf) => buf.includes('REMOVED:') && buf.includes('ADDED:'),
+      'REMOVED and ADDED events',
+    );
 
-      // Pending trigger: the add's filtered run fires after the unlink's full re-run completes.
-      // Wait for both runs to complete (initial + at least 2 more: unlink full-run + add filtered-run).
-      const rerunBuf = await waitForRunComplete(session, 3, 'unlink full-run + add filtered-run');
+    // Pending trigger: the add's filtered run fires after the unlink's full re-run completes.
+    // Wait for both runs to complete (initial + at least 2 more: unlink full-run + add filtered-run).
+    const rerunBuf = await waitForRunComplete(session, 3, 'unlink full-run + add filtered-run');
 
-      // Final run is the filtered run of the renamed file — same content (id), passes.
-      const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
-      assert.includes(rerunOutput, '# fail 0');
-      assert.includes(rerunOutput, id);
-    });
+    // Final run is the filtered run of the renamed file — same content (id), passes.
+    const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
+    assert.includes(rerunOutput, '# fail 0');
+    assert.includes(rerunOutput, id);
   });
 
   test('renaming a watched directory removes its files from tracking', async (assert) => {
@@ -130,57 +126,52 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
     await fs.mkdir(otherDir, { recursive: true });
     await fs.writeFile(`${otherDir}/other-tests.ts`, testContent.replace(id, id2));
 
-    await withWatchSession(['tests', 'other-tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id });
-      assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
+    await using session = await spawnWatch(['tests', 'other-tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id });
+    assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
 
-      // Rename tests/ — parent watcher detects disappearance and fires unlinkDir.
-      await fs.rename(testsDir, `${dir}/old-tests`);
+    // Rename tests/ — parent watcher detects disappearance and fires unlinkDir.
+    await fs.rename(testsDir, `${dir}/old-tests`);
 
-      await session.waitFor(
-        (buf) => buf.includes('REMOVED:'),
-        'REMOVED event for renamed directory',
-      );
-      const rerunBuf = await waitForRunComplete(session, 2, 're-run to start');
+    await session.waitFor((buf) => buf.includes('REMOVED:'), 'REMOVED event for renamed directory');
+    const rerunBuf = await waitForRunComplete(session, 2, 're-run to start');
 
-      const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
-      // Only the other-tests file runs — renamed directory's files are no longer tracked.
-      assert.includes(rerunOutput, id2);
-      assert.false(rerunOutput.includes(id), 'renamed-away directory files absent from re-run');
-    });
+    const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
+    // Only the other-tests file runs — renamed directory's files are no longer tracked.
+    assert.includes(rerunOutput, id2);
+    assert.false(rerunOutput.includes(id), 'renamed-away directory files absent from re-run');
   });
 
   test('rapid file changes coalesce: only the final state is tested', async (assert) => {
     const { dir, id, testFile, testContent } = await makeWatchProject();
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id });
 
-      // Write the file three times in quick succession. The pending-trigger mechanism
-      // ensures the last write wins: intermediate builds are coalesced.
-      const finalId = randomUUID();
-      await fs.writeFile(testFile, testContent + '\n// intermediate 1');
-      await fs.writeFile(testFile, testContent + '\n// intermediate 2');
-      await fs.writeFile(testFile, testContent.replace(id, finalId));
+    // Write the file three times in quick succession. The pending-trigger mechanism
+    // ensures the last write wins: intermediate builds are coalesced.
+    const finalId = randomUUID();
+    await fs.writeFile(testFile, testContent + '\n// intermediate 1');
+    await fs.writeFile(testFile, testContent + '\n// intermediate 2');
+    await fs.writeFile(testFile, testContent.replace(id, finalId));
 
-      // Wait until finalId has actually appeared in a completed run.
-      // Using count >= 2 is not enough: the first re-run may show an intermediate state while
-      // the pending trigger's build (which reads finalId) hasn't finished yet.
-      // waitFor returns a frozen snapshot of stdout at the exact moment the condition fired.
-      // Anchoring lastIndexOf before finalId's position guards against the edge case where a
-      // new run's 'QUnitX running:' banner arrived in the same data chunk as '# duration'.
-      const rerunBuf = await session.waitFor((buf) => {
-        const idx = buf.indexOf(finalId);
-        return idx !== -1 && buf.includes('# duration', idx);
-      }, 'final coalesced re-run with finalId to complete');
+    // Wait until finalId has actually appeared in a completed run.
+    // Using count >= 2 is not enough: the first re-run may show an intermediate state while
+    // the pending trigger's build (which reads finalId) hasn't finished yet.
+    // waitFor returns a frozen snapshot of stdout at the exact moment the condition fired.
+    // Anchoring lastIndexOf before finalId's position guards against the edge case where a
+    // new run's 'QUnitX running:' banner arrived in the same data chunk as '# duration'.
+    const rerunBuf = await session.waitFor((buf) => {
+      const idx = buf.indexOf(finalId);
+      return idx !== -1 && buf.includes('# duration', idx);
+    }, 'final coalesced re-run with finalId to complete');
 
-      const finalIdIdx = rerunBuf.indexOf(finalId);
-      const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:', finalIdIdx));
-      // The final state (finalId) ran — no crash, no broken intermediate state.
-      assert.includes(rerunOutput, '# fail 0');
-      assert.includes(rerunOutput, finalId);
-    });
+    const finalIdIdx = rerunBuf.indexOf(finalId);
+    const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:', finalIdIdx));
+    // The final state (finalId) ran — no crash, no broken intermediate state.
+    assert.includes(rerunOutput, '# fail 0');
+    assert.includes(rerunOutput, finalId);
   });
 
   test('simultaneous writes to files in two watched directories both appear in the rebuild', async (assert) => {
@@ -200,32 +191,31 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
     await fs.mkdir(testsDir2, { recursive: true });
     await fs.writeFile(testFile2, content2);
 
-    await withWatchSession(['tests', 'tests2', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id1 });
-      assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
+    await using session = await spawnWatch(['tests', 'tests2', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id1 });
+    assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
 
-      // Write to both files at the same time. The two separate fs.watch instances can
-      // deliver their change events at different times: the first event starts a full
-      // rebuild while the second queues as a pending trigger and fires after. On slower
-      // CI environments both new IDs may therefore appear across two consecutive runs
-      // rather than a single one. Wait for both IDs anywhere in the accumulated output.
-      const newId1 = randomUUID();
-      const newId2 = randomUUID();
-      await Promise.all([
-        fs.writeFile(testFile1, testContent.replace(id1, newId1)),
-        fs.writeFile(testFile2, content2.replace(id2, newId2)),
-      ]);
+    // Write to both files at the same time. The two separate fs.watch instances can
+    // deliver their change events at different times: the first event starts a full
+    // rebuild while the second queues as a pending trigger and fires after. On slower
+    // CI environments both new IDs may therefore appear across two consecutive runs
+    // rather than a single one. Wait for both IDs anywhere in the accumulated output.
+    const newId1 = randomUUID();
+    const newId2 = randomUUID();
+    await Promise.all([
+      fs.writeFile(testFile1, testContent.replace(id1, newId1)),
+      fs.writeFile(testFile2, content2.replace(id2, newId2)),
+    ]);
 
-      await session.waitFor(
-        (buf) => buf.includes(newId1) && buf.includes(newId2),
-        'both new module IDs appear in output',
-      );
+    await session.waitFor(
+      (buf) => buf.includes(newId1) && buf.includes(newId2),
+      'both new module IDs appear in output',
+    );
 
-      assert.includes(session.stdout, newId1);
-      assert.includes(session.stdout, newId2);
-      assert.includes(session.stdout, '# fail 0');
-    });
+    assert.includes(session.stdout, newId1);
+    assert.includes(session.stdout, newId2);
+    assert.includes(session.stdout, '# fail 0');
   });
 
   test('removing one watched directory fires REMOVED exactly once and leaves the other watcher live', async (assert) => {
@@ -238,42 +228,34 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
     await fs.mkdir(testsDir2, { recursive: true });
     await fs.writeFile(testFile2, content2);
 
-    await withWatchSession(['tests', 'tests2', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id1 });
-      assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
+    await using session = await spawnWatch(['tests', 'tests2', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id1 });
+    assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
 
-      // Rename tests/ away — the parent watcher fires a 'rename' event (Linux: IN_MOVED_FROM +
-      // IN_MOVED_TO appear as two separate events). The parentUnlinkFired guard ensures unlinkDir
-      // fires exactly once even if both arrive before the async stat() check completes.
-      await fs.rename(testsDir1, `${dir}/old-tests`);
+    // Rename tests/ away — the parent watcher fires a 'rename' event (Linux: IN_MOVED_FROM +
+    // IN_MOVED_TO appear as two separate events). The parentUnlinkFired guard ensures unlinkDir
+    // fires exactly once even if both arrive before the async stat() check completes.
+    await fs.rename(testsDir1, `${dir}/old-tests`);
 
-      await session.waitFor(
-        (buf) => buf.includes('REMOVED:'),
-        'REMOVED event for renamed directory',
-      );
-      await waitForRunComplete(session, 2, 're-run to start after removal');
+    await session.waitFor((buf) => buf.includes('REMOVED:'), 'REMOVED event for renamed directory');
+    await waitForRunComplete(session, 2, 're-run to start after removal');
 
-      // Removed directory's files are absent; remaining directory's files are present.
-      const afterRemoval = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
-      assert.false(afterRemoval.includes(id1), 'removed directory module absent from re-run');
-      assert.includes(afterRemoval, id2);
+    // Removed directory's files are absent; remaining directory's files are present.
+    const afterRemoval = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
+    assert.false(afterRemoval.includes(id1), 'removed directory module absent from re-run');
+    assert.includes(afterRemoval, id2);
 
-      // REMOVED: must appear exactly once — verifies the parentUnlinkFired double-fire fix.
-      assert.equal(
-        countOccurrences(session.stdout, 'REMOVED:'),
-        1,
-        'REMOVED: printed exactly once',
-      );
+    // REMOVED: must appear exactly once — verifies the parentUnlinkFired double-fire fix.
+    assert.equal(countOccurrences(session.stdout, 'REMOVED:'), 1, 'REMOVED: printed exactly once');
 
-      // Verify the remaining watcher (tests2/) is still functional after the removal.
-      const newId2 = randomUUID();
-      await fs.writeFile(testFile2, content2.replace(id2, newId2));
+    // Verify the remaining watcher (tests2/) is still functional after the removal.
+    const newId2 = randomUUID();
+    await fs.writeFile(testFile2, content2.replace(id2, newId2));
 
-      await waitForRunComplete(session, 3, 'second re-run to start');
+    await waitForRunComplete(session, 3, 'second re-run to start');
 
-      assert.includes(session.stdout, newId2);
-    });
+    assert.includes(session.stdout, newId2);
   });
 
   test('renaming a nested subdirectory fires one REMOVED and re-runs every watched path without it', async (assert) => {
@@ -303,41 +285,40 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
     await fs.mkdir(testsDir2, { recursive: true });
     await fs.writeFile(`${testsDir2}/extra.ts`, testContent.replace(rootId, id2));
 
-    await withWatchSession(['tests', 'tests2', '--watch'], { cwd: dir }, async (session) => {
-      // Initial run: 5 modules × 3 tests = 15 tests.
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: rootId });
-      assert.passingTestCaseFor(session.stdout, { moduleName: nestedId1 });
-      assert.passingTestCaseFor(session.stdout, { moduleName: nestedId2 });
-      assert.passingTestCaseFor(session.stdout, { moduleName: deepId });
-      assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
+    await using session = await spawnWatch(['tests', 'tests2', '--watch'], { cwd: dir });
+    // Initial run: 5 modules × 3 tests = 15 tests.
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: rootId });
+    assert.passingTestCaseFor(session.stdout, { moduleName: nestedId1 });
+    assert.passingTestCaseFor(session.stdout, { moduleName: nestedId2 });
+    assert.passingTestCaseFor(session.stdout, { moduleName: deepId });
+    assert.passingTestCaseFor(session.stdout, { moduleName: id2 });
 
-      // Rename tests/subdir/ away — fires ONE 'rename' event for the directory itself.
-      // The child watcher detects tracked children and fires a single unlinkDir.
-      await fs.rename(subdir, `${dir}/old-subdir`);
+    // Rename tests/subdir/ away — fires ONE 'rename' event for the directory itself.
+    // The child watcher detects tracked children and fires a single unlinkDir.
+    await fs.rename(subdir, `${dir}/old-subdir`);
 
-      await session.waitFor((buf) => buf.includes('REMOVED:'), 'REMOVED event for renamed subdir');
-      await waitForRunComplete(session, 2, 're-run to start');
+    await session.waitFor((buf) => buf.includes('REMOVED:'), 'REMOVED event for renamed subdir');
+    await waitForRunComplete(session, 2, 're-run to start');
 
-      // Re-run must include tests/root.ts and tests2/extra.ts only (6 tests).
-      const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
-      assert.includes(rerunOutput, '# pass 6');
-      assert.includes(rerunOutput, '# fail 0');
-      assert.includes(rerunOutput, rootId);
-      assert.includes(rerunOutput, id2);
-      assert.false(rerunOutput.includes(nestedId1), 'subdir files absent from re-run');
-      assert.false(rerunOutput.includes(nestedId2), 'subdir files absent from re-run');
-      assert.false(rerunOutput.includes(deepId), 'deeper files absent from re-run');
+    // Re-run must include tests/root.ts and tests2/extra.ts only (6 tests).
+    const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
+    assert.includes(rerunOutput, '# pass 6');
+    assert.includes(rerunOutput, '# fail 0');
+    assert.includes(rerunOutput, rootId);
+    assert.includes(rerunOutput, id2);
+    assert.false(rerunOutput.includes(nestedId1), 'subdir files absent from re-run');
+    assert.false(rerunOutput.includes(nestedId2), 'subdir files absent from re-run');
+    assert.false(rerunOutput.includes(deepId), 'deeper files absent from re-run');
 
-      // Exactly one REMOVED: must appear — the directory rename fires one child-watcher
-      // 'rename' event which the new unlinkDir detection coalesces into a single event,
-      // rather than N separate unlink events for each file inside the directory.
-      assert.equal(
-        countOccurrences(session.stdout, 'REMOVED:'),
-        1,
-        'exactly one REMOVED: for the whole renamed subdirectory',
-      );
-    });
+    // Exactly one REMOVED: must appear — the directory rename fires one child-watcher
+    // 'rename' event which the new unlinkDir detection coalesces into a single event,
+    // rather than N separate unlink events for each file inside the directory.
+    assert.equal(
+      countOccurrences(session.stdout, 'REMOVED:'),
+      1,
+      'exactly one REMOVED: for the whole renamed subdirectory',
+    );
   });
 
   test('watch mode starts without crashing when the initial file has a build error', async (assert) => {
@@ -345,53 +326,51 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
 
     // Break the file BEFORE launching qunitx so the first build attempt always fails.
     await fs.writeFile(testFile, 'this is not valid typescript !!@#$%^&*');
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      // The process must NOT crash — it should stay alive, print the bundle error, then
-      // set up the watcher and print "Watching files...". Wait for the latter so both
-      // assertions are guaranteed to be present in stdout at assertion time.
-      await session.waitFor(
-        (buf) => buf.includes('Watching files'),
-        'process to stay alive and reach watch-ready state after initial build error',
-      );
-      assert.includes(session.stdout, 'esbuild Bundle Error:');
-      assert.includes(session.stdout, 'Watching files');
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    // The process must NOT crash — it should stay alive, print the bundle error, then
+    // set up the watcher and print "Watching files...". Wait for the latter so both
+    // assertions are guaranteed to be present in stdout at assertion time.
+    await session.waitFor(
+      (buf) => buf.includes('Watching files'),
+      'process to stay alive and reach watch-ready state after initial build error',
+    );
+    assert.includes(session.stdout, 'esbuild Bundle Error:');
+    assert.includes(session.stdout, 'Watching files');
 
-      // Fix the file — the watcher must pick it up and run successfully.
-      await fs.writeFile(testFile, testContent);
-      await waitForRunComplete(session, 1, 're-run after initial error fixed');
+    // Fix the file — the watcher must pick it up and run successfully.
+    await fs.writeFile(testFile, testContent);
+    await waitForRunComplete(session, 1, 're-run after initial error fixed');
 
-      const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
-      assert.includes(rerunOutput, '# pass');
-      assert.includes(rerunOutput, '# fail 0');
-    });
+    const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
+    assert.includes(rerunOutput, '# pass');
+    assert.includes(rerunOutput, '# fail 0');
   });
 
   test('a build error in watch mode prints the error without exiting', async (assert) => {
     const { dir, id, testFile, testContent } = await makeWatchProject();
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      // Wait for the initial passing run.
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    // Wait for the initial passing run.
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id });
 
-      // Overwrite the file with invalid syntax that esbuild cannot bundle.
-      await fs.writeFile(testFile, 'this is not valid typescript !!@#$%^&*');
+    // Overwrite the file with invalid syntax that esbuild cannot bundle.
+    await fs.writeFile(testFile, 'this is not valid typescript !!@#$%^&*');
 
-      // Wait for the bundle error message to appear.
-      await session.waitFor(
-        (buf) => buf.includes('esbuild Bundle Error:'),
-        'esbuild Bundle Error to appear',
-      );
-      assert.includes(session.stdout, 'esbuild Bundle Error:');
+    // Wait for the bundle error message to appear.
+    await session.waitFor(
+      (buf) => buf.includes('esbuild Bundle Error:'),
+      'esbuild Bundle Error to appear',
+    );
+    assert.includes(session.stdout, 'esbuild Bundle Error:');
 
-      // Fix the file — a still-alive process will pick this up and re-run.
-      await fs.writeFile(testFile, testContent);
+    // Fix the file — a still-alive process will pick this up and re-run.
+    await fs.writeFile(testFile, testContent);
 
-      await waitForRunComplete(session, 2, 're-run after fix to start');
+    await waitForRunComplete(session, 2, 're-run after fix to start');
 
-      const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
-      assert.includes(rerunOutput, '# pass 3');
-      assert.includes(rerunOutput, '# fail 0');
-    });
+    const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
+    assert.includes(rerunOutput, '# pass 3');
+    assert.includes(rerunOutput, '# fail 0');
   });
 
   // ── Symlink tests ────────────────────────────────────────────────────────────────────────────
@@ -405,33 +384,31 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
     // Verifies the FSTree.build fix: symlinks inside the watched directory are included in the
     // initial fsTree scan and therefore bundled in the first run.
     const { dir, id, symlinkId } = await makeWatchProjectWithSymlink();
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      // Both the regular test file and the symlinked file must be in the initial bundle.
-      assert.passingTestCaseFor(session.stdout, { moduleName: id });
-      assert.passingTestCaseFor(session.stdout, { moduleName: symlinkId });
-    });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    // Both the regular test file and the symlinked file must be in the initial bundle.
+    assert.passingTestCaseFor(session.stdout, { moduleName: id });
+    assert.passingTestCaseFor(session.stdout, { moduleName: symlinkId });
   });
 
   test('adding a symlink to a .ts file triggers a filtered re-run', async (assert) => {
     // fs.watch fires a rename event when a symlink is created; classifyRenameEvent follows the
     // symlink via stat() and classifies it as 'add', triggering a filtered re-run.
     const { dir, id, testsDir, testContent } = await makeWatchProject();
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id });
 
-      const symlinkId = randomUUID();
-      const target = `${dir}/new-target.ts`;
-      await fs.writeFile(target, testContent.replace(id, symlinkId));
-      await fs.symlink(target, `${testsDir}/new-symlink.ts`);
+    const symlinkId = randomUUID();
+    const target = `${dir}/new-target.ts`;
+    await fs.writeFile(target, testContent.replace(id, symlinkId));
+    await fs.symlink(target, `${testsDir}/new-symlink.ts`);
 
-      await waitForRunComplete(session, 2, 'symlink add re-run to start');
+    await waitForRunComplete(session, 2, 'symlink add re-run to start');
 
-      const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
-      assert.includes(rerunOutput, symlinkId);
-      assert.includes(rerunOutput, '# fail 0');
-    });
+    const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
+    assert.includes(rerunOutput, symlinkId);
+    assert.includes(rerunOutput, '# fail 0');
   });
 
   test('writing through a symlink (modifying its target) triggers a re-run', async (assert) => {
@@ -445,70 +422,67 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
       testContent,
       symlinkId,
     } = await makeWatchProjectWithSymlink();
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: symlinkId });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: symlinkId });
 
-      const newId = randomUUID();
-      await fs.writeFile(symlink, testContent.replace(id, newId)); // writes through symlink to target
+    const newId = randomUUID();
+    await fs.writeFile(symlink, testContent.replace(id, newId)); // writes through symlink to target
 
-      // A write-through fires more than one fs event, and a mid-write one can trigger a re-run
-      // that reads the target before its bytes settle — a stale rebuild without newId. The
-      // content-hash gate then rebuilds once more on the settled write. Wait for the re-run that
-      // actually reflects the new content rather than asserting on whichever run happened to be
-      // second: in CI run 29790598868 a stale second run reached the assertion first and failed
-      // it. Waiting for the settled content tests the guarantee a user cares about (the watcher
-      // eventually shows the new bytes) and stays deterministic; a watcher that never converges
-      // still fails here on the waitFor timeout.
-      const rerunBuf = await session.waitFor((buf) => {
-        const latest = buf.slice(buf.lastIndexOf('QUnitX running:'));
-        return latest.includes(newId) && latest.includes('# duration');
-      }, 'symlink write-through re-run reflecting the new content');
+    // A write-through fires more than one fs event, and a mid-write one can trigger a re-run
+    // that reads the target before its bytes settle — a stale rebuild without newId. The
+    // content-hash gate then rebuilds once more on the settled write. Wait for the re-run that
+    // actually reflects the new content rather than asserting on whichever run happened to be
+    // second: in CI run 29790598868 a stale second run reached the assertion first and failed
+    // it. Waiting for the settled content tests the guarantee a user cares about (the watcher
+    // eventually shows the new bytes) and stays deterministic; a watcher that never converges
+    // still fails here on the waitFor timeout.
+    const rerunBuf = await session.waitFor((buf) => {
+      const latest = buf.slice(buf.lastIndexOf('QUnitX running:'));
+      return latest.includes(newId) && latest.includes('# duration');
+    }, 'symlink write-through re-run reflecting the new content');
 
-      const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
-      assert.includes(rerunOutput, newId);
-      assert.includes(rerunOutput, '# fail 0');
-    });
+    const rerunOutput = rerunBuf.slice(rerunBuf.lastIndexOf('QUnitX running:'));
+    assert.includes(rerunOutput, newId);
+    assert.includes(rerunOutput, '# fail 0');
   });
 
   test('deleting a symlink .ts file triggers a full re-run without it', async (assert) => {
     // fs.unlink on a symlink fires NO fs.watch events on Linux. The watcher uses fs.watchFile
     // polling (500 ms interval) to detect the deletion.
     const { dir, id, symlink, symlinkId } = await makeWatchProjectWithSymlink();
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id });
-      assert.passingTestCaseFor(session.stdout, { moduleName: symlinkId });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id });
+    assert.passingTestCaseFor(session.stdout, { moduleName: symlinkId });
 
-      await fs.unlink(symlink);
+    await fs.unlink(symlink);
 
-      // Poll detection fires within ~500 ms; use a 3 s cap to keep CI stable.
-      await waitForRunComplete(session, 2, 'symlink deletion re-run to start');
+    // Poll detection fires within ~500 ms; use a 3 s cap to keep CI stable.
+    await waitForRunComplete(session, 2, 'symlink deletion re-run to start');
 
-      assert.includes(session.stdout, 'REMOVED:');
-      const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
-      assert.includes(rerunOutput, id);
-      assert.false(rerunOutput.includes(symlinkId), 'deleted symlink module absent from re-run');
-    });
+    assert.includes(session.stdout, 'REMOVED:');
+    const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
+    assert.includes(rerunOutput, id);
+    assert.false(rerunOutput.includes(symlinkId), 'deleted symlink module absent from re-run');
   });
 
   test('deleting the target of a symlink (making it dangling) triggers a full re-run', async (assert) => {
     // When the symlink's target is removed, stat() on the symlink path starts failing.
     // The fs.watchFile poll detects nlink === 0 and fires 'unlink' for the symlink path.
     const { dir, id, symlink: _symlink, target, symlinkId } = await makeWatchProjectWithSymlink();
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: symlinkId });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: symlinkId });
 
-      // Delete the target (outside the watched dir). The symlink in tests/ becomes dangling.
-      await fs.unlink(target);
+    // Delete the target (outside the watched dir). The symlink in tests/ becomes dangling.
+    await fs.unlink(target);
 
-      await waitForRunComplete(session, 2, 'dangling symlink re-run to start');
+    await waitForRunComplete(session, 2, 'dangling symlink re-run to start');
 
-      const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
-      assert.includes(rerunOutput, id);
-      assert.false(rerunOutput.includes(symlinkId), 'dangling symlink module absent from re-run');
-    });
+    const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
+    assert.includes(rerunOutput, id);
+    assert.false(rerunOutput.includes(symlinkId), 'dangling symlink module absent from re-run');
   });
 
   test('renaming a symlink fires an immediate add then a polling-delayed unlink', async (assert) => {
@@ -524,67 +498,65 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
       symlinkId,
       testContent: _testContent,
     } = await makeWatchProjectWithSymlink();
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
-      assert.passingTestCaseFor(session.stdout, { moduleName: id });
-      assert.passingTestCaseFor(session.stdout, { moduleName: symlinkId });
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    assert.passingTestCaseFor(session.stdout, { moduleName: id });
+    assert.passingTestCaseFor(session.stdout, { moduleName: symlinkId });
 
-      // Rename the symlink within the watched dir. fs.watch fires 'rename' for the destination
-      // (add), while the source's removal is detected only by the fs.watchFile poll (~500 ms).
-      const renamedSymlink = `${testsDir}/renamed-symlink.ts`;
-      await fs.rename(symlink, renamedSymlink);
+    // Rename the symlink within the watched dir. fs.watch fires 'rename' for the destination
+    // (add), while the source's removal is detected only by the fs.watchFile poll (~500 ms).
+    const renamedSymlink = `${testsDir}/renamed-symlink.ts`;
+    await fs.rename(symlink, renamedSymlink);
 
-      // The add fires first — wait for the filtered re-run of the renamed symlink.
-      await session.waitFor((buf) => buf.includes('ADDED:'), 'ADDED event for renamed symlink');
-      await waitForRunComplete(session, 2, 'filtered re-run after add');
+    // The add fires first — wait for the filtered re-run of the renamed symlink.
+    await session.waitFor((buf) => buf.includes('ADDED:'), 'ADDED event for renamed symlink');
+    await waitForRunComplete(session, 2, 'filtered re-run after add');
 
-      // The unlink fires later via polling — wait for a second re-run.
-      await session.waitFor((buf) => buf.includes('REMOVED:'), 'REMOVED event via polling');
-      await waitForRunComplete(session, 3, 'full re-run after polling unlink');
+    // The unlink fires later via polling — wait for a second re-run.
+    await session.waitFor((buf) => buf.includes('REMOVED:'), 'REMOVED event via polling');
+    await waitForRunComplete(session, 3, 'full re-run after polling unlink');
 
-      const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
-      // Final state: renamed symlink's content (same symlinkId) present, original path gone.
-      assert.includes(rerunOutput, symlinkId);
-      assert.includes(rerunOutput, '# fail 0');
-    });
+    const rerunOutput = session.stdout.slice(session.stdout.lastIndexOf('QUnitX running:'));
+    // Final state: renamed symlink's content (same symlinkId) present, original path gone.
+    assert.includes(rerunOutput, symlinkId);
+    assert.includes(rerunOutput, '# fail 0');
   });
 
   test('a dangling symlink added to the watched directory is silently ignored', async (assert) => {
     // classifyRenameEvent: stat() fails on the dangling symlink, path is not in fsTree → null.
     // No re-run, no crash, no ADDED: in output.
     const { dir, id, testsDir, testContent } = await makeWatchProject();
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => buf.includes('Press "qq"'), 'initial run to complete');
 
-      await fs.symlink(`${dir}/nonexistent.ts`, `${testsDir}/dangling.ts`);
+    await fs.symlink(`${dir}/nonexistent.ts`, `${testsDir}/dangling.ts`);
 
-      // Proving a negative needs a horizon, and a fixed sleep is a guess at one. Adding a real
-      // file afterwards and waiting for its re-run gives a real horizon: handleWatchEvent logs
-      // every event it acts on before it acts, so by the time the real file's rebuild has
-      // finished, anything the symlink was going to produce has already been logged.
-      const realId = randomUUID();
-      await fs.writeFile(`${testsDir}/real-tests.ts`, testContent.replace(id, realId));
-      await waitForRunComplete(session, 2, 're-run for the real file');
+    // Proving a negative needs a horizon, and a fixed sleep is a guess at one. Adding a real
+    // file afterwards and waiting for its re-run gives a real horizon: handleWatchEvent logs
+    // every event it acts on before it acts, so by the time the real file's rebuild has
+    // finished, anything the symlink was going to produce has already been logged.
+    const realId = randomUUID();
+    await fs.writeFile(`${testsDir}/real-tests.ts`, testContent.replace(id, realId));
+    await waitForRunComplete(session, 2, 're-run for the real file');
 
-      // The event log is the invariant, not the run count. A dangling symlink is dropped by
-      // classifyRenameEvent (stat fails, path not in fsTree → null) before anything is logged
-      // or any rebuild is queued, so its absence from the log is exactly the claim.
-      //
-      // Run counts are deliberately NOT asserted. One fs.writeFile can emit both a rename and
-      // a trailing change, and whether the second is deduplicated depends on whether the add's
-      // build finished inside ADD_SUPPRESS_WINDOW_MS — best-effort, and false on a loaded
-      // runner. So the real file may legitimately produce one rebuild or two, which says
-      // nothing about the symlink. See the boundary pinned in
-      // `Setup | FileWatcher.handleWatchEvent`.
-      //
-      // session.stdout rather than the waitFor snapshot: it is the live buffer, so a symlink
-      // event arriving late (macOS coalesces and can reorder directory events) is still caught.
-      assert.notIncludes(session.stdout, 'dangling.ts');
-      // Matched separately rather than as one 'ADDED: <path>' string: the logged path is
-      // project-relative and separator-native, so it reads \tests\ on Windows.
-      assert.includes(session.stdout, 'ADDED:');
-      assert.includes(session.stdout, 'real-tests.ts');
-    });
+    // The event log is the invariant, not the run count. A dangling symlink is dropped by
+    // classifyRenameEvent (stat fails, path not in fsTree → null) before anything is logged
+    // or any rebuild is queued, so its absence from the log is exactly the claim.
+    //
+    // Run counts are deliberately NOT asserted. One fs.writeFile can emit both a rename and
+    // a trailing change, and whether the second is deduplicated depends on whether the add's
+    // build finished inside ADD_SUPPRESS_WINDOW_MS — best-effort, and false on a loaded
+    // runner. So the real file may legitimately produce one rebuild or two, which says
+    // nothing about the symlink. See the boundary pinned in
+    // `Setup | FileWatcher.handleWatchEvent`.
+    //
+    // session.stdout rather than the waitFor snapshot: it is the live buffer, so a symlink
+    // event arriving late (macOS coalesces and can reorder directory events) is still caught.
+    assert.notIncludes(session.stdout, 'dangling.ts');
+    // Matched separately rather than as one 'ADDED: <path>' string: the logged path is
+    // project-relative and separator-native, so it reads \tests\ on Windows.
+    assert.includes(session.stdout, 'ADDED:');
+    assert.includes(session.stdout, 'real-tests.ts');
   });
 
   test('no-tests warning in watch mode serves warning HTML at / until tests are added', async (assert) => {
@@ -593,152 +565,146 @@ module('Flags | --watch | re-runs', { concurrency: true }, () => {
 
     // Start with a no-tests file so the initial run produces a 0-tests warning.
     await fs.writeFile(testFile, 'export const x = 1;');
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => {
-        const match = buf.match(/http:\/\/localhost:(\d+)/);
-        if (match && port === null) port = Number(match[1]);
-        return buf.includes('Press "qq"');
-      }, 'initial no-tests run to complete');
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => {
+      const match = buf.match(/http:\/\/localhost:(\d+)/);
+      if (match && port === null) port = Number(match[1]);
+      return buf.includes('Press "qq"');
+    }, 'initial no-tests run to complete');
 
-      assert.includes(session.stdout, '# Warning: 0 tests registered');
+    assert.includes(session.stdout, '# Warning: 0 tests registered');
 
-      // Poll until / serves the amber warning HTML (not the normal QUnit page).
-      const warnBody = await pollUntil(
-        () => fetch(`http://localhost:${port}/`).then((r) => r.text()),
-        (body) => body.includes('Warning: No Tests Registered'),
-        { interval: 50, timeout: 5000, label: 'warning HTML at /' },
-      );
-      assert.includes(warnBody, 'Warning: No Tests Registered');
-      assert.includes(warnBody, '<html');
-      assert.notIncludes(warnBody, 'Build Error:');
+    // Poll until / serves the amber warning HTML (not the normal QUnit page).
+    const warnBody = await pollUntil(
+      () => fetch(`http://localhost:${port}/`).then((r) => r.text()),
+      (body) => body.includes('Warning: No Tests Registered'),
+      { interval: 50, timeout: 5000, label: 'warning HTML at /' },
+    );
+    assert.includes(warnBody, 'Warning: No Tests Registered');
+    assert.includes(warnBody, '<html');
+    assert.notIncludes(warnBody, 'Build Error:');
 
-      // Fix the file — add real tests. Warning must clear and normal page return.
-      await fs.writeFile(testFile, testContent);
-      await waitForRunComplete(session, 2, 're-run after tests added');
+    // Fix the file — add real tests. Warning must clear and normal page return.
+    await fs.writeFile(testFile, testContent);
+    await waitForRunComplete(session, 2, 're-run after tests added');
 
-      const okBody = await fetch(`http://localhost:${port}/`).then((r) => r.text());
-      assert.notIncludes(okBody, 'Warning: No Tests Registered');
-    });
+    const okBody = await fetch(`http://localhost:${port}/`).then((r) => r.text());
+    assert.notIncludes(okBody, 'Warning: No Tests Registered');
   });
 
   test('build error in watch mode serves error HTML at / until the file is fixed', async (assert) => {
     const { dir, testFile, testContent } = await makeWatchProject();
     let port: number | null = null;
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => {
-        const match = buf.match(/http:\/\/localhost:(\d+)/);
-        if (match && port === null) port = Number(match[1]);
-        return buf.includes('Press "qq"');
-      }, 'initial run to complete');
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => {
+      const match = buf.match(/http:\/\/localhost:(\d+)/);
+      if (match && port === null) port = Number(match[1]);
+      return buf.includes('Press "qq"');
+    }, 'initial run to complete');
 
-      // Trigger a build error
-      await fs.writeFile(testFile, 'this is not valid typescript !!@#$%^&*');
-      await session.waitFor(
-        (buf) => buf.includes('esbuild Bundle Error:'),
-        'build error to appear',
-      );
+    // Trigger a build error
+    await fs.writeFile(testFile, 'this is not valid typescript !!@#$%^&*');
+    await session.waitFor((buf) => buf.includes('esbuild Bundle Error:'), 'build error to appear');
 
-      // Poll until / serves the error HTML.
-      // Race: a single fs.writeFile can produce two inotify events. The second queues as a
-      // pending-trigger rebuild that clears fallbackPage = null at its start before re-setting
-      // it after the second failure. A single fetch right after 'esbuild Bundle Error:'
-      // appears in stdout can land in that brief null window and receive normal HTML.
-      const errorBody = await pollUntil(
-        () => fetch(`http://localhost:${port}/`).then((r) => r.text()),
-        (body) => body.includes('Build Error:'),
-        { interval: 50, timeout: 5000, label: 'error HTML at /' },
-      );
-      assert.includes(errorBody, 'Build Error:', 'error HTML served at / after build error');
-      assert.includes(errorBody, '<html', 'response is HTML, not a TAP stream');
+    // Poll until / serves the error HTML.
+    // Race: a single fs.writeFile can produce two inotify events. The second queues as a
+    // pending-trigger rebuild that clears fallbackPage = null at its start before re-setting
+    // it after the second failure. A single fetch right after 'esbuild Bundle Error:'
+    // appears in stdout can land in that brief null window and receive normal HTML.
+    const errorBody = await pollUntil(
+      () => fetch(`http://localhost:${port}/`).then((r) => r.text()),
+      (body) => body.includes('Build Error:'),
+      { interval: 50, timeout: 5000, label: 'error HTML at /' },
+    );
+    assert.includes(errorBody, 'Build Error:', 'error HTML served at / after build error');
+    assert.includes(errorBody, '<html', 'response is HTML, not a TAP stream');
 
-      // Fix the file — error clears, normal page returns
-      await fs.writeFile(testFile, testContent);
-      await waitForRunComplete(session, 2, 're-run after fix');
+    // Fix the file — error clears, normal page returns
+    await fs.writeFile(testFile, testContent);
+    await waitForRunComplete(session, 2, 're-run after fix');
 
-      const okBody = await fetch(`http://localhost:${port}/`).then((r) => r.text());
-      assert.notIncludes(okBody, 'Build Error:', 'error HTML cleared at / after fix');
-    });
+    const okBody = await fetch(`http://localhost:${port}/`).then((r) => r.text());
+    assert.notIncludes(okBody, 'Build Error:', 'error HTML cleared at / after fix');
   });
 
   test('build error in watch mode sends a WebSocket refresh message to connected clients', async (assert) => {
     const { dir, testFile, testContent } = await makeWatchProject();
     let port: number | null = null;
-    await withWatchSession(['tests', '--watch'], { cwd: dir }, async (session) => {
-      await session.waitFor((buf) => {
-        const match = buf.match(/http:\/\/localhost:(\d+)/);
-        if (match && port === null) port = Number(match[1]);
-        return buf.includes('Press "qq"');
-      }, 'initial run to complete');
+    await using session = await spawnWatch(['tests', '--watch'], { cwd: dir });
+    await session.waitFor((buf) => {
+      const match = buf.match(/http:\/\/localhost:(\d+)/);
+      if (match && port === null) port = Number(match[1]);
+      return buf.includes('Press "qq"');
+    }, 'initial run to complete');
 
-      const messages: string[] = [];
-      // Callbacks waiting for the next 'refresh' message. Drained and called on each arrival.
-      const refreshWaiters: Array<() => void> = [];
+    const messages: string[] = [];
+    // Callbacks waiting for the next 'refresh' message. Drained and called on each arrival.
+    const refreshWaiters: Array<() => void> = [];
 
-      const ws = new WebSocket(`ws://localhost:${port}`);
-      await new Promise<void>((resolve, reject) => {
-        ws.onopen = () => resolve();
-        ws.onerror = () => reject(new Error('WS connect failed'));
-      });
-      ws.onmessage = (e) => {
-        const data = typeof e.data === 'string' ? e.data : String(e.data);
-        messages.push(data);
-        if (data === 'refresh') {
-          const waiting = refreshWaiters.splice(0);
-          for (const cb of waiting) cb();
-        }
-      };
-
-      // Resolves as soon as messages contains at least n 'refresh' entries, or rejects after 5 s.
-      // Checks immediately so it never sleeps when the message has already arrived.
-      const waitForNRefreshes = (n: number): Promise<void> => {
-        const count = () => messages.filter((m) => m === 'refresh').length;
-        if (count() >= n) return Promise.resolve();
-        return new Promise<void>((resolve, reject) => {
-          const timer = setTimeout(
-            () => reject(new Error(`timed out waiting for ${n} refresh message(s)`)),
-            5000,
-          );
-          const check = () => {
-            if (count() >= n) {
-              clearTimeout(timer);
-              resolve();
-            } else {
-              refreshWaiters.push(check);
-            }
-          };
-          refreshWaiters.push(check);
-        });
-      };
-
-      try {
-        // Trigger the error and wait reactively for the first refresh — no fixed sleep.
-        // A single fs.writeFile can produce two inotify events; the second queues as a
-        // pending trigger. waitForNRefreshes(1) resolves on the first, and
-        // refreshCountAfterError captures however many actually fired.
-        await fs.writeFile(testFile, 'this is not valid typescript !!@#$%^&*');
-        await session.waitFor(
-          (buf) => buf.includes('esbuild Bundle Error:'),
-          'build error to appear',
-        );
-        await waitForNRefreshes(1);
-
-        const refreshCountAfterError = messages.filter((m) => m === 'refresh').length;
-        assert.ok(refreshCountAfterError >= 1, 'refresh sent to WS client on build error');
-
-        // Fix the file. onFinishFunc fires after run returns (after '# duration'
-        // appears). Wait reactively for one more refresh rather than sleeping.
-        await fs.writeFile(testFile, testContent);
-        await waitForRunComplete(session, 2, 're-run after fix');
-        await waitForNRefreshes(refreshCountAfterError + 1);
-
-        assert.ok(
-          messages.filter((m) => m === 'refresh').length > refreshCountAfterError,
-          'additional refresh sent to WS client after successful rebuild',
-        );
-      } finally {
-        ws.close();
-      }
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => resolve();
+      ws.onerror = () => reject(new Error('WS connect failed'));
     });
+    ws.onmessage = (e) => {
+      const data = typeof e.data === 'string' ? e.data : String(e.data);
+      messages.push(data);
+      if (data === 'refresh') {
+        const waiting = refreshWaiters.splice(0);
+        for (const cb of waiting) cb();
+      }
+    };
+
+    // Resolves as soon as messages contains at least n 'refresh' entries, or rejects after 5 s.
+    // Checks immediately so it never sleeps when the message has already arrived.
+    const waitForNRefreshes = (n: number): Promise<void> => {
+      const count = () => messages.filter((m) => m === 'refresh').length;
+      if (count() >= n) return Promise.resolve();
+      return new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error(`timed out waiting for ${n} refresh message(s)`)),
+          5000,
+        );
+        const check = () => {
+          if (count() >= n) {
+            clearTimeout(timer);
+            resolve();
+          } else {
+            refreshWaiters.push(check);
+          }
+        };
+        refreshWaiters.push(check);
+      });
+    };
+
+    try {
+      // Trigger the error and wait reactively for the first refresh — no fixed sleep.
+      // A single fs.writeFile can produce two inotify events; the second queues as a
+      // pending trigger. waitForNRefreshes(1) resolves on the first, and
+      // refreshCountAfterError captures however many actually fired.
+      await fs.writeFile(testFile, 'this is not valid typescript !!@#$%^&*');
+      await session.waitFor(
+        (buf) => buf.includes('esbuild Bundle Error:'),
+        'build error to appear',
+      );
+      await waitForNRefreshes(1);
+
+      const refreshCountAfterError = messages.filter((m) => m === 'refresh').length;
+      assert.ok(refreshCountAfterError >= 1, 'refresh sent to WS client on build error');
+
+      // Fix the file. onFinishFunc fires after run returns (after '# duration'
+      // appears). Wait reactively for one more refresh rather than sleeping.
+      await fs.writeFile(testFile, testContent);
+      await waitForRunComplete(session, 2, 're-run after fix');
+      await waitForNRefreshes(refreshCountAfterError + 1);
+
+      assert.ok(
+        messages.filter((m) => m === 'refresh').length > refreshCountAfterError,
+        'additional refresh sent to WS client after successful rebuild',
+      );
+    } finally {
+      ws.close();
+    }
   });
 });
 
@@ -761,32 +727,12 @@ function countOccurrences(str: string, needle: string): number {
   return count;
 }
 
-interface WatchSession {
+interface WatchSession extends AsyncDisposable {
   /** Resolves once `condition(accumulatedStdout)` returns true, or rejects after 90s. */
   waitFor(condition: (buf: string) => boolean, description?: string): Promise<string>;
   /** Sends SIGTERM and resolves once the child process has fully exited. */
   kill(): Promise<void>;
   readonly stdout: string;
-}
-
-// Runs `body` against a live watch session and always kills it afterwards.
-//
-// Every session holds a permit from the cross-process browser semaphore, released by kill().
-// A forgotten `finally` therefore does not fail its own test — it starves every later test of
-// a browser until the run times out, which is a miserable thing to debug. Handing the session
-// to a scope instead of returning it makes that impossible to get wrong, and takes an indent
-// level off all 21 tests that use one.
-async function withWatchSession<T>(
-  args: string[],
-  options: { cwd?: string; timeout?: number },
-  body: (session: WatchSession) => Promise<T>,
-): Promise<T> {
-  const session = await spawnWatch(args, options);
-  try {
-    return await body(session);
-  } finally {
-    await session.kill();
-  }
 }
 
 // Spawns a long-running watch-mode process. Returns a session object that lets tests
@@ -876,6 +822,13 @@ async function spawnWatch(
       } finally {
         permit.release();
       }
+    },
+    // What makes `await using session = await spawnWatch(...)` release the browser permit at the
+    // end of the test, however the test ends. The permit is the reason this matters: it comes
+    // from a semaphore capped at availableParallelism(), so a session that is not killed does
+    // not fail its own test — it starves every test that runs after it.
+    [Symbol.asyncDispose]() {
+      return this.kill();
     },
     get stdout() {
       return buf;

--- a/test/helpers/runner-registry.ts
+++ b/test/helpers/runner-registry.ts
@@ -75,16 +75,16 @@ export async function joinRunnerRegistry(
   const mutexPath = `${registryDir}.lock`;
 
   const releaseMutex = await acquireMutex(mutexPath);
-  let wasSolo = false;
-  try {
-    wasSolo = (await liveRunners(registryDir)).length === 0;
-    // Skipping the wipe is always safe; wiping while someone else runs is the bug. So when the
-    // mutex could not be taken (releaseMutex === null) we simply don't wipe.
-    if (wasSolo && releaseMutex) await onSolo();
-    await fs.writeFile(entryPath, JSON.stringify({ pid: process.pid, startedAt: Date.now() }));
-  } finally {
-    await releaseMutex?.();
-  }
+  // The mutex is held for exactly this scope. `await using` rather than try/finally because the
+  // release is the lock's own business, not the caller's — and a registry mutex that is not
+  // released wedges every later runner, not this one.
+  await using _mutex = { [Symbol.asyncDispose]: async () => void (await releaseMutex?.()) };
+
+  const wasSolo = (await liveRunners(registryDir)).length === 0;
+  // Skipping the wipe is always safe; wiping while someone else runs is the bug. So when the
+  // mutex could not be taken (releaseMutex === null) we simply don't wipe.
+  if (wasSolo && releaseMutex) await onSolo();
+  await fs.writeFile(entryPath, JSON.stringify({ pid: process.pid, startedAt: Date.now() }));
 
   return {
     runId: String(process.pid),
@@ -145,18 +145,19 @@ async function acquireMutex(mutexPath: string): Promise<(() => Promise<void>) | 
 async function publish(lockPath: string, entry: RunnerEntry): Promise<boolean> {
   const tmpPath = `${lockPath}.${process.pid}.tmp`;
   await fs.writeFile(tmpPath, JSON.stringify(entry));
-  try {
-    // EEXIST is the whole point of the link: someone else published first, which is an
-    // outcome, not a fault. The rethrow line means an EACCES or ENOSPC on the registry
-    // directory propagates instead of being read as "we lost the race" and silently
-    // disabling the cap.
-    const linked = await Result.try(fs.link, tmpPath, lockPath);
-    if (!linked.ok && !Result.isErrno(linked.error, 'EEXIST')) throw linked.error;
-    return linked.ok;
-  } finally {
-    // Drop our second reference; on success the lock's own name keeps the inode alive.
-    await fs.unlink(tmpPath).catch(ignore('runner registry tmpfile unlink'));
-  }
+  // The tmpfile is a resource from the moment it exists. Disposal drops our second reference to
+  // the inode; on success the lock's own name is what keeps it alive.
+  await using _tmpfile = {
+    [Symbol.asyncDispose]: () => fs.unlink(tmpPath).catch(ignore('runner registry tmpfile unlink')),
+  };
+
+  // EEXIST is the whole point of the link: someone else published first, which is an
+  // outcome, not a fault. The rethrow line means an EACCES or ENOSPC on the registry
+  // directory propagates instead of being read as "we lost the race" and silently
+  // disabling the cap.
+  const linked = await Result.try(fs.link, tmpPath, lockPath);
+  if (!linked.ok && !Result.isErrno(linked.error, 'EEXIST')) throw linked.error;
+  return linked.ok;
 }
 
 // `null` here means "no usable entry", which is genuinely all three of missing, torn, and


### PR DESCRIPTION
Stacked on #56. Converts the cleanups whose job is releasing a *resource* to `using` / `await using`, and leaves `try`/`finally` where the cleanup is not a resource.

### The daemon's globals were leaking

`runOnce` borrowed **both** `process.env` and `process.argv`. It restored argv in a `finally` and env in three other places — none of which ran when `Config.setup()` **threw**: the argv `finally` fired, the exception left `runOnce`, and that client's environment stayed on the daemon for every later run. This is the two-resources-acquired-one-released shape that `using` exists to make impossible.

```ts
using _env = borrowEnv(env);
using _argv = borrowArgv(['node', process.argv[1] ?? 'cli.ts', ...argv]);

const configured = await Config.setup();   // restored on return, throw, or early return
```

Two lines replace three restore sites. Disposal is reverse-order, so argv unwinds before env.

### What changed

| site | resource |
|---|---|
| `lib/utils/borrowed-globals.ts` *(new)* | `borrowArgv` / `borrowEnv` |
| `daemon/server.ts` — `runOnce`, `serve` | `process.argv`, `process.env` |
| `runner-registry.ts` | the registry mutex, the publish tmpfile |
| `watch-rerun-test.ts` | the browser semaphore permit |

The watch session is now `AsyncDisposable`, so `await using session = await spawnWatch(...)` releases the permit however the test ends. That deletes the `withWatchSession` callback wrapper from #56 and takes an indent level off all 21 tests with it. The permit is why it matters: it comes from a semaphore capped at `availableParallelism()`, so a leaked one does not fail its own test — it starves every test after it.

### Why not just `await task; cleanup()`

Measured, with a resource counter: cleanup after a bare `await` is skipped when the task fails, when the block returns early **on the success path**, when anything throws before the await, and when `.result()` re-throws a bug. `try`/`finally` and `await using` both hold across all five exits; `using` additionally can't be forgotten by a caller, and keeps both failures in a `SuppressedError` when the disposal itself throws.

### Verification

1127 tests, 361 doctests, typecheck, lint, prettier — green. `await using`, `Symbol.asyncDispose` and `SuppressedError` all verified under both `node` and `deno run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)