### PR TITLE
JS API: run qunitx from JavaScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ docs/lib
 benches/results.json
 dist/
 npm/*/bin/
+jsr/lib/
+jsr/templates/
+jsr/package.json

--- a/Makefile
+++ b/Makefile
@@ -248,10 +248,14 @@ release:
 	  npm install --package-lock-only --ignore-scripts; \
 	fi
 	npm publish --access public
-# Publish the jsr/ bootstrap package to JSR alongside npm. One arch-agnostic package
-# (jsr/cli.ts resolves os-arch at runtime and fetches the matching prebuilt binary
-# from the GitHub release), so a single publish covers every platform. --allow-dirty:
-# jsr/deno.json's bumped version is not committed yet at this point in the recipe.
+# Publish to JSR alongside npm. One arch-agnostic package with two exports: `.` is the
+# bootstrap (jsr/cli.ts resolves os-arch at runtime and fetches the matching prebuilt binary
+# from the GitHub release, so a single publish covers every platform), and `./api` is the JS
+# API. The staging step copies lib/, templates/ and package.json into jsr/ first, because JSR
+# resolves every export relative to the package root and a specifier may not climb above it.
+# --allow-dirty: jsr/deno.json's bumped version is not committed yet at this point in the
+# recipe, and the staged files are generated and gitignored.
+	node scripts/stage-jsr-library.ts
 	cd jsr && deno publish --allow-dirty
 	@node scripts/remove-optional-deps.js
 	@npm install --package-lock-only --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -224,13 +224,46 @@ const result = await run({
   onTest: (test) => console.log(test.status, test.fullName), // streamed as they finish
 });
 
-result.tests; // every test: name, modules, fullName, status, durationMs, assertions
+result.tests; // every test: name, modules, fullName, status, durationMs, assertions, file
 result.failedFiles; // absolute paths, attributed through source maps
-result.notices; // qunitx's own `# …` diagnostics, as data
+result.notices; // qunitx's own `# …` diagnostics, as data — see below
 result.browserLogs; // console.* and uncaught errors from the page (newest 1000)
+result.browserLogsTruncated; // how many were dropped past that cap
 result.coverage; // per-file line coverage, or null
 result.junitXml; // the XML document, or null
+result.startedAt; // epoch ms
+result.finishedAt; //  ″
+result.groupCount; // how many concurrent groups the files were split across
+result.resolved; // { browser, projectRoot, output, port, extensions, coverageFormats, filter? }
 ```
+
+`resolved` answers questions the caller cannot recover from what it passed in — chiefly which
+browser ran, and which port was actually bound (it auto-increments past a busy one).
+
+`file` on a test is populated **for failures only**: QUnit's `testEnd` carries no file, so the
+path is recovered from the failing assertion's stack through the source map. A passing test
+leaves no stack to map.
+
+### Notices — why `ok` alone is not enough
+
+`notices` are every `# …` line the CLI prints, as structured data. They matter because `ok` is
+ambiguous on its own:
+
+```js
+const result = await run({ inputs: ['test/'], onlyFailed: true });
+result.ok;           // true
+result.counts.total; // 0   ← nothing ran, and a gate checking `ok` would pass
+result.notices;      // [{ level: 'info',
+                     //    message: 'qunitx --only-failed: no previously-failing test files to run' }]
+```
+
+Each carries a `level`: `info` (a decision qunitx made), `warning` (a surprise), `error` (also
+went to stderr). So a cheap gate is `result.notices.some((n) => n.level !== 'info')`. Typical
+ones: a filter that matched nothing, `--changed` narrowing the run, a line target superseded by a
+broader input, coverage skipped on a non-chromium browser, build errors, timeouts.
+
+They are *not* captured stdout — text is a rendering **of** these, not their source. To capture
+the rendered text instead, pass `reporter` and `stdout`.
 
 Every CLI flag has an option; see the [CLI Reference](#cli-reference). `run('test/')` and
 `run(['a.ts', 'b.ts'])` are shorthand for `inputs`.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ matches.map((test) => `${test.fullName}  ${test.file}#${test.line}`);
 A reporter is any object with the handlers it cares about. Pass an instance as `reporter`; it can
 sit alongside a built-in one. A reporter that throws costs its own output and nothing else.
 
+Passing an object does **not** turn on printing — only a built-in *name*, or an explicit
+`stdout`, does. So a collector of your own keeps the run silent.
+
 ```js
 await run({
   reporter: [
@@ -317,6 +320,10 @@ if (Failure.is(outcome)) {
 ```
 
 `await run(…)` throws the same failure instead, if you prefer `try`/`catch`.
+
+A runnable end-to-end example lives in
+[`examples/js-api-quality-gate.ts`](examples/js-api-quality-gate.ts) — search, run, coverage
+floor, JUnit, a custom reporter, and failure handling in one script.
 
 ### Deno and TypeScript
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ output to the terminal.
 - `--junit` writes a JUnit XML report for CI dashboards, alongside the normal terminal output
 - `--coverage` reports V8 line coverage (terminal summary, plus optional `lcov` and `html` reports)
 - `--version` / `-v` prints the installed version
-- [JavaScript API](#javascript-api) — `await run('test/')` returns the results as data; silent by default, with `watch`, `search`, custom reporters and daemon control
+- [JavaScript API](#javascript-api) — `await run('test/')` returns the results as data; silent by default, with `watch`, `search`, custom reporters and daemon control. On npm and JSR (`jsr:@izelnakri/qunitx-cli/api`)
 - Optional daemon mode (`qunitx daemon start`) keeps Chrome and the esbuild context warm across runs — roughly halves the wall-clock time of repeated invocations
 - Docker image for zero-install CI usage
 
@@ -327,7 +327,14 @@ floor, JUnit, a custom reporter, and failure handling in one script.
 
 ### Deno and TypeScript
 
-The package ships its TypeScript sources, so Deno and Node 24 can import them directly:
+From JSR:
+
+```ts
+import { run } from 'jsr:@izelnakri/qunitx-cli/api';
+```
+
+The package also ships its TypeScript sources on npm, so Deno and Node 24 can import them
+directly:
 
 ```ts
 import { run } from 'qunitx-cli/lib/api/index.ts';

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ result.junitXml; // the XML document, or null
 result.startedAt; // epoch ms
 result.finishedAt; //  ″
 result.groupCount; // how many concurrent groups the files were split across
+result.aborted; // true when something stopped the run — see below
 result.resolved; // { browser, projectRoot, output, port, extensions, coverageFormats, filter? }
 ```
 
@@ -243,6 +244,16 @@ browser ran, and which port was actually bound (it auto-increments past a busy o
 `file` on a test is populated **for failures only**: QUnit's `testEnd` carries no file, so the
 path is recovered from the failing assertion's stack through the source map. A passing test
 leaves no stack to map.
+
+`aborted` distinguishes *stopped* from *red* — both end with `ok: false`. Check it before
+reporting failures, or a UI says "3 failures" when someone pressed stop. Pass a `signal` to
+cancel; an already-aborted one answers without launching a browser at all.
+
+```js
+const controller = new AbortController();
+const result = await run({ inputs: ['test/'], signal: controller.signal });
+result.aborted; // true — counts are a prefix of the suite, not a verdict on it
+```
 
 ### Notices — why `ok` alone is not enough
 
@@ -271,7 +282,8 @@ Every CLI flag has an option; see the [CLI Reference](#cli-reference). `run('tes
 ### watch
 
 An async-iterable session that yields a complete result per rerun, and closes deterministically.
-No keyboard shortcuts are installed and your stdin is left alone.
+No keyboard shortcuts are installed and your stdin is left alone — the behaviours behind them are
+methods instead.
 
 ```js
 import { watch } from 'qunitx-cli';
@@ -285,8 +297,47 @@ for await (const result of session) {
 }
 ```
 
-`session.rerun(files?)` forces a run and resolves with it; `session.close()` releases the browser
-and the port.
+The session is a handle with the same verbs the CLI's keyboard shortcuts are bound to — the CLI
+binds keys to these methods, so a terminal UI built on this API is not reimplementing them:
+
+```js
+await session.run(files?); // rerun, optionally scoped     (the file watcher's own path)
+await session.runAll(); // whole suite, drops line targets  (`qa`)
+await session.runFailed(); // only what failed last run     (`qf`)
+await session.abort(); // stop the run in flight            (`qq`)
+await session.close(); // release the browser and the port
+
+session.latest; // the most recent result, without consuming the iteration
+session.running; // is a run executing or queued
+```
+
+`session.events()` is the fine-grained feed — every event of every rerun, flat and in order, for
+progress bars and live logs.
+
+### runSession
+
+One run, watched as it happens. `run()` is the smaller thing when only the outcome matters; this
+is for when the *progress* is the point.
+
+```js
+import { runSession } from 'qunitx-cli';
+
+await using session = await runSession('test/');
+
+for await (const event of session) {
+  if (event.kind === 'test') process.stdout.write(event.test.status === 'passed' ? '.' : 'F');
+}
+
+const result = await session.result(); // RunResult — never undefined
+```
+
+Events are `runStart`, `test`, `notice`, `browserLog`, and finally `runEnd`, which carries the
+complete result — so a consumer reading only this feed never needs a second channel. Watch
+sessions emit the same shape, so a display written against one works against the other.
+
+**The run does not start until you consume it.** That is the correctness property, not an
+optimization: a browser cannot be told to slow down, so a run started before anyone was reading
+would either drop events or buffer the whole suite. Awaiting `result()` counts as consuming.
 
 ### search
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ const result = await run({
 result.tests; // every test: name, modules, fullName, status, durationMs, assertions
 result.failedFiles; // absolute paths, attributed through source maps
 result.notices; // qunitx's own `# …` diagnostics, as data
-result.browserLogs; // console.* and uncaught errors from the page
+result.browserLogs; // console.* and uncaught errors from the page (newest 1000)
 result.coverage; // per-file line coverage, or null
 result.junitXml; // the XML document, or null
 ```
@@ -271,7 +271,7 @@ matches.map((test) => `${test.fullName}  ${test.file}#${test.line}`);
 A reporter is any object with the handlers it cares about. Pass an instance as `reporter`; it can
 sit alongside a built-in one. A reporter that throws costs its own output and nothing else.
 
-Passing an object does **not** turn on printing — only a built-in *name*, or an explicit
+Passing an object does **not** turn on printing — only a built-in _name_, or an explicit
 `stdout`, does. So a collector of your own keeps the run silent.
 
 ```js
@@ -542,11 +542,11 @@ Don't forget to add the plugin's file extension(s) to `qunitx.extensions` so dir
 
 ### Environment variables
 
-| Variable              | Description                                                                                                                                                                                                                                                                                                                                  |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CHROME_BIN`          | Path to the Chrome/Chromium executable. Required on systems where Chrome is not on `PATH` (e.g. many CI environments). Set automatically when using `browser-actions/setup-chrome` in GitHub Actions.                                                                                                                                        |
-| `QUNITX_BROWSER`      | Browser engine to use (`chromium`, `firefox`, `webkit`). Equivalent to `--browser` on the CLI. Useful in CI matrix jobs.                                                                                                                                                                                                                     |
-| `NODE_COMPILE_CACHE`  | Standard Node env, auto-enabled by qunitx. Stores V8 bytecode for the CLI + its dep graph on disk so the second and subsequent `qunitx` runs skip the parser pass — measured ~8% faster end-to-end (more on slow CI disks). Defaults to `${TMPDIR}/node-compile-cache`; set to a path to relocate (handy for a CI cache key) or `""` to disable. |
+| Variable             | Description                                                                                                                                                                                                                                                                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CHROME_BIN`         | Path to the Chrome/Chromium executable. Required on systems where Chrome is not on `PATH` (e.g. many CI environments). Set automatically when using `browser-actions/setup-chrome` in GitHub Actions.                                                                                                                                            |
+| `QUNITX_BROWSER`     | Browser engine to use (`chromium`, `firefox`, `webkit`). Equivalent to `--browser` on the CLI. Useful in CI matrix jobs.                                                                                                                                                                                                                         |
+| `NODE_COMPILE_CACHE` | Standard Node env, auto-enabled by qunitx. Stores V8 bytecode for the CLI + its dep graph on disk so the second and subsequent `qunitx` runs skip the parser pass — measured ~8% faster end-to-end (more on slow CI disks). Defaults to `${TMPDIR}/node-compile-cache`; set to a path to relocate (handy for a CI cache key) or `""` to disable. |
 
 If you do not provide any HTML template, qunitx falls back to its built-in `test/tests.html` boilerplate internally, so `qunitx init` is optional.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ output to the terminal.
 - `--junit` writes a JUnit XML report for CI dashboards, alongside the normal terminal output
 - `--coverage` reports V8 line coverage (terminal summary, plus optional `lcov` and `html` reports)
 - `--version` / `-v` prints the installed version
+- [JavaScript API](#javascript-api) — `await run('test/')` returns the results as data; silent by default, with `watch`, `search`, custom reporters and daemon control
 - Optional daemon mode (`qunitx daemon start`) keeps Chrome and the esbuild context warm across runs — roughly halves the wall-clock time of repeated invocations
 - Docker image for zero-install CI usage
 
@@ -183,6 +184,150 @@ qunitx test/**/*.js --browser=webkit
 > npx playwright install firefox
 > npx playwright install webkit
 > ```
+
+## JavaScript API
+
+Everything the CLI does, available as a function — for CI scripts, editor integrations, agents,
+and anything else that needs the results as data rather than as text on a terminal.
+
+```js
+import { run } from 'qunitx-cli';
+
+const result = await run('test/');
+
+result.ok; // false
+result.counts; // { total: 42, passed: 41, failed: 1, skipped: 0, todo: 0, assertionsFailed: 1 }
+result.failures.map((test) => test.fullName); // ['Cart > Coupons: applies code']
+```
+
+Four things to know:
+
+- **Nothing is printed unless you ask.** The returned result is the whole answer. Pass
+  `reporter: 'tap'` (or `'spec'`, `'dot'`, `'github'`) to get the CLI's output too.
+- **Failing tests are not an error.** `run()` resolves with `ok: false`. It rejects only when the
+  run could not happen — a bad option, an unreadable input, no `package.json`.
+- **It is lazy.** These return a `Task` (a Promise superset), so nothing starts until you `await`.
+- **It is the same engine as the CLI**, taking the same code path, so behaviour cannot drift.
+
+### run
+
+```js
+import { run } from 'qunitx-cli';
+
+const result = await run({
+  inputs: ['test/', 'src/cart-test.ts#34'], // same grammar as the command line
+  filter: 'Cart',
+  browser: 'chromium',
+  coverage: { formats: ['lcov'] },
+  junit: true,
+  reporter: 'spec', // omit for silence
+  onTest: (test) => console.log(test.status, test.fullName), // streamed as they finish
+});
+
+result.tests; // every test: name, modules, fullName, status, durationMs, assertions
+result.failedFiles; // absolute paths, attributed through source maps
+result.notices; // qunitx's own `# …` diagnostics, as data
+result.browserLogs; // console.* and uncaught errors from the page
+result.coverage; // per-file line coverage, or null
+result.junitXml; // the XML document, or null
+```
+
+Every CLI flag has an option; see the [CLI Reference](#cli-reference). `run('test/')` and
+`run(['a.ts', 'b.ts'])` are shorthand for `inputs`.
+
+### watch
+
+An async-iterable session that yields a complete result per rerun, and closes deterministically.
+No keyboard shortcuts are installed and your stdin is left alone.
+
+```js
+import { watch } from 'qunitx-cli';
+
+const session = await watch({ inputs: ['test/'] });
+console.log(session.url); // http://localhost:1234
+
+for await (const result of session) {
+  console.log(`${result.counts.passed}/${result.counts.total}`);
+  if (result.ok) break; // breaking out closes the session
+}
+```
+
+`session.rerun(files?)` forces a run and resolves with it; `session.close()` releases the browser
+and the port.
+
+### search
+
+Lists what a selection would run, without running it — no browser, no bundle, milliseconds.
+
+```js
+import { search } from 'qunitx-cli';
+
+const { matches, total } = await search({ filter: 'Cart' });
+matches.map((test) => `${test.fullName}  ${test.file}#${test.line}`);
+```
+
+### Custom reporters
+
+A reporter is any object with the handlers it cares about. Pass an instance as `reporter`; it can
+sit alongside a built-in one. A reporter that throws costs its own output and nothing else.
+
+```js
+await run({
+  reporter: [
+    'tap',
+    {
+      onRunStart: (config, info) => {},
+      onTestEnd: (config, details) => {},
+      onNotice: (config, notice) => {}, // qunitx's own diagnostics
+      onBrowserLog: (config, log) => {}, // console.* from the page
+      onRunEnd: (config, info) => {},
+    },
+  ],
+  stdout: myWritable, // where the built-in reporter writes; defaults to process.stdout
+});
+```
+
+### daemon
+
+Reuses a persistent browser and warm bundle across runs — worth roughly 800 ms per run once it
+is up. `daemon.run` takes the options that survive a socket, so plugin objects, reporter
+instances and callbacks are a compile error rather than a silent drop.
+
+```js
+import { daemon } from 'qunitx-cli';
+
+await daemon.start();
+const result = await daemon.run({ inputs: ['test/'] }); // same RunResult
+await daemon.status(); // { running: true, pid, cwd, socketPath, … }
+await daemon.stop();
+```
+
+### Errors
+
+Declared failures are discriminable values, not messages to parse.
+
+```js
+import { run, Failure } from 'qunitx-cli';
+
+const outcome = await run({ browser: 'netscape' }).result(); // never throws
+if (Failure.is(outcome)) {
+  outcome.code; // 'InvalidOption'
+  Failure.format(outcome); // 'Invalid `browser` value: "netscape". Expected one of …'
+}
+```
+
+`await run(…)` throws the same failure instead, if you prefer `try`/`catch`.
+
+### Deno and TypeScript
+
+The package ships its TypeScript sources, so Deno and Node 24 can import them directly:
+
+```ts
+import { run } from 'qunitx-cli/lib/api/index.ts';
+```
+
+Types are shipped for the bundled entry too — `import { run, type RunResult } from 'qunitx-cli'`
+typechecks under `--strict`.
 
 ## Daemon mode
 

--- a/benches/api.bench.ts
+++ b/benches/api.bench.ts
@@ -17,7 +17,8 @@
  */
 import { Collector, buildResult } from '../lib/api/result.ts';
 import { resolveReporting, toConfigOptions } from '../lib/api/options.ts';
-import { run, search } from '../lib/api/index.ts';
+import { Channel, eventReporter, type RunEvent } from '../lib/api/events.ts';
+import { run, runSession, search } from '../lib/api/index.ts';
 import type { Config } from '../lib/types.ts';
 import type { TestDetails } from '../lib/reporters/types.ts';
 
@@ -47,6 +48,21 @@ Deno.bench('api: run() one file, tap reporter', { group: 'api-run', n: 3, warmup
     stdout: { write: () => {} },
   });
 });
+
+// What the event feed costs over the plain value: same run, same browser, one extra reporter and
+// one channel push per event. If watching a run is meaningfully slower than waiting one out, the
+// session abstraction is not worth having.
+Deno.bench(
+  'api: runSession() one file, events consumed',
+  { group: 'api-run', n: 3, warmup: 1 },
+  async () => {
+    await using session = await runSession({
+      inputs: [FIXTURE],
+      output: `tmp/bench-api-${crypto.randomUUID()}`,
+    });
+    for await (const _event of session);
+  },
+);
 
 Deno.bench('api: search() one file, no browser', { group: 'api-scan', n: 20 }, async () => {
   await search({ inputs: [FIXTURE] });
@@ -93,6 +109,7 @@ const benchConfig = (): Config =>
         failedFiles: new Set<string>(),
         failedTests: [],
         coverage: null,
+        aborted: false,
       },
     },
   }) as unknown as Config;
@@ -113,4 +130,25 @@ Deno.bench('api: buildResult over 10k tests', { group: 'api-collect' }, () => {
 Deno.bench('api: resolve options + reporters', { group: 'api-collect' }, () => {
   const reporting = resolveReporting({ inputs: [FIXTURE], reporter: 'tap' });
   toConfigOptions({ inputs: [FIXTURE], reporter: 'tap' }, reporting);
+});
+
+// The event path's own cost, with no browser in the way: 10k pushes through a channel a consumer
+// is draining as fast as it can. This is the number that would move if the queue grew an
+// allocation per event.
+Deno.bench('api: channel round-trips 10k events', { group: 'api-collect' }, async () => {
+  const channel = new Channel<RunEvent>();
+  const drained = (async () => {
+    let seen = 0;
+    for await (const _event of channel) seen++;
+
+    return seen;
+  })();
+
+  // One config, hoisted: the reporter ignores it, and rebuilding it per event would price the
+  // fixture rather than the channel.
+  const config = benchConfig();
+  const reporter = eventReporter(channel);
+  for (let index = 0; index < 10_000; index++) reporter.onTestEnd?.(config, details(index));
+  channel.close();
+  await drained;
 });

--- a/benches/api.bench.ts
+++ b/benches/api.bench.ts
@@ -1,0 +1,116 @@
+/**
+ * JS API benchmarks — what a programmatic caller pays, as distinct from what a CLI user pays.
+ *
+ * Three cost layers, deliberately separated so a regression lands on the one that caused it:
+ *
+ *   in-process   →  `run()` against a live browser, minus Node boot and module load. The
+ *                   difference from `benches/e2e.bench.ts`'s `e2e-1` is the whole reason to
+ *                   drive the API rather than spawn the CLI, so it is worth a number.
+ *   silent       →  the same run with a reporter attached, to price the reporting fan-out.
+ *                   Silence is the API's default, so "does printing cost anything" is the
+ *                   question every caller implicitly asks.
+ *   scan         →  `search()`, which touches no browser at all — the floor for "what would run".
+ *
+ * The collector benches are pure CPU: they price the per-test bookkeeping the API adds on top of
+ * the runner, at a scale (10k) no real suite reaches, so a per-event regression shows up as a
+ * number rather than as a vague sense that large suites got slower.
+ */
+import { Collector, buildResult } from '../lib/api/result.ts';
+import { resolveReporting, toConfigOptions } from '../lib/api/options.ts';
+import { run, search } from '../lib/api/index.ts';
+import type { Config } from '../lib/types.ts';
+import type { TestDetails } from '../lib/reporters/types.ts';
+
+const PROJECT_ROOT = new URL('..', import.meta.url).pathname;
+const FIXTURE = 'test/fixtures/passing-tests.ts';
+
+Deno.chdir(PROJECT_ROOT);
+
+// ─── browser-backed ──────────────────────────────────────────────────────────
+// Low iteration counts: each of these launches a real Chrome.
+
+Deno.bench(
+  'api: run() one file, silent',
+  { group: 'api-run', baseline: true, n: 3, warmup: 1 },
+  async () => {
+    await run({ inputs: [FIXTURE], output: `tmp/bench-api-${crypto.randomUUID()}` });
+  },
+);
+
+Deno.bench('api: run() one file, tap reporter', { group: 'api-run', n: 3, warmup: 1 }, async () => {
+  await run({
+    inputs: [FIXTURE],
+    output: `tmp/bench-api-${crypto.randomUUID()}`,
+    reporter: 'tap',
+    // Into a sink rather than the process stream: the bench measures the fan-out and rendering,
+    // not the terminal's ability to absorb it.
+    stdout: { write: () => {} },
+  });
+});
+
+Deno.bench('api: search() one file, no browser', { group: 'api-scan', n: 20 }, async () => {
+  await search({ inputs: [FIXTURE] });
+});
+
+// ─── in-memory bookkeeping ───────────────────────────────────────────────────
+// What the API adds per test on top of the runner: one projection and one array push.
+
+const details = (index: number): TestDetails => ({
+  status: index % 10 === 0 ? 'failed' : 'passed',
+  fullName: ['Bench', `case ${index}`],
+  runtime: 1,
+  assertions: index % 10 === 0 ? [{ passed: false, todo: false, actual: 1, expected: 2 }] : [],
+});
+
+Deno.bench('api: collector records 10k testEnd events', { group: 'api-collect' }, () => {
+  const collector = new Collector();
+  for (let index = 0; index < 10_000; index++) {
+    collector.onTestEnd(undefined as unknown as Config, details(index));
+  }
+});
+
+const benchConfig = (): Config =>
+  ({
+    projectRoot: PROJECT_ROOT,
+    cwd: PROJECT_ROOT,
+    output: 'tmp',
+    browser: 'chromium',
+    port: 1234,
+    extensions: ['js', 'ts'],
+    fsTree: { [`${PROJECT_ROOT}${FIXTURE}`]: null },
+    state: {
+      groupCount: 1,
+      group: { lastRanFiles: [`${PROJECT_ROOT}${FIXTURE}`] },
+      results: {
+        counter: {
+          testCount: 10_000,
+          passCount: 9_000,
+          failCount: 1_000,
+          skipCount: 0,
+          todoCount: 0,
+          errorCount: 1_000,
+        },
+        failedFiles: new Set<string>(),
+        failedTests: [],
+        coverage: null,
+      },
+    },
+  }) as unknown as Config;
+
+Deno.bench('api: buildResult over 10k tests', { group: 'api-collect' }, () => {
+  const collector = new Collector();
+  for (let index = 0; index < 10_000; index++) {
+    collector.onTestEnd(undefined as unknown as Config, details(index));
+  }
+  buildResult(
+    benchConfig(),
+    { exitCode: 1, durationMs: 100, startedAt: 0, finishedAt: 100 },
+    collector,
+    null,
+  );
+});
+
+Deno.bench('api: resolve options + reporters', { group: 'api-collect' }, () => {
+  const reporting = resolveReporting({ inputs: [FIXTURE], reporter: 'tap' });
+  toConfigOptions({ inputs: [FIXTURE], reporter: 'tap' }, reporting);
+});

--- a/benches/task.bench.ts
+++ b/benches/task.bench.ts
@@ -1,0 +1,175 @@
+/**
+ * Benchmarks the future-outcome layer.
+ *
+ * A Task is a real Promise (`instanceof Promise` holds, the Promises/A+ suite passes) built
+ * from a lazy recipe. That buys laziness, lineage and retry — and the cost of those has to
+ * stay small enough that reaching for a Task instead of a Promise is never a performance
+ * decision. Every group below pairs the Task spelling with its native equivalent so the
+ * overhead is legible rather than asserted.
+ *
+ * The `create` group also pins the thing laziness is FOR: constructing a Task that is never
+ * awaited must not run its recipe, so it should be far cheaper than the eager Promise it
+ * replaces.
+ */
+import { Task } from '../lib/task/index.ts';
+import * as Failure from '../lib/result/failure.ts';
+
+const NotFound = Failure.define('NotFound', (data: { id: number }) => `no user ${data.id}`);
+const double = (n: number) => n * 2;
+
+// ── Construction: what a Task costs before anyone awaits it ───────────────────
+
+Deno.bench('task: construct (recipe never run)', { group: 'create' }, () => {
+  Task(() => 21);
+});
+
+Deno.bench('task: Promise.resolve for comparison', { group: 'create' }, () => {
+  Promise.resolve(21);
+});
+
+Deno.bench('task: construct + three derivations, unawaited', { group: 'create' }, () => {
+  Task(() => 21)
+    .map(double)
+    .map(double)
+    .map(double);
+});
+
+// ── Awaiting: the run, once ───────────────────────────────────────────────────
+
+Deno.bench('task: await a one-step task', { group: 'await' }, async () => {
+  await Task(() => 21).map(double);
+});
+
+Deno.bench('task: await the native equivalent', { group: 'await' }, async () => {
+  await Promise.resolve(21).then(double);
+});
+
+Deno.bench('task: await a three-step chain', { group: 'await' }, async () => {
+  await Task(() => 21)
+    .map(double)
+    .map(double)
+    .map(double);
+});
+
+Deno.bench('task: memoised second await (shares one run)', { group: 'await' }, async () => {
+  const task = Task(() => 21).map(double);
+  await task;
+  await task;
+});
+
+// ── The failure path: declared failures settle, they do not throw ─────────────
+
+Deno.bench('task: result() on a declared failure', { group: 'failure' }, async () => {
+  await Task(() => NotFound({ id: 7 })).result();
+});
+
+Deno.bench('task: mapErr classifies a foreign error', { group: 'failure' }, async () => {
+  await Task(() => {
+    throw new Error('boom');
+  })
+    .mapErr(() => NotFound({ id: 7 }))
+    .result();
+});
+
+// ── Combinators: the overridden statics, and their laziness ───────────────────
+
+const TEN = Array.from({ length: 10 }, (_, index) => index);
+
+Deno.bench('task: Task.all over 10 members', { group: 'combinators' }, async () => {
+  await Task.all(TEN.map((n) => Task(() => n)));
+});
+
+Deno.bench('task: Promise.all over 10 members', { group: 'combinators' }, async () => {
+  await Promise.all(TEN.map((n) => Promise.resolve(n)));
+});
+
+Deno.bench('task: Task.results keeps every outcome bare', { group: 'combinators' }, async () => {
+  await Task.results(TEN.map((n) => Task(() => (n % 3 === 0 ? NotFound({ id: n }) : n))));
+});
+
+// ── Executor question: is `Task(recipe => new Promise(exec))` a viable substitute ──
+// for a hypothetical `Task((resolve, reject, signal) => …)` constructor overload?
+// These measure what the "executor via recipe" ergonomic actually costs vs a plain
+// recipe, vs withResolvers, vs the native Promise executor it would wrap.
+
+Deno.bench('exec: Task(recipe) — plain', { group: 'executor' }, async () => {
+  await Task<number>(() => 21);
+});
+
+Deno.bench('exec: Task(signal => new Promise(exec))', { group: 'executor' }, async () => {
+  await Task<number>(
+    (_signal) => new Promise<number>((resolve) => resolve(21)),
+  );
+});
+
+Deno.bench('exec: Task.withResolvers settle+await', { group: 'executor' }, async () => {
+  const { promise, resolve } = Task.withResolvers<number>();
+  resolve(21);
+  await promise;
+});
+
+Deno.bench('exec: native new Promise(executor)', { group: 'executor' }, async () => {
+  await new Promise<number>((resolve) => resolve(21));
+});
+
+// ── The Elixir family the port added — cost of the await/yield/shutdown surface ──
+
+Deno.bench('elixir: Task.async then await()', { group: 'elixir' }, async () => {
+  await Task.async(() => 21).await(1000);
+});
+
+Deno.bench('elixir: task.yield(ms) settled', { group: 'elixir' }, async () => {
+  await Task(() => 21).yield(1000);
+});
+
+Deno.bench('elixir: task.await(ms) settled', { group: 'elixir' }, async () => {
+  await Task(() => 21).await(1000);
+});
+
+Deno.bench('elixir: task.shutdown(ms) on settled', { group: 'elixir' }, async () => {
+  await Task(() => 21).perform().shutdown(1000);
+});
+
+Deno.bench('elixir: Task.awaitMany over 10', { group: 'elixir' }, async () => {
+  await Task.awaitMany(TEN.map((n) => Task(() => n)), 1000);
+});
+
+Deno.bench('elixir: Task.completed passthrough', { group: 'elixir' }, async () => {
+  await Task.completed(21);
+});
+
+// ── Unified constructor: does arity dispatch cost anything? ───────────────────
+// The constructor now reads `fn.length` once and stores a boolean. These pin that the
+// recipe path is unchanged and that the executor path beats the `new Promise` it replaces.
+
+Deno.bench('unified: Task(() => v) recipe', { group: 'unified' }, async () => {
+  await Task<number>(() => 21);
+});
+
+Deno.bench('unified: Task((resolve) => resolve(v)) executor', { group: 'unified' }, async () => {
+  await Task<number>((resolve) => resolve(21));
+});
+
+Deno.bench('unified: Task((r, j, signal) => promise)', { group: 'unified' }, async () => {
+  await Task<number>((_resolve, _reject, _signal) => Promise.resolve(21));
+});
+
+Deno.bench('unified: Task(() => new Promise(exec)) old way', { group: 'unified' }, async () => {
+  await Task<number>(() => new Promise<number>((resolve) => resolve(21)));
+});
+
+Deno.bench('unified: native new Promise(executor)', { group: 'unified' }, async () => {
+  await new Promise<number>((resolve) => resolve(21));
+});
+
+Deno.bench('unified: construct executor, never awaited', { group: 'unified-create' }, () => {
+  Task<number>((resolve) => resolve(21));
+});
+
+Deno.bench('unified: construct recipe, never awaited', { group: 'unified-create' }, () => {
+  Task<number>(() => 21);
+});
+
+Deno.bench('unified: native Promise executor (eager)', { group: 'unified-create' }, () => {
+  new Promise<number>((resolve) => resolve(21));
+});

--- a/cli.ts
+++ b/cli.ts
@@ -124,7 +124,7 @@ const EXIT_CODE_SIGTERM = 128 + 15;
       import('./lib/utils/color.ts'),
       import('./lib/utils/close-with-grace.ts'),
     ]);
-    KeyboardEvents.setup(session.config, session.connections);
+    KeyboardEvents.setup(session);
     // Close the HTTP SERVER on SIGTERM — and only the server. The point is that the port is
     // reclaimed by application code rather than as a side effect of OS process cleanup: on macOS,
     // waitpid() can return a few ms before the socket is reclaimed, which makes the port look busy

--- a/cli.ts
+++ b/cli.ts
@@ -20,6 +20,8 @@ process.title = 'qunitx';
 // write queue stalls until the reader catches up. 250ms was tight enough to be the normal path
 // there, which is exactly what it must never be.
 const FLUSH_GRACE_MS = 30_000;
+// Conventional exit code for a process terminated by SIGTERM (128 + signal number 15).
+const EXIT_CODE_SIGTERM = 128 + 15;
 
 // Command-module imports are dynamic so the daemon-routed-run path doesn't
 // load `help.ts`, `init.ts`, `generate.ts`, or `setup/config.ts` (and its
@@ -74,7 +76,7 @@ const FLUSH_GRACE_MS = 30_000;
   // Local-run path: lazy-import Config.setup + run.ts (and their transitive
   // chains: esbuild, playwright-core, fs-tree, etc.). Loading in parallel lets
   // playwright-core's heavy module evaluation overlap with config assembly.
-  const [Config, { run }] = await Promise.all([
+  const [Config, { run, watch }] = await Promise.all([
     import('./lib/setup/config.ts'),
     import('./lib/commands/run.ts'),
   ]);
@@ -102,7 +104,39 @@ const FLUSH_GRACE_MS = 30_000;
     return exitAfterFlush(exitCode);
   }
 
-  return await run(config);
+  // Watch mode hands back a live session and leaves the process running. Everything that makes
+  // it a *terminal* session rather than a library call — stdin shortcuts, the SIGTERM handler,
+  // the banner — is wired up here, because `lib/` has no business owning any of the three.
+  if (config.watch) {
+    const session = await watch(config);
+    const [KeyboardEvents, { blue }] = await Promise.all([
+      import('./lib/setup/keyboard-events.ts'),
+      import('./lib/utils/color.ts'),
+    ]);
+    KeyboardEvents.setup(session.config, session.connections);
+    // Close the HTTP server explicitly on SIGTERM so the port is reclaimed by application code
+    // rather than as a side effect of OS process cleanup — on macOS, waitpid() can return a few
+    // ms before the socket is reclaimed, which makes the port look busy to whatever starts next.
+    // On Windows child.kill('SIGTERM') calls TerminateProcess() so this never runs, and
+    // TerminateProcess is synchronous, so the race doesn't exist there either.
+    process.once('SIGTERM', () => {
+      void session.close().finally(() => process.exit(EXIT_CODE_SIGTERM));
+    });
+    console.log('#', blue(`Watching files... You can browse the tests on ${session.url} ...`));
+    return console.log(
+      '#',
+      blue(
+        `Shortcuts: Press "qq" to abort running tests, "qa" to run all the tests, "qf" to run last failing test, "ql" to repeat last test`,
+      ),
+    );
+  }
+
+  const outcome = await run(config);
+  // The trailing newline the batch run has always ended on. Daemon-routed runs skip it — the
+  // daemon's own local run produced it inside the socket stream already.
+  process.stdout.write('\n');
+
+  return exitAfterFlush(outcome.exitCode);
 })().catch(async (error) => {
   // The program's ONE crash boundary, and the two-tier rule at the very edge: a declared failure
   // is a message (`init`/`generate` reach here when there is no package.json to work in), a bug

--- a/cli.ts
+++ b/cli.ts
@@ -7,11 +7,15 @@ import './lib/utils/enable-compile-cache.ts';
 // env is already set or no sidecar is present (npm / source / Node SEA paths).
 import './lib/utils/find-sidecar-esbuild.ts';
 import process from 'node:process';
-import { shutdownPrelaunch } from './lib/chrome/prelaunch.ts';
+import { shutdownPrelaunch, startPrelaunch } from './lib/chrome/prelaunch.ts';
 import { Failure } from './lib/result/index.ts';
 import pkg from './package.json' with { type: 'json' };
 
 process.title = 'qunitx';
+// First statement, and deliberately so: this spawns Chrome for run commands, and the whole
+// point is that its ~150ms start-up overlaps the dynamic import of playwright-core below
+// rather than following it. Everything between here and that import is synchronous.
+startPrelaunch();
 
 // The timer is a LAST RESORT, not a routine path: whenever it fires before the drain callback,
 // process.exit() drops whatever is still queued. run.ts learned this the hard way and uses the
@@ -42,9 +46,15 @@ const EXIT_CODE_SIGTERM = 128 + 15;
   } else if (['help', 'h', 'p', 'print'].includes(cmd)) {
     return await (await import('./lib/commands/help.ts')).run();
   } else if (['new', 'n', 'g', 'generate'].includes(cmd)) {
-    return await (await import('./lib/commands/generate.ts')).run();
+    const { path, created } = await (await import('./lib/commands/generate.ts')).run();
+    const { green } = await import('./lib/utils/color.ts');
+    return console.log(created ? green(`${path} written`) : `${path} already exists!`);
   } else if (cmd === 'init') {
-    return await (await import('./lib/commands/init.ts')).run();
+    const { written, skipped } = await (await import('./lib/commands/init.ts')).run();
+    // The scaffolding commands report what they did and let this decide how to say it — the same
+    // split as everywhere else, so `Qunitx.init()` returns the facts instead of printing them.
+    skipped.forEach((file) => console.log(`${file} already exists`));
+    return written.forEach((file) => console.log(`${file} written`));
   } else if (cmd === 'daemon') {
     const Daemon = await import('./lib/commands/daemon/index.ts');
     process.exit(await Daemon.run());

--- a/cli.ts
+++ b/cli.ts
@@ -119,18 +119,27 @@ const EXIT_CODE_SIGTERM = 128 + 15;
   // the banner — is wired up here, because `lib/` has no business owning any of the three.
   if (config.watch) {
     const session = await watch(config);
-    const [KeyboardEvents, { blue }] = await Promise.all([
+    const [KeyboardEvents, { blue }, { closeWithGrace }] = await Promise.all([
       import('./lib/setup/keyboard-events.ts'),
       import('./lib/utils/color.ts'),
+      import('./lib/utils/close-with-grace.ts'),
     ]);
     KeyboardEvents.setup(session.config, session.connections);
-    // Close the HTTP server explicitly on SIGTERM so the port is reclaimed by application code
-    // rather than as a side effect of OS process cleanup — on macOS, waitpid() can return a few
-    // ms before the socket is reclaimed, which makes the port look busy to whatever starts next.
-    // On Windows child.kill('SIGTERM') calls TerminateProcess() so this never runs, and
-    // TerminateProcess is synchronous, so the race doesn't exist there either.
+    // Close the HTTP SERVER on SIGTERM — and only the server. The point is that the port is
+    // reclaimed by application code rather than as a side effect of OS process cleanup: on macOS,
+    // waitpid() can return a few ms before the socket is reclaimed, which makes the port look busy
+    // to whatever starts next. On Windows child.kill('SIGTERM') calls TerminateProcess(), so this
+    // never runs and the race does not exist there either.
+    //
+    // NOT `session.close()`, which also tears down the browser: Playwright's `browser.close()`
+    // deadlocks on WebKit often enough that the teardown outlived the 5s SIGTERM + 2s SIGKILL
+    // budget a supervising process allows, and the child had to be killed instead of exiting.
+    // Nothing needs closing here anyway — the process is about to exit, and the prelaunch exit
+    // hook SIGKILLs Chrome's whole process group on the way out.
     process.once('SIGTERM', () => {
-      void session.close().finally(() => process.exit(EXIT_CODE_SIGTERM));
+      void closeWithGrace([session.connections.server.close()]).finally(() =>
+        process.exit(EXIT_CODE_SIGTERM),
+      );
     });
     console.log('#', blue(`Watching files... You can browse the tests on ${session.url} ...`));
     return console.log(

--- a/deno.json
+++ b/deno.json
@@ -6,15 +6,21 @@
     "@std/fmt/colors": "jsr:@std/fmt@^1/colors"
   },
   "tasks": {
-    "bench": "deno bench --allow-all benches/esbuild.bench.ts benches/server.bench.ts benches/tap.bench.ts benches/e2e.bench.ts",
-    "bench:check": "deno run --allow-all scripts/check-benchmarks.ts --files benches/esbuild.bench.ts benches/server.bench.ts benches/tap.bench.ts benches/e2e.bench.ts benches/daemon.bench.ts",
-    "bench:update": "deno run --allow-all scripts/check-benchmarks.ts --save --files benches/esbuild.bench.ts benches/server.bench.ts benches/tap.bench.ts benches/e2e.bench.ts benches/daemon.bench.ts",
+    "bench": "deno bench --allow-all benches/esbuild.bench.ts benches/server.bench.ts benches/tap.bench.ts benches/e2e.bench.ts benches/api.bench.ts",
+    "bench:check": "deno run --allow-all scripts/check-benchmarks.ts --files benches/esbuild.bench.ts benches/server.bench.ts benches/tap.bench.ts benches/e2e.bench.ts benches/api.bench.ts benches/daemon.bench.ts",
+    "bench:update": "deno run --allow-all scripts/check-benchmarks.ts --save --files benches/esbuild.bench.ts benches/server.bench.ts benches/tap.bench.ts benches/e2e.bench.ts benches/api.bench.ts benches/daemon.bench.ts",
     "build:binary": "deno compile --allow-all --no-check --include templates --include lib --include package.json --output dist/qunitx cli.ts"
   },
   "lint": {
-    "exclude": ["test/fixtures/"],
+    "exclude": [
+      "test/fixtures/"
+    ],
     "rules": {
-      "exclude": ["no-process-global", "no-node-globals", "no-window"]
+      "exclude": [
+        "no-process-global",
+        "no-node-globals",
+        "no-window"
+      ]
     }
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -4,6 +4,7 @@
     "jsr:@std/fmt@*": "1.0.9",
     "jsr:@std/fmt@1": "1.0.9",
     "npm:@types/ws@*": "8.18.1",
+    "npm:@types/ws@8": "8.18.1",
     "npm:esbuild@*": "0.28.1",
     "npm:esbuild@~0.28.1": "0.28.1",
     "npm:js-yaml@^5.2.1": "5.2.1",

--- a/examples/js-api-quality-gate.ts
+++ b/examples/js-api-quality-gate.ts
@@ -1,0 +1,97 @@
+// A runnable end-to-end example of the qunitx JS API: a quality gate that runs the suite,
+// enforces a coverage floor, writes a JUnit report, and explains itself — the kind of script a
+// CI job or an agent reaches for when it needs the *results*, not a terminal transcript.
+//
+// It runs the REAL lib/api/ against this repository's own fixtures, so what you read here is
+// what the API actually does against a live browser.
+//
+// run:   node examples/js-api-quality-gate.ts
+//        node examples/js-api-quality-gate.ts --verbose   (also stream the CLI's spec output)
+// check: deno check examples/js-api-quality-gate.ts
+//
+// What it demonstrates, in the order the code does it:
+//   1. `search()`  — what would run, without running it (no browser, milliseconds)
+//   2. `run()`     — the suite, silent, with coverage and a JUnit document
+//   3. `Failure`   — a run that could not happen, told apart from a run that failed
+//   4. reporters   — a reporter of your own, alongside a built-in one
+import process from 'node:process';
+import { Failure, run, search, type Reporter, type RunResult } from '../lib/api/index.ts';
+
+// This repo's own fixtures, so the example is runnable from a fresh clone with no setup.
+const TARGET = 'test/fixtures/coverage/calculator-test.ts';
+const COVERAGE_FLOOR = 50;
+const verbose = process.argv.includes('--verbose');
+
+// A reporter is any object with the handlers it cares about. This one tracks the slowest test,
+// which is the sort of thing no built-in format will ever report for you.
+const slowest: { name: string; ms: number } = { name: '(none)', ms: -1 };
+const slowestReporter: Reporter = {
+  onTestEnd(_config, details) {
+    if (details.runtime <= slowest.ms) return;
+    slowest.name = details.fullName.join(' > ');
+    slowest.ms = details.runtime;
+  },
+};
+
+console.log('1. What would run?\n');
+const preview = await search({ inputs: [TARGET] });
+for (const test of preview.matches) {
+  console.log(`   ${test.fullName}  ${test.file.split('/').pop()}#${test.line}`);
+}
+console.log(`\n   ${preview.matches.length} of ${preview.total} tests, no browser involved.\n`);
+
+console.log('2. Running them.\n');
+const result = await run({
+  inputs: [TARGET],
+  output: 'tmp/js-api-example',
+  coverage: true,
+  junit: 'tmp/js-api-example/junit.xml',
+  // Omit `reporter` entirely and nothing is printed at all; `--verbose` opts into the CLI's
+  // spec output alongside the custom reporter, which runs either way.
+  reporter: verbose ? ['spec', slowestReporter] : slowestReporter,
+});
+
+report(result);
+
+console.log('\n3. A run that cannot happen is not the same as a run that failed.\n');
+// `.result()` settles to the bare `RunResult | RunFailure` union instead of throwing, so this
+// branches rather than catching. `await run(…)` would throw the same failure.
+const rejected = await run({ inputs: [TARGET], browser: 'netscape' as 'chromium' }).result();
+if (Failure.is(rejected)) {
+  // `format` already leads with the code, so printing `rejected.code` too would double it.
+  console.log(`   ${Failure.format(rejected)}`);
+} else {
+  console.log('   unexpectedly ran');
+}
+
+const floorMet = (result.coverage?.percent ?? 0) >= COVERAGE_FLOOR;
+console.log(
+  `\nGate: ${result.ok && floorMet ? 'PASS' : 'FAIL'} ` +
+    `(tests ${result.ok ? 'green' : 'red'}, coverage floor ${COVERAGE_FLOOR}% ${floorMet ? 'met' : 'missed'})`,
+);
+process.exitCode = result.ok && floorMet ? 0 : 1;
+
+/** Prints the parts of a {@link RunResult} a gate actually reads. */
+function report(outcome: RunResult): void {
+  const { counts, coverage } = outcome;
+  console.log(
+    `   ${counts.passed}/${counts.total} passed in ${outcome.durationMs}ms` +
+      `${counts.skipped ? `, ${counts.skipped} skipped` : ''}`,
+  );
+  for (const failure of outcome.failures) {
+    const assertion = failure.assertions.find((one) => !one.passed);
+    console.log(`   ✖ ${failure.fullName}${assertion?.message ? ` — ${assertion.message}` : ''}`);
+  }
+  if (coverage) {
+    console.log(`   coverage ${coverage.percent}% (${coverage.files.length} files)`);
+  }
+  console.log(`   slowest: ${slowest.name} (${slowest.ms}ms)`);
+  console.log(
+    `   junit: ${outcome.junitXml ? `${outcome.junitXml.length} bytes` : 'not requested'}`,
+  );
+  // Every `# …` line the CLI would have printed, available as data instead. Printed first-line
+  // only here because one of them is the whole coverage table, which was rendered above already.
+  for (const notice of outcome.notices) {
+    console.log(`   note[${notice.level}]: ${notice.message.split('\n')[0]}`);
+  }
+}

--- a/jsr/deno.json
+++ b/jsr/deno.json
@@ -1,16 +1,27 @@
 {
   "name": "@izelnakri/qunitx-cli",
   "version": "0.33.0",
-  "description": "Bootstrap that fetches and caches the matching qunitx-cli prebuilt binary, then spawns it.",
+  "description": "qunitx-cli: the JS API under ./api, plus a bootstrap that fetches and caches the matching prebuilt binary for the CLI.",
   "license": "MIT",
+  "nodeModulesDir": "auto",
+  "imports": {
+    "esbuild": "npm:esbuild@^0.28.1",
+    "ws": "npm:ws@^8.21.0",
+    "@types/ws": "npm:@types/ws@^8",
+    "playwright-core": "npm:playwright-core@1.61.1"
+  },
   "exports": {
-    ".": "./cli.ts"
+    ".": "./cli.ts",
+    "./api": "./lib/api/index.ts"
   },
   "publish": {
     "include": [
       "cli.ts",
       "deno.json",
-      "README.md"
+      "README.md",
+      "lib",
+      "templates",
+      "package.json"
     ]
   }
 }

--- a/lib/api/daemon.ts
+++ b/lib/api/daemon.ts
@@ -128,7 +128,11 @@ export function status(): Task<DaemonStatus, never> {
  */
 export function run(options: DaemonRunOptions = {}): Task<RunResult, Client.RunViaFailure> {
   return Task(async () => {
-    await Daemon.ensureRunning();
+    // The boolean matters: `ensureRunning` returns false when the spawn never became reachable
+    // within its budget. Proceeding anyway meant dialling a socket that certainly is not there
+    // and reporting `DaemonUnreachable` a connect-timeout later — the same failure, minutes
+    // after it was already known.
+    if (!(await Daemon.ensureRunning())) throw Client.DaemonUnreachable();
     const sink = options.stdout
       ? streamOutput(options.stdout, options.stderr ?? options.stdout)
       : undefined;

--- a/lib/api/daemon.ts
+++ b/lib/api/daemon.ts
@@ -1,0 +1,138 @@
+import * as Client from '../commands/daemon/client.ts';
+import * as Daemon from '../commands/daemon/index.ts';
+import * as Paths from '../commands/daemon/paths.ts';
+import { Task } from '../task/index.ts';
+import { streamOutput } from '../reporters/output.ts';
+import type { DaemonRunOptions } from './options.ts';
+import type { RunResult } from './result.ts';
+
+export type { DaemonRunOptions } from './options.ts';
+
+/**
+ * A live daemon, as reported by {@link status}.
+ *
+ * ```ts
+ * const daemon: DaemonStatus = {
+ *   running: true, pid: 4242, cwd: '/proj',
+ *   nodeVersion: 'v24.14.0', startedAt: 1_760_000_000_000, socketPath: '/tmp/qunitx-…sock',
+ * };
+ * daemon.running; // true — the other fields are absent when it is false
+ * ```
+ */
+export type DaemonStatus =
+  | { running: false }
+  | {
+      /** A daemon answered the probe. */
+      running: true;
+      /** Its process id. */
+      pid: number;
+      /** The project directory it serves. Only runs from this directory may use it. */
+      cwd: string;
+      /** The Node version it is running; a client on a different one is refused. */
+      nodeVersion: string;
+      /** Epoch ms when it began listening. */
+      startedAt: number;
+      /** The Unix socket (or Windows named pipe) it listens on. */
+      socketPath: string;
+    };
+
+/**
+ * Ensures a daemon is running for this project, spawning one if there isn't.
+ *
+ * The daemon holds a browser and a warm esbuild context between runs, which is worth roughly
+ * 800 ms per run — so it pays for itself the second time a long-lived process runs the suite.
+ *
+ * Idempotent: with one already up, this is a liveness probe and nothing is spawned.
+ *
+ * ```ts
+ * import { start } from './daemon.ts';
+ *
+ * // Defined, not invoked: may spawn a real background process.
+ * async function warmUp() {
+ *   return await start(); // true once a daemon is reachable
+ * }
+ * ```
+ */
+export function start(): Task<boolean, never> {
+  return Task(() => Daemon.ensureRunning());
+}
+
+/**
+ * Stops this project's daemon. Resolves `true` if one was running, `false` if there was nothing
+ * to stop — either way, no daemon is running afterwards.
+ *
+ * ```ts
+ * import { stop } from './daemon.ts';
+ *
+ * // Defined, not invoked: shuts down a real background process.
+ * async function coolDown() {
+ *   return await stop(); // false when none was running
+ * }
+ * ```
+ */
+export function stop(): Task<boolean, never> {
+  return Task(() => Client.shutdown());
+}
+
+/**
+ * Probes this project's daemon. An actual round-trip over the socket, not a look at the sentinel
+ * file, so a crashed daemon that left its files behind reports `{ running: false }`.
+ *
+ * ```ts
+ * import { status } from './daemon.ts';
+ *
+ * // Defined, not invoked: opens a real socket connection.
+ * async function uptimeMinutes() {
+ *   const daemon = await status();
+ *   return daemon.running ? Math.round((Date.now() - daemon.startedAt) / 60_000) : null;
+ * }
+ * ```
+ */
+export function status(): Task<DaemonStatus, never> {
+  return Task(async () => {
+    const pong = await Client.ping();
+    if (pong?.type !== 'pong') return { running: false as const };
+
+    return {
+      running: true as const,
+      pid: pong.pid,
+      cwd: pong.cwd,
+      nodeVersion: pong.nodeVersion,
+      startedAt: pong.startedAt,
+      socketPath: Paths.socket(pong.cwd),
+    };
+  });
+}
+
+/**
+ * Runs the suite inside this project's daemon and resolves with the same {@link RunResult} a
+ * local run would produce — reusing the daemon's browser and warm bundle instead of paying for
+ * a fresh one.
+ *
+ * Spawns the daemon if one isn't running, so a first call is not measurably faster than
+ * {@link run}; every call after it is.
+ *
+ * {@link DaemonRunOptions} is narrower than the local `RunOptions` by exactly what cannot cross
+ * a process boundary: plugin objects, reporter instances and callbacks. `stdout`/`stderr` still
+ * work — the daemon's text is streamed back and written there.
+ *
+ * ```ts
+ * import { run as runViaDaemon } from './daemon.ts';
+ *
+ * // Defined, not invoked: dispatches a real run to the daemon.
+ * async function fastCheck() {
+ *   const result = await runViaDaemon({ inputs: ['test/'] });
+ *   return result.ok;
+ * }
+ * ```
+ */
+export function run(options: DaemonRunOptions = {}): Task<RunResult, Client.RunViaFailure> {
+  return Task(async () => {
+    await Daemon.ensureRunning();
+    const sink = options.stdout
+      ? streamOutput(options.stdout, options.stderr ?? options.stdout)
+      : undefined;
+
+    return await Client.runOptionsVia(options, sink);
+  });
+}

--- a/lib/api/events.ts
+++ b/lib/api/events.ts
@@ -1,0 +1,202 @@
+import { toTestResult, type RunResult, type TestResult } from './result.ts';
+import type {
+  BrowserLog,
+  Notice,
+  Reporter,
+  RunStartInfo,
+  TestDetails,
+} from '../reporters/types.ts';
+import type { Config } from '../types.ts';
+
+/**
+ * One thing that happened during a run, as it happened.
+ *
+ * The fine-grained view of what {@link RunResult} summarizes. A caller that only wants the answer
+ * awaits the result; a caller drawing a progress bar reads these. Discriminated on `kind` so a
+ * `switch` is exhaustive and adding a variant is a compile error at every consumer rather than a
+ * silently-ignored event.
+ *
+ * The last event of every run is `runEnd`, and it carries the complete result — so a consumer
+ * reading only this feed never needs a second channel to learn how the run came out.
+ *
+ * ```ts
+ * // Defined, not invoked: real events arrive from a session.
+ * function label(event: RunEvent) {
+ *   return event.kind === 'test' ? event.test.fullName : event.kind;
+ * }
+ * ```
+ */
+export type RunEvent =
+  | ({ kind: 'runStart' } & RunStartInfo)
+  | { kind: 'test'; test: TestResult }
+  | { kind: 'notice'; notice: Notice }
+  | { kind: 'browserLog'; log: BrowserLog }
+  | { kind: 'runEnd'; result: RunResult };
+
+/**
+ * How many events a feed buffers for a consumer that has stopped reading.
+ *
+ * Generous enough that no real suite reaches it: tests and notices are bounded by the suite, and
+ * the only unbounded channel is page output — the same flood `MAX_BROWSER_LOGS` exists for.
+ *
+ * ```ts
+ * MAX_BUFFERED_EVENTS; // 10000
+ * ```
+ */
+export const MAX_BUFFERED_EVENTS = 10_000;
+
+/**
+ * A one-consumer async queue: the producer pushes whenever it likes, the consumer iterates.
+ *
+ * The shape every push-source in this API needs, because the producer is a browser and cannot be
+ * slowed down. Backpressure is therefore not on offer: the choice is buffer or drop, and this
+ * buffers up to {@link MAX_BUFFERED_EVENTS} before dropping the oldest — the same trade, for the
+ * same reason, as the page-log cap on a result. Both sessions keep the buffer near zero in
+ * practice by not starting the run until someone is actually consuming.
+ *
+ * One consumer. Two concurrent `for await` loops would each take half the events rather than both
+ * seeing all of them; fan out inside the single loop instead.
+ *
+ * ```ts
+ * const channel = new Channel<number>();
+ * channel.push(1);
+ * channel.close();
+ * channel.buffered; // 1 — waiting for whoever iterates
+ * ```
+ */
+export class Channel<T> implements AsyncIterable<T> {
+  /** How many pushes were dropped to stay under the cap. `0` in every ordinary run. */
+  dropped = 0;
+  #queued: T[] = [];
+  #waiting: ((result: IteratorResult<T>) => void) | null = null;
+  #closed = false;
+
+  /**
+   * How many values are buffered for a consumer that has not asked for them yet.
+   *
+   * ```ts
+   * const channel = new Channel<number>();
+   * channel.push(1);
+   * channel.buffered; // 1
+   * ```
+   */
+  get buffered(): number {
+    return this.#queued.length;
+  }
+
+  /**
+   * Whether {@link close} has been called.
+   *
+   * ```ts
+   * const channel = new Channel<number>();
+   * channel.closed; // false — still accepting pushes
+   * ```
+   */
+  get closed(): boolean {
+    return this.#closed;
+  }
+
+  /**
+   * Hands a value to whoever is iterating, or buffers it until someone is. Silently ignored once
+   * closed — a late event from a run being torn down is not worth a throw at the producer, which
+   * is a browser callback with nowhere to report it.
+   *
+   * ```ts
+   * const channel = new Channel<string>();
+   * channel.push('a');
+   * channel.buffered; // 1
+   * ```
+   */
+  push(value: T): void {
+    if (this.#closed) return;
+    if (this.#waiting) {
+      const resolve = this.#waiting;
+      this.#waiting = null;
+
+      return resolve({ done: false, value });
+    }
+
+    this.#queued.push(value);
+    // Oldest first, matching the page-log cap: under a flood the newest entries are the ones
+    // adjacent to whatever went wrong, and they are what a consumer catching up wants to see.
+    if (this.#queued.length > MAX_BUFFERED_EVENTS) {
+      this.#queued.shift();
+      this.dropped++;
+    }
+  }
+
+  /**
+   * Ends the iteration once the buffer drains. Idempotent.
+   *
+   * ```ts
+   * const channel = new Channel<string>();
+   * channel.close();
+   * channel.closed; // true
+   * ```
+   */
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    // Wake a consumer parked on a value that is never going to arrive.
+    this.#waiting?.({ done: true, value: undefined });
+    this.#waiting = null;
+  }
+
+  /**
+   * ```ts
+   * // Defined, not invoked: iterating a live channel waits for its producer.
+   * async function drain(channel: Channel<number>) {
+   *   const seen: number[] = [];
+   *   for await (const value of channel) seen.push(value);
+   *   return seen;
+   * }
+   * ```
+   */
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: (): Promise<IteratorResult<T>> => {
+        // Buffer first, even when closed: values that arrived before the close are still values,
+        // and dropping them would make closing racy from the consumer's side.
+        if (this.#queued.length > 0) {
+          return Promise.resolve({ done: false, value: this.#queued.shift() as T });
+        } else if (this.#closed) {
+          return Promise.resolve({ done: true, value: undefined });
+        }
+
+        return new Promise((resolve) => (this.#waiting = resolve));
+      },
+      return: (): Promise<IteratorResult<T>> => {
+        this.close();
+
+        return Promise.resolve({ done: true, value: undefined });
+      },
+    };
+  }
+}
+
+/**
+ * A reporter that turns the run into {@link RunEvent}s on `channel`.
+ *
+ * The reporter contract is already the live feed — this only reshapes its five callbacks into one
+ * ordered stream. `runEnd` is not emitted here: only the session knows how to assemble the result
+ * that event carries, and it pushes that itself once the collector has been read.
+ *
+ * ```ts
+ * import type { Config } from '../types.ts';
+ *
+ * const channel = new Channel<RunEvent>();
+ * const reporter = eventReporter(channel);
+ * reporter.onNotice?.({} as Config, { level: 'info', message: 'scoped to 2 files' });
+ * channel.buffered; // 1
+ * ```
+ */
+export function eventReporter(channel: Channel<RunEvent>): Reporter {
+  return {
+    onRunStart: (_config: Config, info: RunStartInfo) =>
+      channel.push({ kind: 'runStart', ...info }),
+    onTestEnd: (_config: Config, details: TestDetails) =>
+      channel.push({ kind: 'test', test: toTestResult(details) }),
+    onNotice: (_config: Config, notice: Notice) => channel.push({ kind: 'notice', notice }),
+    onBrowserLog: (_config: Config, log: BrowserLog) => channel.push({ kind: 'browserLog', log }),
+  };
+}

--- a/lib/api/failure.ts
+++ b/lib/api/failure.ts
@@ -1,0 +1,41 @@
+import { is, format, hasCode, type Any } from '../result/failure.ts';
+
+/**
+ * A declared failure: something the runner decided it could not do, carrying a `code` you can
+ * branch on and a `message` you can show.
+ *
+ * ```ts
+ * // Defined, not invoked: real failures come back from `run(...).result()`.
+ * function codeOf(failure: AnyFailure) {
+ *   return failure.code; // 'InvalidOption' | 'ProjectRootNotFound' | …
+ * }
+ * ```
+ */
+export type AnyFailure = Any;
+
+/**
+ * The failure taxonomy, as the JS API's public surface.
+ *
+ * Deliberately a hand-written subset rather than the whole internal module re-exported: these
+ * three are what a consumer needs to handle a failure, and freezing only them keeps the rest —
+ * `define`, the tracing hooks, the ignore channel — free to change without breaking anyone.
+ *
+ * ```ts
+ * import { Failure } from './failure.ts';
+ *
+ * Failure.is(new Error('plain')); // false — only declared failures answer to this
+ * ```
+ */
+export const Failure: {
+  /**
+   * Narrows an unknown value to a declared failure. The guard to reach for after `.result()`.
+   */
+  is: (value: unknown) => value is AnyFailure;
+  /** Renders a failure as the one-line message the CLI would print. */
+  format: (error: unknown, options?: { stacks?: boolean }) => string;
+  /** Narrows to a specific set of codes, for handling some failures and rethrowing the rest. */
+  hasCode: <const Codes extends readonly string[]>(
+    value: unknown,
+    ...codes: Codes
+  ) => value is AnyFailure & { code: Codes[number] };
+} = { is, format, hasCode };

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -1,0 +1,83 @@
+/**
+ * The qunitx JS API: run your QUnit tests in a real browser from Node.js or Deno, and get the
+ * results back as a value.
+ *
+ * ```ts
+ * import { run } from './run.ts';
+ *
+ * // Defined, not invoked: launches a browser and runs the project's tests.
+ * async function check() {
+ *   const result = await run('test/');
+ *   return result.ok ? 0 : result.failures.length;
+ * }
+ * ```
+ *
+ * Four things worth knowing before reading further:
+ *
+ * - **Nothing is printed unless you ask.** No `reporter`, no output — the returned
+ *   {@link RunResult} is the whole answer. `reporter: 'tap'` gets the CLI's text as well.
+ * - **Failing tests are not an error.** `run()` resolves with `ok: false`; it rejects only when
+ *   the run could not happen at all (a bad option, an unreadable input, no `package.json`).
+ * - **Everything is lazy.** These return a {@link Task} — a Promise superset — so nothing starts
+ *   until you await it, and `.result()` hands back a `Result` union instead of throwing.
+ * - **It is the same engine as the CLI.** `run(options)` and `qunitx <flags>` assemble the same
+ *   config and take the same code path; there is no second implementation to drift.
+ */
+
+export { run, type RunFailure } from './run.ts';
+export { watch, type WatchSession } from './watch.ts';
+export { search, type SearchMatch, type SearchResult } from './search.ts';
+export { init, generate, type InitOptions, type GenerateOptions } from './scaffold.ts';
+export * as daemon from './daemon.ts';
+
+export type { RunOptions, ReporterOption, WritableLike } from './options.ts';
+export type {
+  RunResult,
+  RunCounts,
+  TestResult,
+  CoverageSummary,
+  FileCoverageSummary,
+} from './result.ts';
+
+/**
+ * The reporter contract and its payloads. Implement {@link Reporter} to observe a run as it
+ * happens; pass the instance as `reporter`.
+ */
+export type {
+  Reporter,
+  ReporterName,
+  Notice,
+  BrowserLog,
+  TestAssertion,
+  TestDetails,
+  RunStartInfo,
+  RunEndInfo,
+} from '../reporters/types.ts';
+export { REPORTERS } from '../reporters/types.ts';
+
+/**
+ * Where reporters write. `processOutput` is the CLI's, `silentOutput` discards, and
+ * `streamOutput` adapts anything with a `write(string)`.
+ */
+export { type Output, processOutput, silentOutput, streamOutput } from '../reporters/output.ts';
+
+/**
+ * The error-handling primitives these functions are built on.
+ *
+ * `Task<T, E>` is what every entry point returns: a lazy, retryable Promise superset whose
+ * declared failures are `Failure` rejections. `Failure` is the taxonomy — `Failure.is(x)`
+ * discriminates one, `Failure.format(x)` renders it. `Result<T, E>` is the bare `T | E` union
+ * `task.result()` settles to, for callers who would rather branch than catch.
+ *
+ * ```ts
+ * import { run } from './run.ts';
+ * import { Failure } from '../task/index.ts';
+ *
+ * // Defined, not invoked: launches a browser.
+ * async function branchOnFailure() {
+ *   const outcome = await run().result();
+ *   return Failure.is(outcome) ? Failure.format(outcome) : outcome.counts;
+ * }
+ * ```
+ */
+export { Task, Failure, type Result } from '../task/index.ts';

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -43,6 +43,7 @@ export { init, generate, type InitOptions, type GenerateOptions } from './scaffo
  * ```
  */
 export * as daemon from './daemon.ts';
+export type { DaemonRunOptions, DaemonStatus } from './daemon.ts';
 
 export type { RunOptions, ReporterOption, WritableLike } from './options.ts';
 export type {

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -25,6 +25,7 @@
  */
 
 export { run, type RunFailure } from './run.ts';
+export { runSession, type RunSession } from './session.ts';
 export { watch, type WatchSession } from './watch.ts';
 export { search, type SearchMatch, type SearchResult } from './search.ts';
 export { init, generate, type InitOptions, type GenerateOptions } from './scaffold.ts';
@@ -50,9 +51,18 @@ export type {
   RunResult,
   RunCounts,
   TestResult,
+  ResolvedRun,
   CoverageSummary,
   FileCoverageSummary,
 } from './result.ts';
+
+/**
+ * The live view of a run: what a session yields, in the order it happened.
+ *
+ * The fine-grained counterpart to {@link RunResult} — the same run, as it happens rather than once
+ * it is over. Both sessions produce the same events, so a progress display works against either.
+ */
+export type { RunEvent } from './events.ts';
 
 /**
  * The reporter contract and its payloads. Implement {@link Reporter} to observe a run as it

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -28,6 +28,20 @@ export { run, type RunFailure } from './run.ts';
 export { watch, type WatchSession } from './watch.ts';
 export { search, type SearchMatch, type SearchResult } from './search.ts';
 export { init, generate, type InitOptions, type GenerateOptions } from './scaffold.ts';
+/**
+ * Daemon control: `start`, `stop`, `status`, and a `run` that reuses the daemon's warm browser
+ * and returns the same {@link RunResult} a local run does.
+ *
+ * ```ts
+ * import * as daemon from './daemon.ts';
+ *
+ * // Defined, not invoked: spawns and talks to a real background process.
+ * async function warmRun() {
+ *   await daemon.start();
+ *   return await daemon.run({ inputs: ['test/'] });
+ * }
+ * ```
+ */
 export * as daemon from './daemon.ts';
 
 export type { RunOptions, ReporterOption, WritableLike } from './options.ts';
@@ -71,7 +85,7 @@ export { type Output, processOutput, silentOutput, streamOutput } from '../repor
  *
  * ```ts
  * import { run } from './run.ts';
- * import { Failure } from '../task/index.ts';
+ * import { Failure } from './failure.ts';
  *
  * // Defined, not invoked: launches a browser.
  * async function branchOnFailure() {
@@ -80,4 +94,6 @@ export { type Output, processOutput, silentOutput, streamOutput } from '../repor
  * }
  * ```
  */
-export { Task, Failure, type Result } from '../task/index.ts';
+export { Task, type Result } from '../task/index.ts';
+
+export { Failure, type AnyFailure } from './failure.ts';

--- a/lib/api/options.ts
+++ b/lib/api/options.ts
@@ -5,6 +5,8 @@ import { SpecReporter } from '../reporters/spec.ts';
 import { TAPReporter } from '../reporters/tap.ts';
 import { processOutput, silentOutput, streamOutput, type Output } from '../reporters/output.ts';
 import { Collector, toTestResult } from './result.ts';
+import { REPORTERS } from '../reporters/types.ts';
+import { Failure } from '../task/index.ts';
 import type { BrowserLog, Notice, Reporter, ReporterName } from '../reporters/types.ts';
 import type { TestResult } from './result.ts';
 import type { ConfigOptions } from '../setup/config.ts';
@@ -129,6 +131,91 @@ export interface ResolvedReporting {
   output: Output;
   /** The collector the result is built from. */
   collector: Collector;
+}
+
+/**
+ * An option was given a value the runner will not accept.
+ *
+ * The API's equivalent of `InvalidFlag`, and it exists for the same reason: the values that come
+ * from outside — an enum spelled wrong, a port out of range — must be rejected where they are
+ * named, not several layers down as an unexplained browser-launch failure.
+ *
+ * ```ts
+ * const failure = InvalidOption({ option: 'browser', value: 'netscape', expected: 'chromium, firefox, webkit' });
+ * failure.data.option; // 'browser' — typed payload, no message parsing
+ * ```
+ */
+export const InvalidOption = Failure.define(
+  'InvalidOption',
+  (data: { option: string; value: unknown; expected: string }) =>
+    `Invalid \`${data.option}\` value: ${JSON.stringify(data.value) ?? String(data.value)}. Expected ${data.expected}.`,
+);
+
+/** The one failure {@link validate} raises. */
+export type InvalidOptionFailure = Failure.Of<typeof InvalidOption>;
+
+const BROWSERS = ['chromium', 'firefox', 'webkit'];
+const COVERAGE_FORMATS = ['lcov', 'html'];
+
+/**
+ * Rejects options the run cannot honour, before anything is launched.
+ *
+ * Only the closed sets and the bounded numbers are checked here — the same ones `Args.parse`
+ * validates for argv. Everything else is either free-form (a filter, a path) or already a
+ * compile-time error for a TypeScript caller; this is the guard for the ones that are neither,
+ * which is exactly what a JavaScript caller or a generated call can get wrong.
+ *
+ * ```ts
+ * import { validate, InvalidOption } from './options.ts';
+ *
+ * try {
+ *   validate({ browser: 'netscape' as 'chromium' });
+ * } catch (error) {
+ *   InvalidOption.is(error); // true
+ * }
+ * ```
+ */
+export function validate(options: RunOptions): void {
+  if (options.browser !== undefined && !BROWSERS.includes(options.browser)) {
+    throw InvalidOption({
+      option: 'browser',
+      value: options.browser,
+      expected: `one of ${BROWSERS.join(', ')}`,
+    });
+  }
+  for (const entry of Array.isArray(options.reporter) ? options.reporter : [options.reporter]) {
+    if (typeof entry === 'string' && !(REPORTERS as readonly string[]).includes(entry)) {
+      throw InvalidOption({
+        option: 'reporter',
+        value: entry,
+        expected: `one of ${REPORTERS.join(', ')}, a Reporter object, or false`,
+      });
+    }
+  }
+  const formats = typeof options.coverage === 'object' ? (options.coverage.formats ?? []) : [];
+  for (const format of formats) {
+    if (!COVERAGE_FORMATS.includes(format)) {
+      throw InvalidOption({
+        option: 'coverage.formats',
+        value: format,
+        expected: `one of ${COVERAGE_FORMATS.join(', ')}`,
+      });
+    }
+  }
+  if (options.port !== undefined && !isPort(options.port)) {
+    throw InvalidOption({ option: 'port', value: options.port, expected: 'an integer 0-65535' });
+  }
+  if (options.timeout !== undefined && !(Number.isFinite(options.timeout) && options.timeout > 0)) {
+    throw InvalidOption({
+      option: 'timeout',
+      value: options.timeout,
+      expected: 'a positive number of milliseconds',
+    });
+  }
+}
+
+function isPort(value: number): boolean {
+  return Number.isInteger(value) && value >= 0 && value <= 65535;
 }
 
 /**

--- a/lib/api/options.ts
+++ b/lib/api/options.ts
@@ -94,6 +94,17 @@ export interface RunOptions {
   debug?: boolean;
   /** Open the output in a browser: `true` for the default, a string to name a binary. */
   open?: boolean | string;
+  /**
+   * Cancels the run when it fires.
+   *
+   * Cancellation here means "stop and answer", not "throw": the browser drops the rest of its
+   * queue and the run resolves with whatever it had, marked `aborted: true`. The tests that did
+   * finish are still on the result, which is the point — a cancelled run that discarded its own
+   * findings would be no more useful than one that never started.
+   *
+   * An already-aborted signal short-circuits: no browser is launched at all.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -114,7 +125,7 @@ export interface RunOptions {
  */
 export interface DaemonRunOptions extends Omit<
   RunOptions,
-  'reporter' | 'plugins' | 'onTest' | 'onNotice' | 'onBrowserLog' | 'open'
+  'reporter' | 'plugins' | 'onTest' | 'onNotice' | 'onBrowserLog' | 'open' | 'signal'
 > {
   /** A built-in reporter's name, several of them, or `false`. Instances cannot cross a socket. */
   reporter?: ReporterName | ReadonlyArray<ReporterName> | false;

--- a/lib/api/options.ts
+++ b/lib/api/options.ts
@@ -330,20 +330,23 @@ function instantiate(entry: ReporterName | Reporter): Reporter {
 }
 
 /**
- * Silence unless something is going to be printed. A reporter with nowhere to write would be a
- * confusing no-op, and a `stdout` with no reporter would still carry the `#` diagnostics — which
- * is a legitimate thing to want, so both independently opt in.
+ * Silence unless something is going to be printed.
+ *
+ * A *named* reporter is a request for the CLI's text, so it defaults to the process streams. A
+ * reporter **object** is not: it is a request to observe the run programmatically, and turning on
+ * the host's stdout because someone passed a collector would break the silent-by-default promise
+ * in the exact case they were being careful. Naming `stdout`/`stderr` opts in either way — and
+ * does so even with no reporter at all, which is how you get just the `#` diagnostics.
  */
 function resolveOutput(options: RunOptions): Output {
   if (options.stdout) {
     return streamOutput(options.stdout, options.stderr ?? options.stdout);
   } else if (options.stderr) {
     return streamOutput(process.stdout, options.stderr);
-  } else if (options.reporter) {
-    return processOutput;
   }
+  const requested = Array.isArray(options.reporter) ? options.reporter : [options.reporter];
 
-  return silentOutput;
+  return requested.some((entry) => typeof entry === 'string') ? processOutput : silentOutput;
 }
 
 /** Wraps the three convenience callbacks into one reporter, or nothing when none were given. */

--- a/lib/api/options.ts
+++ b/lib/api/options.ts
@@ -1,0 +1,272 @@
+import { DotReporter } from '../reporters/dot.ts';
+import { GithubReporter } from '../reporters/github.ts';
+import { JUnitReporter } from '../reporters/junit.ts';
+import { SpecReporter } from '../reporters/spec.ts';
+import { TAPReporter } from '../reporters/tap.ts';
+import { processOutput, silentOutput, streamOutput, type Output } from '../reporters/output.ts';
+import { Collector, toTestResult } from './result.ts';
+import type { BrowserLog, Notice, Reporter, ReporterName } from '../reporters/types.ts';
+import type { TestResult } from './result.ts';
+import type { ConfigOptions } from '../setup/config.ts';
+import type { Plugin as EsbuildPlugin } from 'esbuild';
+
+/** `--reporter` by name, a reporter of your own, or `false` for none. */
+export type ReporterOption = ReporterName | Reporter | false;
+
+/** Anything that can take a chunk of text — a `node:fs` write stream, a socket, a fake. */
+export interface WritableLike {
+  /** Called with each chunk. The return value is ignored. */
+  write(text: string): unknown;
+}
+
+/**
+ * Everything a run can be told to do. Every field is optional: `run()` with no arguments runs
+ * the project exactly as a bare `qunitx` would, minus the printing.
+ *
+ * Two things differ from the command line, both because they cannot be typed into a shell:
+ * `plugins` takes live esbuild plugin objects, and `cwd` picks the project.
+ *
+ * ```ts
+ * const options: RunOptions = { inputs: ['test/'], filter: 'Cart', coverage: true };
+ * options.reporter; // undefined — nothing is printed unless you ask for it
+ * ```
+ */
+export interface RunOptions {
+  /**
+   * Files, directories, globs, or `file.ts#34` line targets — the same grammar as the
+   * command line's positional arguments. Defaults to `package.json#qunitx.inputs`.
+   */
+  inputs?: string[];
+  /** Directory the project root and relative inputs resolve against. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /**
+   * Run only tests whose `"Module: test name"` matches. QUnit's own semantics: case-insensitive
+   * substring, `/regex/`, `/regex/i`, or a leading `!` to invert.
+   */
+  filter?: string;
+  /** Browser engine. Defaults to `chromium`, the only one that can collect coverage. */
+  browser?: 'chromium' | 'firefox' | 'webkit';
+  /** Milliseconds a single test may take before the run is declared stalled. Defaults to 20000. */
+  timeout?: number;
+  /** Stop the run at the first failing test. */
+  failFast?: boolean;
+  /** Run only the files that failed last time, from the persistent failure cache. */
+  onlyFailed?: boolean;
+  /** Run only files whose transitive imports changed since this git ref (`'HEAD'` for uncommitted). */
+  changedSince?: string;
+  /** Collect V8 line coverage (chromium only). `formats` additionally writes lcov/html artifacts. */
+  coverage?: boolean | { formats?: Array<'lcov' | 'html'> };
+  /** Write a JUnit XML report. `true` writes `<output>/junit.xml`; a string is a path. */
+  junit?: boolean | string;
+  /**
+   * Print the run. A built-in name (`'tap'`, `'spec'`, `'dot'`, `'github'`), your own
+   * {@link Reporter}, an array of either, or `false`. **Omitted means nothing is printed** —
+   * the result value is the output.
+   */
+  reporter?: ReporterOption | ReadonlyArray<ReporterOption>;
+  /** Where a reporter writes. Defaults to `process.stdout` when a reporter is set. */
+  stdout?: WritableLike;
+  /** Where error-level output goes. Defaults to `stdout` when that is set, else `process.stderr`. */
+  stderr?: WritableLike;
+  /** Called as each test finishes — the streaming half of `result.tests`. */
+  onTest?: (test: TestResult) => void;
+  /** Called for each of qunitx's own diagnostics. */
+  onNotice?: (notice: Notice) => void;
+  /** Called for each `console.*` call and uncaught error from the page. */
+  onBrowserLog?: (log: BrowserLog) => void;
+  /** Directory for the compiled bundle and HTML output. Defaults to `'tmp'`. */
+  output?: string;
+  /** Port for the local test server. Defaults to 1234, incrementing on conflict. */
+  port?: number;
+  /** File extensions treated as test files. Defaults to `['js', 'ts', 'jsx', 'tsx']`. */
+  extensions?: string[];
+  /** HTML fixture files to wrap the bundle in, relative to the project root. */
+  html?: string[];
+  /** Path to a module run before the tests; it receives the resolved config. */
+  before?: string | false;
+  /** Path to a module run after the tests; it receives the run's counters. */
+  after?: string | false;
+  /** esbuild plugins for the test bundle — live objects, not specifiers. */
+  plugins?: EsbuildPlugin[];
+  /** Forward every page console call and print the server URL. */
+  debug?: boolean;
+  /** Open the output in a browser: `true` for the default, a string to name a binary. */
+  open?: boolean | string;
+}
+
+/**
+ * The options a daemon run accepts: everything from {@link RunOptions} that survives a socket.
+ *
+ * A daemon run happens in another process, so a plugin object, a reporter instance, a callback
+ * and a `plugins` array cannot come along — they are functions, and functions do not serialize.
+ * Rather than accepting them and silently dropping them, they are simply not in this type: the
+ * limitation is a compile error at the call site instead of a surprise at run time.
+ *
+ * `reporter` narrows to the built-in names for the same reason. `stdout`/`stderr` stay, because
+ * they are the *client's* sinks for the text the daemon streams back — they never cross.
+ *
+ * ```ts
+ * const options: DaemonRunOptions = { inputs: ['test/'], reporter: 'tap' };
+ * options.reporter; // 'tap' — a name, not an instance
+ * ```
+ */
+export interface DaemonRunOptions extends Omit<
+  RunOptions,
+  'reporter' | 'plugins' | 'onTest' | 'onNotice' | 'onBrowserLog' | 'open'
+> {
+  /** A built-in reporter's name, several of them, or `false`. Instances cannot cross a socket. */
+  reporter?: ReporterName | ReadonlyArray<ReporterName> | false;
+}
+
+/**
+ * The reporters and output a set of options resolves to, plus the collector that will observe
+ * the run either way.
+ */
+export interface ResolvedReporting {
+  /** What to hand `Config.setup` as `reporters`. Always ends with the collector. */
+  reporters: Reporter[];
+  /** Where those reporters write. */
+  output: Output;
+  /** The collector the result is built from. */
+  collector: Collector;
+}
+
+/**
+ * Accepts the shorthands: a single path, a list of paths, or the full options object. So
+ * `run('test/')` and `run({ inputs: ['test/'] })` are the same call.
+ *
+ * ```ts
+ * normalizeOptions('test/cart-test.ts').inputs; // ['test/cart-test.ts']
+ * normalizeOptions(['a.ts', 'b.ts']).inputs; // ['a.ts', 'b.ts']
+ * normalizeOptions({ filter: 'Cart' }).filter; // 'Cart'
+ * ```
+ */
+export function normalizeOptions(options: RunOptions | string | string[] = {}): RunOptions {
+  if (typeof options === 'string') return { inputs: [options] };
+  if (Array.isArray(options)) return { inputs: options };
+
+  return options;
+}
+
+/**
+ * Builds the run's reporter set and output stream.
+ *
+ * The default is silence: with no `reporter`, nothing is printed and the run's diagnostics exist
+ * only as data on the result. Naming one opts back into text, and `stdout` says where it goes.
+ *
+ * ```ts
+ * resolveReporting({}).reporters.length; // 1 — the collector, which prints nothing
+ * resolveReporting({ reporter: 'tap' }).reporters.length; // 2 — the collector, then TAP
+ * ```
+ */
+export function resolveReporting(options: RunOptions): ResolvedReporting {
+  const collector = new Collector();
+  const requested = (Array.isArray(options.reporter) ? options.reporter : [options.reporter])
+    .filter((entry): entry is ReporterName | Reporter => Boolean(entry))
+    .map(instantiate);
+  // The JUnit reporter is additive rather than a choice of format, exactly as `--junit` is.
+  if (options.junit) requested.push(new JUnitReporter());
+  const callbacks = callbackReporter(options);
+  if (callbacks) requested.push(callbacks);
+
+  return {
+    // Collector FIRST: the fan-out in `Reporter.testEnd` is a plain forEach, so a reporter that
+    // throws stops the ones after it. Recording before printing means a broken custom reporter
+    // costs the caller some output, never the result.
+    reporters: [collector, ...requested],
+    output: resolveOutput(options),
+    collector,
+  };
+}
+
+/**
+ * Translates public options into the internal {@link ConfigOptions}. The two are deliberately
+ * separate types: the public one is stable, ergonomic, and free to disagree with the flag names
+ * (`html` rather than `htmlPaths`, `coverage: { formats }` rather than two parallel fields).
+ *
+ * ```ts
+ * const reporting = resolveReporting({});
+ * toConfigOptions({ coverage: { formats: ['lcov'] } }, reporting).coverageFormats; // ['lcov']
+ * toConfigOptions({ html: ['test/index.html'] }, reporting).htmlPaths; // ['test/index.html']
+ * ```
+ */
+export function toConfigOptions(options: RunOptions, reporting: ResolvedReporting): ConfigOptions {
+  const coverage = options.coverage;
+
+  // `withoutUndefined` is load-bearing, not tidiness: `Config.setup` merges these over
+  // `package.json#qunitx` with a spread, and a key present-but-undefined overwrites the
+  // package.json value with nothing. An option the caller did not set must not silently
+  // un-set the project's own configuration.
+  return withoutUndefined({
+    inputs: options.inputs,
+    cwd: options.cwd,
+    filter: options.filter,
+    browser: options.browser,
+    timeout: options.timeout,
+    failFast: options.failFast,
+    onlyFailed: options.onlyFailed,
+    changedSince: options.changedSince,
+    coverage: coverage === undefined ? undefined : Boolean(coverage),
+    coverageFormats: typeof coverage === 'object' ? (coverage.formats ?? []) : undefined,
+    junit: options.junit,
+    output: options.output,
+    port: options.port,
+    // An explicitly requested port must not silently slide to the next free one — the caller
+    // picked it because something else is about to connect there.
+    portExplicit: options.port === undefined ? undefined : true,
+    extensions: options.extensions,
+    htmlPaths: options.html,
+    before: options.before,
+    after: options.after,
+    debug: options.debug,
+    open: options.open,
+    esbuildPlugins: options.plugins,
+    reporters: reporting.reporters,
+    reporterOutput: reporting.output,
+  });
+}
+
+/** Drops keys whose value is `undefined`, so a spread over defaults leaves them alone. */
+function withoutUndefined<T extends object>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as T;
+}
+
+const BUILT_IN: Record<ReporterName, new () => Reporter> = {
+  tap: TAPReporter,
+  spec: SpecReporter,
+  dot: DotReporter,
+  github: GithubReporter,
+};
+
+function instantiate(entry: ReporterName | Reporter): Reporter {
+  return typeof entry === 'string' ? new BUILT_IN[entry]() : entry;
+}
+
+/**
+ * Silence unless something is going to be printed. A reporter with nowhere to write would be a
+ * confusing no-op, and a `stdout` with no reporter would still carry the `#` diagnostics — which
+ * is a legitimate thing to want, so both independently opt in.
+ */
+function resolveOutput(options: RunOptions): Output {
+  if (options.stdout) {
+    return streamOutput(options.stdout, options.stderr ?? options.stdout);
+  } else if (options.stderr) {
+    return streamOutput(process.stdout, options.stderr);
+  } else if (options.reporter) {
+    return processOutput;
+  }
+
+  return silentOutput;
+}
+
+/** Wraps the three convenience callbacks into one reporter, or nothing when none were given. */
+function callbackReporter(options: RunOptions): Reporter | null {
+  const { onTest, onNotice, onBrowserLog } = options;
+  if (!onTest && !onNotice && !onBrowserLog) return null;
+
+  return {
+    onTestEnd: onTest && ((_config, details) => onTest(toTestResult(details))),
+    onNotice: onNotice && ((_config, notice) => onNotice(notice)),
+    onBrowserLog: onBrowserLog && ((_config, log) => onBrowserLog(log)),
+  };
+}

--- a/lib/api/options.ts
+++ b/lib/api/options.ts
@@ -145,7 +145,10 @@ export interface ResolvedReporting {
  * failure.data.option; // 'browser' — typed payload, no message parsing
  * ```
  */
-export const InvalidOption = Failure.define(
+export const InvalidOption: Failure.FailureFactory<
+  'InvalidOption',
+  { option: string; value: unknown; expected: string }
+> = Failure.define(
   'InvalidOption',
   (data: { option: string; value: unknown; expected: string }) =>
     `Invalid \`${data.option}\` value: ${JSON.stringify(data.value) ?? String(data.value)}. Expected ${data.expected}.`,

--- a/lib/api/result.ts
+++ b/lib/api/result.ts
@@ -141,13 +141,33 @@ export interface RunResult {
   failedFiles: string[];
   /** qunitx's own diagnostics for this run, in emission order. */
   notices: Notice[];
-  /** `console.*` calls and uncaught errors from the page. Warnings and errors unless `debug`. */
+  /**
+   * `console.*` calls and uncaught errors from the page — warnings and errors unless `debug`.
+   *
+   * Capped at the most recent {@link MAX_BROWSER_LOGS}; `browserLogsTruncated` counts what was
+   * dropped. The cap is not tidiness: unlike tests and notices, page output is bounded by nothing
+   * — one `for` loop around `console.warn` produced 50,001 entries and 252 MB of retained heap.
+   * The newest are kept because they are the ones adjacent to the failure being diagnosed.
+   */
   browserLogs: BrowserLog[];
+  /** How many page-log entries were dropped to stay under the cap. `0` in every ordinary run. */
+  browserLogsTruncated: number;
   /** Line coverage, or `null` when `coverage` was not requested. */
   coverage: CoverageSummary | null;
   /** The JUnit XML document, when `junit` was requested. Written to disk as well. */
   junitXml: string | null;
 }
+
+/**
+ * How many page-log entries a result retains. Tests and notices are bounded by the suite; page
+ * output is bounded by nothing a test runner controls, so this is the one channel that needs a
+ * ceiling. Generous enough that a real run never reaches it.
+ *
+ * ```ts
+ * MAX_BROWSER_LOGS; // 1000
+ * ```
+ */
+export const MAX_BROWSER_LOGS = 1000;
 
 /**
  * The reporter that turns a run into a value: it records what happened instead of printing it.
@@ -168,8 +188,10 @@ export class Collector implements Reporter {
   readonly tests: TestResult[] = [];
   /** Every diagnostic, in emission order. */
   readonly notices: Notice[] = [];
-  /** Every page console call and uncaught error, in arrival order. */
+  /** The most recent page console calls and uncaught errors, capped at {@link MAX_BROWSER_LOGS}. */
   readonly browserLogs: BrowserLog[] = [];
+  /** How many page-log entries the cap dropped. */
+  browserLogsTruncated = 0;
 
   /**
    * Drops everything from a previous run. Watch sessions reuse one collector across reruns, so
@@ -186,6 +208,7 @@ export class Collector implements Reporter {
     this.tests.length = 0;
     this.notices.length = 0;
     this.browserLogs.length = 0;
+    this.browserLogsTruncated = 0;
   }
 
   /**
@@ -231,6 +254,11 @@ export class Collector implements Reporter {
    */
   onBrowserLog(_config: Config, log: BrowserLog): void {
     this.browserLogs.push(log);
+    // Drop from the front: a flood's newest lines are the ones next to whatever went wrong.
+    if (this.browserLogs.length > MAX_BROWSER_LOGS) {
+      this.browserLogs.shift();
+      this.browserLogsTruncated++;
+    }
   }
 }
 
@@ -278,6 +306,7 @@ export function buildResult(
     failedFiles: Array.from(failedFiles),
     notices: collector.notices.slice(),
     browserLogs: collector.browserLogs.slice(),
+    browserLogsTruncated: collector.browserLogsTruncated,
     coverage: coverage ? summarizeCoverage(config) : null,
     junitXml,
   };

--- a/lib/api/result.ts
+++ b/lib/api/result.ts
@@ -6,6 +6,7 @@ import type {
   TestAssertion,
   TestDetails,
 } from '../reporters/types.ts';
+import { buildRows } from '../coverage/report.ts';
 import type { RunOutcome } from '../commands/run.ts';
 
 /**
@@ -306,44 +307,36 @@ export function toTestResult(details: TestDetails): TestResult {
   };
 }
 
-/** Folds the raw per-line coverage map into per-file counts plus the run totals. */
+/**
+ * Folds the run's coverage into per-file counts plus the totals.
+ *
+ * `buildRows` does the folding — the same function the terminal report uses — rather than a
+ * second walk of the collector. That is not only less code: it carries the Windows lesson, where
+ * the two sides arrive in different shapes (fsTree paths use backslashes, source-map keys always
+ * `/`) and a naive comparison silently leaks every test file into its own report.
+ */
 function summarizeCoverage(config: Config): CoverageSummary {
-  const collected = config.state.results.coverage!;
-  const testFiles = new Set(Object.keys(config.fsTree));
-  const files: FileCoverageSummary[] = [];
-  let coveredLines = 0;
-  let coverableLines = 0;
+  const rows = buildRows(
+    config.state.results.coverage!,
+    new Set(Object.keys(config.fsTree)),
+    config.projectRoot,
+  );
+  const coveredLines = rows.reduce((total, row) => total + row.covered, 0);
+  const coverableLines = rows.reduce((total, row) => total + row.total, 0);
 
-  for (const [absolutePath, fileCoverage] of collected) {
-    // Same exclusion the terminal report applies: a test file's own coverage is noise, and
-    // node_modules never reached the collector.
-    if (testFiles.has(absolutePath)) continue;
-    const coverable = fileCoverage.coverable.size;
-    if (coverable === 0) continue;
-    let covered = 0;
-    for (const line of fileCoverage.coverable) {
-      if ((fileCoverage.covered.get(line) ?? 0) > 0) covered++;
-    }
-    coveredLines += covered;
-    coverableLines += coverable;
-    files.push({
-      path: displayPath(absolutePath, config.projectRoot),
-      coveredLines: covered,
-      coverableLines: coverable,
-      percent: percentOf(covered, coverable),
-    });
-  }
-  files.sort((left, right) => left.path.localeCompare(right.path));
-
-  return { files, coveredLines, coverableLines, percent: percentOf(coveredLines, coverableLines) };
+  return {
+    files: rows.map((row) => ({
+      path: row.displayPath,
+      coveredLines: row.covered,
+      coverableLines: row.total,
+      percent: percentOf(row.covered, row.total),
+    })),
+    coveredLines,
+    coverableLines,
+    percent: percentOf(coveredLines, coverableLines),
+  };
 }
 
 function percentOf(covered: number, coverable: number): number {
   return coverable === 0 ? 0 : Math.round((covered / coverable) * 10000) / 100;
-}
-
-function displayPath(absolutePath: string, projectRoot: string): string {
-  return absolutePath.startsWith(`${projectRoot}/`)
-    ? absolutePath.slice(projectRoot.length + 1)
-    : absolutePath.replaceAll('\\', '/');
 }

--- a/lib/api/result.ts
+++ b/lib/api/result.ts
@@ -204,6 +204,15 @@ export interface RunResult {
   finishedAt: number;
   /** How many concurrent groups the files were split across; `1` for watch and single-file runs. */
   groupCount: number;
+  /**
+   * Whether this run was cut short — `session.abort()`, the CLI's `qq`, or an aborted `signal`.
+   *
+   * Check it before reporting a red run as red. An aborted run also has `ok: false` and
+   * `exitCode: 1`, because tests that never ran did not pass — but its counts are a prefix of the
+   * suite rather than a verdict on it, and a UI that conflates the two says "3 failures" when the
+   * user pressed stop.
+   */
+  aborted: boolean;
   /** What the run resolved to — see {@link ResolvedRun}. */
   resolved: ResolvedRun;
 }
@@ -371,6 +380,7 @@ export function buildResult(
     startedAt: outcome.startedAt,
     finishedAt: outcome.finishedAt,
     groupCount: config.state.groupCount,
+    aborted: config.state.results.aborted,
     resolved: {
       browser: config.browser,
       projectRoot: config.projectRoot,

--- a/lib/api/result.ts
+++ b/lib/api/result.ts
@@ -186,17 +186,47 @@ export class Collector implements Reporter {
     this.browserLogs.length = 0;
   }
 
-  /** Records one finished test. */
+  /**
+   * Records one finished test.
+   *
+   * ```ts
+   * import type { Config } from '../types.ts';
+   *
+   * const collector = new Collector();
+   * collector.onTestEnd({} as Config, { status: 'failed', fullName: ['Cart', 'adds'], runtime: 4 });
+   * collector.tests[0].status; // 'failed'
+   * ```
+   */
   onTestEnd(_config: Config, details: TestDetails): void {
     this.tests.push(toTestResult(details));
   }
 
-  /** Records one diagnostic. */
+  /**
+   * Records one diagnostic.
+   *
+   * ```ts
+   * import type { Config } from '../types.ts';
+   *
+   * const collector = new Collector();
+   * collector.onNotice({} as Config, { level: 'warning', message: 'No tests matched' });
+   * collector.notices[0].level; // 'warning'
+   * ```
+   */
   onNotice(_config: Config, notice: Notice): void {
     this.notices.push(notice);
   }
 
-  /** Records one page console call or uncaught error. */
+  /**
+   * Records one page console call or uncaught error.
+   *
+   * ```ts
+   * import type { Config } from '../types.ts';
+   *
+   * const collector = new Collector();
+   * collector.onBrowserLog({} as Config, { type: 'error', text: 'boom', args: [] });
+   * collector.browserLogs[0].text; // 'boom'
+   * ```
+   */
   onBrowserLog(_config: Config, log: BrowserLog): void {
     this.browserLogs.push(log);
   }

--- a/lib/api/result.ts
+++ b/lib/api/result.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type { Config } from '../types.ts';
 import type {
   BrowserLog,
@@ -20,6 +21,7 @@ import type { RunOutcome } from '../commands/run.ts';
  *   status: 'failed',
  *   durationMs: 12,
  *   assertions: [{ passed: false, todo: false, actual: 3, expected: 4 }],
+ *   file: 'test/cart-test.ts',
  * };
  * test.fullName; // exactly the string `--filter` matches against
  * ```
@@ -40,6 +42,14 @@ export interface TestResult {
    * failures and empty otherwise — a passing test's assertion count is not reported.
    */
   assertions: TestAssertion[];
+  /**
+   * Source file this test was declared in, relative to the project root, or `null`.
+   *
+   * Populated for **failures only**, and that is a limit of what QUnit reports rather than a
+   * choice: `testEnd` carries no file, so the path is recovered from the failing assertion's
+   * stack through the bundle's source map. A passing test leaves no stack to map.
+   */
+  file: string | null;
 }
 
 /**
@@ -107,6 +117,38 @@ export interface CoverageSummary {
 }
 
 /**
+ * What the run actually resolved to, after `package.json`, the defaults and the options were
+ * merged — the answers a caller cannot otherwise recover from what it passed in.
+ *
+ * `port` is the sharp one: it auto-increments past a busy port, so the value bound is routinely
+ * not the value requested.
+ *
+ * ```ts
+ * const resolved: ResolvedRun = {
+ *   browser: 'chromium', projectRoot: '/proj', output: '/proj/tmp', port: 1235,
+ *   extensions: ['js', 'ts'], coverageFormats: [],
+ * };
+ * resolved.port; // 1235 — 1234 was taken
+ * ```
+ */
+export interface ResolvedRun {
+  /** The engine the tests ran in. */
+  browser: 'chromium' | 'firefox' | 'webkit';
+  /** Absolute path of the directory holding `package.json`. */
+  projectRoot: string;
+  /** Absolute path of the build output directory — where the bundle and artifacts landed. */
+  output: string;
+  /** The port actually bound, which may differ from the one requested. */
+  port: number;
+  /** File extensions treated as test files. */
+  extensions: string[];
+  /** Coverage artifact formats beyond the terminal summary. */
+  coverageFormats: string[];
+  /** The active test-name filter, when one was set. */
+  filter?: string;
+}
+
+/**
  * Everything a finished run produced.
  *
  * **A run whose tests failed is a successful run.** `run()` resolves with `ok: false`; it does
@@ -156,6 +198,14 @@ export interface RunResult {
   coverage: CoverageSummary | null;
   /** The JUnit XML document, when `junit` was requested. Written to disk as well. */
   junitXml: string | null;
+  /** Epoch ms when the test phase began. */
+  startedAt: number;
+  /** Epoch ms when it ended. */
+  finishedAt: number;
+  /** How many concurrent groups the files were split across; `1` for watch and single-file runs. */
+  groupCount: number;
+  /** What the run resolved to — see {@link ResolvedRun}. */
+  resolved: ResolvedRun;
 }
 
 /**
@@ -282,8 +332,17 @@ export function buildResult(
   collector: Collector,
   junitXml: string | null,
 ): RunResult {
-  const { counter, failedFiles, coverage } = config.state.results;
-  const tests = collector.tests.slice();
+  const { counter, failedFiles, failedTests, coverage } = config.state.results;
+  // QUnit's `testEnd` carries no file, so failures are attributed separately — through the
+  // failing assertion's stack and the bundle's source map. Joining on the display name is what
+  // puts that attribution back on the test it belongs to.
+  const fileByTest = new Map(
+    failedTests.map((record) => [`${record.module}\u0000${record.testName}`, record.file]),
+  );
+  const tests = collector.tests.map((test) => ({
+    ...test,
+    file: fileByTest.get(`${test.modules.join(' > ')}\u0000${test.name}`) ?? null,
+  }));
 
   return {
     ok: outcome.exitCode === 0,
@@ -309,6 +368,18 @@ export function buildResult(
     browserLogsTruncated: collector.browserLogsTruncated,
     coverage: coverage ? summarizeCoverage(config) : null,
     junitXml,
+    startedAt: outcome.startedAt,
+    finishedAt: outcome.finishedAt,
+    groupCount: config.state.groupCount,
+    resolved: {
+      browser: config.browser,
+      projectRoot: config.projectRoot,
+      output: path.resolve(config.projectRoot, config.output),
+      port: config.port,
+      extensions: config.extensions,
+      coverageFormats: config.coverageFormats ?? [],
+      ...(config.filter === undefined ? {} : { filter: config.filter }),
+    },
   };
 }
 
@@ -333,6 +404,8 @@ export function toTestResult(details: TestDetails): TestResult {
     status: details.status as TestResult['status'],
     durationMs: details.runtime,
     assertions: details.assertions ?? [],
+    // Filled in by `buildResult`, which is where the failure attribution is available.
+    file: null,
   };
 }
 

--- a/lib/api/result.ts
+++ b/lib/api/result.ts
@@ -1,0 +1,315 @@
+import type { Config } from '../types.ts';
+import type {
+  BrowserLog,
+  Notice,
+  Reporter,
+  TestAssertion,
+  TestDetails,
+} from '../reporters/types.ts';
+import type { RunOutcome } from '../commands/run.ts';
+
+/**
+ * One finished test.
+ *
+ * ```ts
+ * const test: TestResult = {
+ *   name: 'sums line items',
+ *   modules: ['Cart', 'totals'],
+ *   fullName: 'Cart > totals: sums line items',
+ *   status: 'failed',
+ *   durationMs: 12,
+ *   assertions: [{ passed: false, todo: false, actual: 3, expected: 4 }],
+ * };
+ * test.fullName; // exactly the string `--filter` matches against
+ * ```
+ */
+export interface TestResult {
+  /** The test's own name, without its modules. */
+  name: string;
+  /** The QUnit module path it was declared under; empty for a top-level test. */
+  modules: string[];
+  /** `"Module > Sub: test name"` — the string `filter` matches against. */
+  fullName: string;
+  /** QUnit's outcome for this test. */
+  status: 'passed' | 'failed' | 'skipped' | 'todo';
+  /** How long the test took, in milliseconds. */
+  durationMs: number;
+  /**
+   * The test's assertions. QUnit trims these for passing tests, so this is populated for
+   * failures and empty otherwise — a passing test's assertion count is not reported.
+   */
+  assertions: TestAssertion[];
+}
+
+/**
+ * Outcome totals for a run. `total` is the sum of the four buckets; `assertionsFailed` counts
+ * individual assertions rather than tests, so one test can contribute several.
+ *
+ * ```ts
+ * const counts: RunCounts =
+ *   { total: 8, passed: 7, failed: 1, skipped: 0, todo: 0, assertionsFailed: 2 };
+ * counts.passed + counts.failed === counts.total; // true when nothing was skipped
+ * ```
+ */
+export interface RunCounts {
+  /** Every test that reached an outcome. */
+  total: number;
+  /** Tests where every assertion held. */
+  passed: number;
+  /** Tests with at least one failing assertion, or that threw. */
+  failed: number;
+  /** Tests declared with `test.skip`. */
+  skipped: number;
+  /** Tests declared with `test.todo` — expected to fail, and not counted as failures. */
+  todo: number;
+  /** Failing assertions across the whole run, excluding those inside `todo` tests. */
+  assertionsFailed: number;
+}
+
+/**
+ * Per-file line coverage, when `coverage` was requested.
+ *
+ * ```ts
+ * const file: FileCoverageSummary =
+ *   { path: 'lib/cart.ts', coveredLines: 18, coverableLines: 20, percent: 90 };
+ * file.percent; // 90
+ * ```
+ */
+export interface FileCoverageSummary {
+  /** Path relative to the project root, with forward slashes. */
+  path: string;
+  /** Lines executed at least once. */
+  coveredLines: number;
+  /** Lines the source map attributes to executable positions in the bundle. */
+  coverableLines: number;
+  /** `coveredLines / coverableLines`, as a percentage rounded to two decimals. */
+  percent: number;
+}
+
+/**
+ * The run's line coverage: one entry per source file, plus the totals across all of them.
+ *
+ * ```ts
+ * const coverage: CoverageSummary = { files: [], coveredLines: 0, coverableLines: 0, percent: 0 };
+ * coverage.files.length; // 0 — nothing coverable was found
+ * ```
+ */
+export interface CoverageSummary {
+  /** One entry per non-test source file the bundle mapped back to. */
+  files: FileCoverageSummary[];
+  /** Covered lines across every file. */
+  coveredLines: number;
+  /** Coverable lines across every file. */
+  coverableLines: number;
+  /** Overall percentage covered. */
+  percent: number;
+}
+
+/**
+ * Everything a finished run produced.
+ *
+ * **A run whose tests failed is a successful run.** `run()` resolves with `ok: false`; it does
+ * not reject. Rejection is reserved for the run not happening — a bad option, an unreadable
+ * input, a project with no `package.json`. Distinguishing "the suite says no" from "the runner
+ * could not answer" is the whole point of the split, and it is what lets `catch` mean something.
+ *
+ * ```ts
+ * // Defined, not invoked: a real result comes back from `run()`.
+ * function summarize(result: RunResult) {
+ *   return `${result.counts.passed}/${result.counts.total} passed in ${result.durationMs}ms`;
+ * }
+ * ```
+ */
+export interface RunResult {
+  /** `true` when every test passed and nothing else went wrong. */
+  ok: boolean;
+  /** What the CLI would have exited with: `0` when `ok`, `1` otherwise. */
+  exitCode: number;
+  /** Wall-clock duration of the test phase, in milliseconds. */
+  durationMs: number;
+  /** Outcome totals. */
+  counts: RunCounts;
+  /** Every finished test, in the order the browser reported them. */
+  tests: TestResult[];
+  /** The subset of `tests` that failed — the list you almost always want first. */
+  failures: TestResult[];
+  /** Absolute paths of the test files this run executed. */
+  files: string[];
+  /** Absolute paths of the test files with at least one failure, attributed via source maps. */
+  failedFiles: string[];
+  /** qunitx's own diagnostics for this run, in emission order. */
+  notices: Notice[];
+  /** `console.*` calls and uncaught errors from the page. Warnings and errors unless `debug`. */
+  browserLogs: BrowserLog[];
+  /** Line coverage, or `null` when `coverage` was not requested. */
+  coverage: CoverageSummary | null;
+  /** The JUnit XML document, when `junit` was requested. Written to disk as well. */
+  junitXml: string | null;
+}
+
+/**
+ * The reporter that turns a run into a value: it records what happened instead of printing it.
+ *
+ * Attached by the JS API to every run, alongside whatever reporters the caller asked for — so
+ * `reporter: 'tap'` still streams TAP *and* still resolves with a full {@link RunResult}.
+ *
+ * ```ts
+ * import type { Config } from '../types.ts';
+ *
+ * const collector = new Collector();
+ * collector.onTestEnd({} as Config, { status: 'passed', fullName: ['Math', 'adds'], runtime: 2 });
+ * collector.tests[0].fullName; // 'Math: adds'
+ * ```
+ */
+export class Collector implements Reporter {
+  /** Every finished test, in arrival order. */
+  readonly tests: TestResult[] = [];
+  /** Every diagnostic, in emission order. */
+  readonly notices: Notice[] = [];
+  /** Every page console call and uncaught error, in arrival order. */
+  readonly browserLogs: BrowserLog[] = [];
+
+  /**
+   * Drops everything from a previous run. Watch sessions reuse one collector across reruns, so
+   * this is what keeps rerun N's result from containing rerun N-1's tests.
+   *
+   * ```ts
+   * const collector = new Collector();
+   * collector.notices.push({ level: 'info', message: 'stale' });
+   * collector.reset();
+   * collector.notices.length; // 0
+   * ```
+   */
+  reset(): void {
+    this.tests.length = 0;
+    this.notices.length = 0;
+    this.browserLogs.length = 0;
+  }
+
+  /** Records one finished test. */
+  onTestEnd(_config: Config, details: TestDetails): void {
+    this.tests.push(toTestResult(details));
+  }
+
+  /** Records one diagnostic. */
+  onNotice(_config: Config, notice: Notice): void {
+    this.notices.push(notice);
+  }
+
+  /** Records one page console call or uncaught error. */
+  onBrowserLog(_config: Config, log: BrowserLog): void {
+    this.browserLogs.push(log);
+  }
+}
+
+/**
+ * Assembles the run's result from the config's accumulated state, the run's outcome, and the
+ * collector that watched it.
+ *
+ * ```ts
+ * import type { Config } from '../types.ts';
+ * import type { RunOutcome } from '../commands/run.ts';
+ *
+ * // Defined, not invoked: reads the live counters off a resolved Config.
+ * function assemble(config: Config, outcome: RunOutcome) {
+ *   return buildResult(config, outcome, new Collector(), null);
+ * }
+ * ```
+ */
+export function buildResult(
+  config: Config,
+  outcome: RunOutcome,
+  collector: Collector,
+  junitXml: string | null,
+): RunResult {
+  const { counter, failedFiles, coverage } = config.state.results;
+  const tests = collector.tests.slice();
+
+  return {
+    ok: outcome.exitCode === 0,
+    exitCode: outcome.exitCode,
+    durationMs: outcome.durationMs,
+    counts: {
+      total: counter.testCount,
+      passed: counter.passCount,
+      failed: counter.failCount,
+      skipped: counter.skipCount,
+      todo: counter.todoCount,
+      assertionsFailed: counter.errorCount,
+    },
+    tests,
+    failures: tests.filter((test) => test.status === 'failed'),
+    files: Object.keys(config.fsTree),
+    failedFiles: Array.from(failedFiles),
+    notices: collector.notices.slice(),
+    browserLogs: collector.browserLogs.slice(),
+    coverage: coverage ? summarizeCoverage(config) : null,
+    junitXml,
+  };
+}
+
+/**
+ * Projects one QUnit `testEnd` payload into a {@link TestResult}. QUnit's `fullName` is
+ * `[...modules, testName]`; the joined display form matches what `filter` matches against —
+ * modules separated by ` > `, the test name after a `: `.
+ *
+ * ```ts
+ * toTestResult({ status: 'passed', fullName: ['Cart', 'adds item'], runtime: 2 }).fullName;
+ * // 'Cart: adds item'
+ * ```
+ */
+export function toTestResult(details: TestDetails): TestResult {
+  const modules = details.fullName.slice(0, -1);
+  const name = details.fullName[details.fullName.length - 1] ?? '';
+
+  return {
+    name,
+    modules,
+    fullName: modules.length > 0 ? `${modules.join(' > ')}: ${name}` : name,
+    status: details.status as TestResult['status'],
+    durationMs: details.runtime,
+    assertions: details.assertions ?? [],
+  };
+}
+
+/** Folds the raw per-line coverage map into per-file counts plus the run totals. */
+function summarizeCoverage(config: Config): CoverageSummary {
+  const collected = config.state.results.coverage!;
+  const testFiles = new Set(Object.keys(config.fsTree));
+  const files: FileCoverageSummary[] = [];
+  let coveredLines = 0;
+  let coverableLines = 0;
+
+  for (const [absolutePath, fileCoverage] of collected) {
+    // Same exclusion the terminal report applies: a test file's own coverage is noise, and
+    // node_modules never reached the collector.
+    if (testFiles.has(absolutePath)) continue;
+    const coverable = fileCoverage.coverable.size;
+    if (coverable === 0) continue;
+    let covered = 0;
+    for (const line of fileCoverage.coverable) {
+      if ((fileCoverage.covered.get(line) ?? 0) > 0) covered++;
+    }
+    coveredLines += covered;
+    coverableLines += coverable;
+    files.push({
+      path: displayPath(absolutePath, config.projectRoot),
+      coveredLines: covered,
+      coverableLines: coverable,
+      percent: percentOf(covered, coverable),
+    });
+  }
+  files.sort((left, right) => left.path.localeCompare(right.path));
+
+  return { files, coveredLines, coverableLines, percent: percentOf(coveredLines, coverableLines) };
+}
+
+function percentOf(covered: number, coverable: number): number {
+  return coverable === 0 ? 0 : Math.round((covered / coverable) * 10000) / 100;
+}
+
+function displayPath(absolutePath: string, projectRoot: string): string {
+  return absolutePath.startsWith(`${projectRoot}/`)
+    ? absolutePath.slice(projectRoot.length + 1)
+    : absolutePath.replaceAll('\\', '/');
+}

--- a/lib/api/result.ts
+++ b/lib/api/result.ts
@@ -133,7 +133,8 @@ export interface RunResult {
   tests: TestResult[];
   /** The subset of `tests` that failed — the list you almost always want first. */
   failures: TestResult[];
-  /** Absolute paths of the test files this run executed. */
+  /** Absolute paths of the test files this run executed — the ones scoped to, in a
+   * filtered watch rerun, rather than everything being watched. */
   files: string[];
   /** Absolute paths of the test files with at least one failure, attributed via source maps. */
   failedFiles: string[];
@@ -269,7 +270,10 @@ export function buildResult(
     },
     tests,
     failures: tests.filter((test) => test.status === 'failed'),
-    files: Object.keys(config.fsTree),
+    // `lastRanFiles` rather than the whole fsTree: a watch-mode rerun scoped to one saved file
+    // ran that file, not everything being watched. The batch runner sets it to the full set, so
+    // the two agree there.
+    files: config.state.group.lastRanFiles ?? Object.keys(config.fsTree),
     failedFiles: Array.from(failedFiles),
     notices: collector.notices.slice(),
     browserLogs: collector.browserLogs.slice(),

--- a/lib/api/run.ts
+++ b/lib/api/run.ts
@@ -4,15 +4,18 @@ import { JUnitReporter } from '../reporters/junit.ts';
 import { Task } from '../task/index.ts';
 import { unwrap } from '../result/result.ts';
 import { buildResult, type RunResult } from './result.ts';
+import * as RunState from '../setup/run-state.ts';
 import {
   normalizeOptions,
   resolveReporting,
   toConfigOptions,
   validate,
   type InvalidOptionFailure,
+  type ResolvedReporting,
   type RunOptions,
 } from './options.ts';
 import type { Reporter } from '../reporters/types.ts';
+import type { Config as ResolvedConfig } from '../types.ts';
 
 /**
  * Every way a run can fail to happen: an option the runner will not accept, an unreadable input,
@@ -62,10 +65,90 @@ export function run(options: RunOptions | string | string[] = {}): Task<RunResul
     // identity, so `RunFailure` stays a union the caller can discriminate rather than a
     // stringified message.
     const config = unwrap(await Config.setup(toConfigOptions(resolved, reporting)).result());
-    const outcome = await Run.run(config);
+    // Checked here rather than inside `withSignal`, because the first thing a run does is reset
+    // its accumulators — including the aborted flag. A request made before that point would be
+    // cleared by the very run it was meant to stop, so the only honest answer to an
+    // already-cancelled run is to not start one.
+    if (resolved.signal?.aborted) return abortedBeforeStart(config, reporting);
+
+    const outcome = await withSignal(config, resolved.signal, () => Run.run(config));
 
     return buildResult(config, outcome, reporting.collector, junitXml(reporting.reporters));
   });
+}
+
+/**
+ * The JUnit document, when the run was asked for one. Read off the reporter rather than the
+ * disk: the caller may want to publish it without touching the filesystem, and it is the same
+ * string `onRunEnd` just wrote.
+ *
+ * ```ts
+ * junitXml([]); // null — no JUnit reporter was attached, so there is no document
+ * ```
+ */
+/**
+ * The result of a run that was cancelled before it began: no browser, no tests, `aborted: true`.
+ *
+ * A result rather than a rejection, because cancelling is not failing — the caller asked for this
+ * and gets the same shape back, so the code reading the result needs no separate path.
+ *
+ * ```ts
+ * import type { Config } from '../types.ts';
+ * import { resolveReporting } from './options.ts';
+ *
+ * // Defined, not invoked: needs a resolved Config.
+ * function cancelled(config: Config) {
+ *   return abortedBeforeStart(config, resolveReporting({})).aborted; // true
+ * }
+ * ```
+ */
+export function abortedBeforeStart(
+  config: ResolvedConfig,
+  reporting: ResolvedReporting,
+): RunResult {
+  config.state.results.aborted = true;
+  const now = Date.now();
+
+  // Exit 1: a run that produced no passing tests did not succeed. `aborted` is what tells a
+  // caller it was their own doing rather than a red suite.
+  return buildResult(
+    config,
+    { exitCode: 1, durationMs: 0, startedAt: now, finishedAt: now },
+    reporting.collector,
+    null,
+  );
+}
+
+/**
+ * Runs `work` with `signal` wired to the run's abort mechanism, and unsubscribes afterwards.
+ *
+ * The listener is removed on the way out because a caller may reuse one controller across several
+ * runs — a common enough shape (one "stop everything" button) that leaking a listener per run
+ * onto a long-lived signal would be a real accumulation rather than a theoretical one.
+ *
+ * ```ts
+ * import type { Config } from '../types.ts';
+ *
+ * // Defined, not invoked: a real run needs a resolved Config.
+ * function cancellable(config: Config, signal: AbortSignal) {
+ *   return withSignal(config, signal, () => Promise.resolve('done'));
+ * }
+ * ```
+ */
+export async function withSignal<T>(
+  config: ResolvedConfig,
+  signal: AbortSignal | undefined,
+  work: () => Promise<T>,
+): Promise<T> {
+  if (!signal) return await work();
+
+  const abort = () => RunState.requestAbort(config.state);
+  signal.addEventListener('abort', abort);
+  try {
+    return await work();
+  } finally {
+    signal.removeEventListener('abort', abort);
+  }
 }
 
 /**

--- a/lib/api/run.ts
+++ b/lib/api/run.ts
@@ -72,6 +72,10 @@ export function run(options: RunOptions | string | string[] = {}): Task<RunResul
  * The JUnit document, when the run was asked for one. Read off the reporter rather than the
  * disk: the caller may want to publish it without touching the filesystem, and it is the same
  * string `onRunEnd` just wrote.
+ *
+ * ```ts
+ * junitXml([]); // null — no JUnit reporter was attached, so there is no document
+ * ```
  */
 export function junitXml(reporters: readonly Reporter[]): string | null {
   const junit = reporters.find((reporter) => reporter instanceof JUnitReporter);

--- a/lib/api/run.ts
+++ b/lib/api/run.ts
@@ -4,12 +4,19 @@ import { JUnitReporter } from '../reporters/junit.ts';
 import { Task } from '../task/index.ts';
 import { unwrap } from '../result/result.ts';
 import { buildResult, type RunResult } from './result.ts';
-import { normalizeOptions, resolveReporting, toConfigOptions, type RunOptions } from './options.ts';
+import {
+  normalizeOptions,
+  resolveReporting,
+  toConfigOptions,
+  validate,
+  type InvalidOptionFailure,
+  type RunOptions,
+} from './options.ts';
 import type { Reporter } from '../reporters/types.ts';
 
 /**
- * Every way a run can fail to happen: a rejected option, an unreadable input, a directory with
- * no `package.json` above it, an esbuild plugin that will not load.
+ * Every way a run can fail to happen: an option the runner will not accept, an unreadable input,
+ * a directory with no `package.json` above it, an esbuild plugin that will not load.
  *
  * Note what is *not* here. Failing tests are not a failure — they are a {@link RunResult} with
  * `ok: false`. This union is only for the runner being unable to answer the question.
@@ -23,7 +30,7 @@ import type { Reporter } from '../reporters/types.ts';
  * }
  * ```
  */
-export type RunFailure = Config.ConfigFailure;
+export type RunFailure = Config.ConfigFailure | InvalidOptionFailure;
 
 /**
  * Runs the suite once in a real browser and resolves with everything it produced.
@@ -49,6 +56,7 @@ export type RunFailure = Config.ConfigFailure;
 export function run(options: RunOptions | string | string[] = {}): Task<RunResult, RunFailure> {
   return Task(async () => {
     const resolved = normalizeOptions(options);
+    validate(resolved);
     const reporting = resolveReporting(resolved);
     // `unwrap` moves a declared config failure into this Task's E channel by throwing it by
     // identity, so `RunFailure` stays a union the caller can discriminate rather than a

--- a/lib/api/run.ts
+++ b/lib/api/run.ts
@@ -1,0 +1,72 @@
+import * as Config from '../setup/config.ts';
+import * as Run from '../commands/run.ts';
+import { JUnitReporter } from '../reporters/junit.ts';
+import { Task } from '../task/index.ts';
+import { unwrap } from '../result/result.ts';
+import { buildResult, type RunResult } from './result.ts';
+import { normalizeOptions, resolveReporting, toConfigOptions, type RunOptions } from './options.ts';
+import type { Reporter } from '../reporters/types.ts';
+
+/**
+ * Every way a run can fail to happen: a rejected option, an unreadable input, a directory with
+ * no `package.json` above it, an esbuild plugin that will not load.
+ *
+ * Note what is *not* here. Failing tests are not a failure — they are a {@link RunResult} with
+ * `ok: false`. This union is only for the runner being unable to answer the question.
+ *
+ * ```ts
+ * import { Failure } from '../task/index.ts';
+ *
+ * // Defined, not invoked: a real failure comes back from `run(...).result()`.
+ * function explain(failure: RunFailure) {
+ *   return `${failure.code}: ${Failure.format(failure)}`; // 'InvalidFlag: …'
+ * }
+ * ```
+ */
+export type RunFailure = Config.ConfigFailure;
+
+/**
+ * Runs the suite once in a real browser and resolves with everything it produced.
+ *
+ * Silent by default: with no `reporter`, nothing reaches stdout and the {@link RunResult} is the
+ * entire output. Pass `reporter: 'tap'` (or `'spec'`, `'dot'`, `'github'`, or your own object)
+ * to get the CLI's text as well — the result comes back either way.
+ *
+ * Lazy, because it is a {@link Task}: no browser starts until you await it. `await run(…)`
+ * resolves the result or throws a {@link RunFailure}; `run(…).result()` hands back the bare
+ * union instead, for code that would rather branch than catch.
+ *
+ * ```ts
+ * import { run } from './run.ts';
+ *
+ * // Defined, not invoked: launches a browser and runs the project's tests.
+ * async function checkCart() {
+ *   const result = await run({ inputs: ['test/'], filter: 'Cart' });
+ *   return result.ok ? 'green' : result.failures.map((test) => test.fullName);
+ * }
+ * ```
+ */
+export function run(options: RunOptions | string | string[] = {}): Task<RunResult, RunFailure> {
+  return Task(async () => {
+    const resolved = normalizeOptions(options);
+    const reporting = resolveReporting(resolved);
+    // `unwrap` moves a declared config failure into this Task's E channel by throwing it by
+    // identity, so `RunFailure` stays a union the caller can discriminate rather than a
+    // stringified message.
+    const config = unwrap(await Config.setup(toConfigOptions(resolved, reporting)).result());
+    const outcome = await Run.run(config);
+
+    return buildResult(config, outcome, reporting.collector, junitXml(reporting.reporters));
+  });
+}
+
+/**
+ * The JUnit document, when the run was asked for one. Read off the reporter rather than the
+ * disk: the caller may want to publish it without touching the filesystem, and it is the same
+ * string `onRunEnd` just wrote.
+ */
+export function junitXml(reporters: readonly Reporter[]): string | null {
+  const junit = reporters.find((reporter) => reporter instanceof JUnitReporter);
+
+  return junit ? junit.xml() : null;
+}

--- a/lib/api/scaffold.ts
+++ b/lib/api/scaffold.ts
@@ -1,0 +1,51 @@
+import * as Init from '../commands/init.ts';
+import * as Generate from '../commands/generate.ts';
+import { Task } from '../task/index.ts';
+import type { ProjectRootNotFoundFailure } from '../utils/find-project-root.ts';
+
+export type { InitOptions, InitResult } from '../commands/init.ts';
+export type { GenerateOptions, GenerateResult } from '../commands/generate.ts';
+
+/**
+ * Bootstraps a project for qunitx: writes the test HTML fixture, adds a `qunitx` block to
+ * `package.json`, and writes a `tsconfig.json` when there isn't one.
+ *
+ * Never overwrites. Files that already exist come back under `skipped`, untouched — so calling
+ * it twice is safe, and calling it on an existing project only fills in what is missing.
+ *
+ * ```ts
+ * import { init } from './scaffold.ts';
+ *
+ * // Defined, not invoked: writes into a real project directory.
+ * async function bootstrap() {
+ *   const { written, skipped } = await init({ cwd: '/proj' });
+ *   return { created: written.length, left: skipped.length };
+ * }
+ * ```
+ */
+export function init(
+  options: Init.InitOptions = {},
+): Task<Init.InitResult, ProjectRootNotFoundFailure> {
+  return Task(() => Init.run(options));
+}
+
+/**
+ * Writes a new test file from the boilerplate template, deriving its QUnit module name from the
+ * path (`test/users/login-test.ts` → `Users | Login`). Creates missing directories; never
+ * overwrites an existing file.
+ *
+ * ```ts
+ * import { generate } from './scaffold.ts';
+ *
+ * // Defined, not invoked: writes into a real project directory.
+ * async function scaffold() {
+ *   const { path, created } = await generate({ target: 'test/login-test.ts' });
+ *   return created ? path : null;
+ * }
+ * ```
+ */
+export function generate(
+  options: Generate.GenerateOptions,
+): Task<Generate.GenerateResult, ProjectRootNotFoundFailure> {
+  return Task(() => Generate.run(options));
+}

--- a/lib/api/search.ts
+++ b/lib/api/search.ts
@@ -2,7 +2,13 @@ import * as Config from '../setup/config.ts';
 import * as Search from '../commands/search.ts';
 import { Task } from '../task/index.ts';
 import { unwrap } from '../result/result.ts';
-import { normalizeOptions, resolveReporting, toConfigOptions, type RunOptions } from './options.ts';
+import {
+  normalizeOptions,
+  resolveReporting,
+  toConfigOptions,
+  validate,
+  type RunOptions,
+} from './options.ts';
 import type { RunFailure } from './run.ts';
 
 /**
@@ -83,6 +89,7 @@ export function search(
 ): Task<SearchResult, RunFailure> {
   return Task(async () => {
     const resolved = normalizeOptions(options);
+    validate(resolved);
     const reporting = resolveReporting(resolved);
     const config = unwrap(await Config.setup(toConfigOptions(resolved, reporting)).result());
     const report = await Search.scan(config);

--- a/lib/api/search.ts
+++ b/lib/api/search.ts
@@ -1,0 +1,107 @@
+import * as Config from '../setup/config.ts';
+import * as Search from '../commands/search.ts';
+import { Task } from '../task/index.ts';
+import { unwrap } from '../result/result.ts';
+import { normalizeOptions, resolveReporting, toConfigOptions, type RunOptions } from './options.ts';
+import type { RunFailure } from './run.ts';
+
+/**
+ * One test the static scan found.
+ *
+ * ```ts
+ * const match: SearchMatch = {
+ *   fullName: 'Cart > Coupons: applies code',
+ *   name: 'applies code',
+ *   modules: ['Cart', 'Coupons'],
+ *   file: '/proj/test/cart-test.ts',
+ *   line: 6,
+ * };
+ * `${match.file}#${match.line}`; // paste it straight back as a line target
+ * ```
+ */
+export interface SearchMatch {
+  /** `"Module > Sub: test name"` — the string `filter` matches against. */
+  fullName: string;
+  /** The test's own name. */
+  name: string;
+  /** The QUnit module path it is declared under; empty for a top-level test. */
+  modules: string[];
+  /** Absolute path of the file it is declared in. */
+  file: string;
+  /** 1-based line of the declaration. */
+  line: number;
+}
+
+/**
+ * What `search()` found.
+ *
+ * ```ts
+ * const result: SearchResult =
+ *   { matches: [], total: 12, files: 3, filter: 'Cart', warnings: [], unlistable: 0 };
+ * result.matches.length; // 0 of 12 — nothing matched
+ * ```
+ */
+export interface SearchResult {
+  /** The matching tests, in declaration order. */
+  matches: SearchMatch[];
+  /** Every listable test in the scanned files, matched or not. */
+  total: number;
+  /** How many files were scanned. */
+  files: number;
+  /** The expression matched against, or `undefined` when everything was listed. */
+  filter?: string;
+  /** Line-target resolution warnings. */
+  warnings: string[];
+  /**
+   * Declarations the scan could not name: a runtime-computed name (``test(`case ${i}`)``), an
+   * unparseable file, or a declarator reached through a local alias. They may still match at
+   * run time — a non-zero count means `total` is a lower bound.
+   */
+  unlistable: number;
+}
+
+/**
+ * Lists the tests a selection would run, without running them.
+ *
+ * No browser, no bundle, no execution — the answer comes from parsing the declarations, so it
+ * returns in milliseconds even for a large suite. The same scanner `file.ts#34` line targets
+ * use, and the same filter matcher a real run applies, so the preview is what would actually be
+ * selected.
+ *
+ * ```ts
+ * import { search } from './search.ts';
+ *
+ * // Defined, not invoked: reads and parses the project's test files.
+ * async function whatMatches() {
+ *   const { matches } = await search({ filter: 'Cart' });
+ *   return matches.map((test) => `${test.fullName}  ${test.file}#${test.line}`);
+ * }
+ * ```
+ */
+export function search(
+  options: RunOptions | string | string[] = {},
+): Task<SearchResult, RunFailure> {
+  return Task(async () => {
+    const resolved = normalizeOptions(options);
+    const reporting = resolveReporting(resolved);
+    const config = unwrap(await Config.setup(toConfigOptions(resolved, reporting)).result());
+    const report = await Search.scan(config);
+
+    return {
+      matches: report.matches.map((match) => ({
+        fullName: match.fullName,
+        name: match.testName,
+        modules: match.module === '' ? [] : match.module.split(' > '),
+        file: match.file,
+        // `location` is the display path plus `#line`; the line is what a caller can act on, and
+        // `file` already carries the absolute path in a form they can pass straight back in.
+        line: Number(match.location.slice(match.location.lastIndexOf('#') + 1)),
+      })),
+      total: report.total,
+      files: report.files,
+      filter: report.filter,
+      warnings: report.warnings,
+      unlistable: report.computedNames + report.unparseable + report.silent,
+    };
+  });
+}

--- a/lib/api/session.ts
+++ b/lib/api/session.ts
@@ -1,0 +1,214 @@
+import * as Config from '../setup/config.ts';
+import * as Run from '../commands/run.ts';
+import { Task } from '../task/index.ts';
+import { unwrap } from '../result/result.ts';
+import { buildResult, type RunResult } from './result.ts';
+import { Channel, eventReporter, type RunEvent } from './events.ts';
+import { abortedBeforeStart, junitXml, type RunFailure } from './run.ts';
+import * as RunState from '../setup/run-state.ts';
+import {
+  normalizeOptions,
+  resolveReporting,
+  toConfigOptions,
+  validate,
+  type ResolvedReporting,
+  type RunOptions,
+} from './options.ts';
+import type { Config as ResolvedConfig } from '../types.ts';
+
+/**
+ * One run, watched as it happens.
+ *
+ * Async-iterable over {@link RunEvent}: `runStart`, one `test` per finished test, `notice` and
+ * `browserLog` as they arrive, and `runEnd` carrying the complete {@link RunResult}. The same
+ * event shape a {@link WatchSession} produces, so a progress display written against one works
+ * against the other.
+ *
+ * **The run does not start until you consume it.** Not an optimization — the correctness property
+ * that makes the feed lossless. A browser cannot be told to slow down, so a run started before
+ * anyone was reading would either drop events or buffer them all; starting on the first read means
+ * the producer never outruns the consumer by more than one scheduling turn. Awaiting
+ * {@link RunSession.result} counts as consuming, so a caller that only wants the answer still gets
+ * one without iterating.
+ *
+ * ```ts
+ * // Defined, not invoked: a real session launches a browser.
+ * async function progress(session: RunSession) {
+ *   for await (const event of session) {
+ *     if (event.kind === 'test') process.stdout.write('.');
+ *   }
+ *   return (await session.result()).counts;
+ * }
+ * ```
+ */
+export interface RunSession extends AsyncIterable<RunEvent> {
+  /**
+   * The finished run. Starts it if nothing has yet, and resolves with the same
+   * {@link RunResult} the final `runEnd` event carries — never `undefined`, which is the whole
+   * reason this is a session rather than a bare event stream.
+   *
+   * Awaiting it twice is free: the second call returns the first's result.
+   */
+  result(): Promise<RunResult>;
+  /**
+   * Cuts the run short. The browser drops the rest of its queue and the run ends where it is,
+   * with `aborted: true` on the result — which {@link RunSession.result} still resolves with, so
+   * an aborted run is answered rather than left hanging.
+   *
+   * Resolves once the run has finished unwinding. Aborting before the run starts makes it a no-op
+   * that ends the session immediately.
+   */
+  abort(): Promise<void>;
+  /** Closes the session, ending iteration. Idempotent; implied by `await using`. */
+  close(): Promise<void>;
+  /** Closes the session at the end of an `await using` block. */
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
+/**
+ * Starts a single run you can watch happen, rather than one you wait out.
+ *
+ * Use it when the run's progress is the point — a progress bar, a live log, a UI that shows tests
+ * as they finish. When only the outcome matters, `run()` is the smaller thing: it allocates none
+ * of this machinery and hands back the same {@link RunResult}.
+ *
+ * Lazy twice over, and for two different reasons: the {@link Task} does nothing until awaited
+ * (like every other verb here), and the session it resolves to does not start the run until it is
+ * consumed (so the event feed cannot fall behind).
+ *
+ * ```ts
+ * import { runSession } from './session.ts';
+ *
+ * // Defined, not invoked: launches a browser and runs the project's tests.
+ * async function countAsTheyFinish() {
+ *   await using session = await runSession({ inputs: ['test/'] });
+ *   let finished = 0;
+ *   for await (const event of session) if (event.kind === 'test') finished++;
+ *   return finished;
+ * }
+ * ```
+ */
+export function runSession(
+  options: RunOptions | string | string[] = {},
+): Task<RunSession, RunFailure> {
+  return Task(async () => {
+    const resolved = normalizeOptions(options);
+    validate(resolved);
+    const reporting = resolveReporting(resolved);
+    const channel = new Channel<RunEvent>();
+    reporting.reporters.push(eventReporter(channel));
+    // Config assembly happens eagerly — it reads package.json and resolves inputs, so a bad option
+    // is a failure from `runSession(...)` itself rather than a surprise on first iteration. Only
+    // the browser is deferred.
+    const config = unwrap(await Config.setup(toConfigOptions(resolved, reporting)).result());
+
+    return new Session(config, reporting, channel, resolved.signal);
+  });
+}
+
+/** The live session; a class because it owns the run's lifecycle and has to start it exactly once. */
+class Session implements RunSession {
+  #config: ResolvedConfig;
+  #reporting: ResolvedReporting;
+  #channel: Channel<RunEvent>;
+  #started: Promise<RunResult> | null = null;
+  #closed = false;
+
+  constructor(
+    config: ResolvedConfig,
+    reporting: ResolvedReporting,
+    channel: Channel<RunEvent>,
+    signal?: AbortSignal,
+  ) {
+    this.#config = config;
+    this.#reporting = reporting;
+    this.#channel = channel;
+    if (signal) {
+      if (signal.aborted) this.#closed = true;
+      else signal.addEventListener('abort', () => void this.abort(), { once: true });
+    }
+  }
+
+  result(): Promise<RunResult> {
+    return this.#start();
+  }
+
+  async abort(): Promise<void> {
+    // Nothing started means nothing to interrupt — and starting a run in order to stop it would
+    // be an odd reading of `abort`. Close instead, so a consumer parked on the feed is released.
+    if (!this.#started) {
+      this.#closed = true;
+      this.#channel.close();
+
+      return;
+    }
+
+    RunState.requestAbort(this.#config.state);
+    // Swallowed: the caller asked to stop, and a run that failed on the way down is not news they
+    // asked for. `result()` still reports it to anyone who wants it.
+    await this.#started.catch(() => {});
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    // An in-flight run holds a browser, so closing has to stop it rather than walk away from it.
+    if (this.#started) await this.abort();
+    this.#channel.close();
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.close();
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<RunEvent> {
+    // The first read is what starts the run — see the laziness note on `RunSession`.
+    void this.#start().catch(() => {});
+    const inner = this.#channel[Symbol.asyncIterator]();
+
+    return {
+      next: () => inner.next(),
+      return: async (): Promise<IteratorResult<RunEvent>> => {
+        // `break` out of a for-await closes the session, for the same reason it does on a watch
+        // session: a browser left running after its reader stopped is never what was meant.
+        await this.close();
+
+        return { done: true, value: undefined };
+      },
+    };
+  }
+
+  /** Runs, exactly once, and answers with the result every caller shares. */
+  #start(): Promise<RunResult> {
+    if (this.#started) return this.#started;
+    if (this.#closed) {
+      // Aborted or closed before it ever ran: answer with the empty result rather than launch a
+      // browser nobody is waiting for. The counts are zeroes, `aborted` says why.
+      this.#started = Promise.resolve(abortedBeforeStart(this.#config, this.#reporting));
+
+      return this.#started;
+    }
+
+    this.#started = Run.run(this.#config).then((outcome) => {
+      const result = this.#snapshot(outcome);
+      this.#channel.push({ kind: 'runEnd', result });
+      this.#channel.close();
+
+      return result;
+    });
+    // The run's own rejection is delivered through `result()`; this keeps a session that nobody
+    // awaited from taking the process down with an unhandled rejection.
+    this.#started.catch(() => this.#channel.close());
+
+    return this.#started;
+  }
+
+  #snapshot(outcome: Run.RunOutcome): RunResult {
+    return buildResult(
+      this.#config,
+      outcome,
+      this.#reporting.collector,
+      junitXml(this.#reporting.reporters),
+    );
+  }
+}

--- a/lib/api/watch.ts
+++ b/lib/api/watch.ts
@@ -75,12 +75,16 @@ export function watch(
     const reporting = resolveReporting(resolved);
     const configOptions = toConfigOptions(resolved, reporting);
     const config = unwrap(await Config.setup({ ...configOptions, watch: true }).result());
+    const begunAt = Date.now();
     const inner = await Run.watch(config);
 
     // Snapshotted here, before the session installs its own rerun listener: the initial run has
     // already finished by the time `Run.watch` resolves, so it has no listener to fire and would
     // otherwise be the one result that never reaches the iterator.
-    return new Session(inner, config, reporting, snapshot(config, reporting));
+    // The initial run's duration is the one number this path cannot recover after the fact —
+    // `Run.watch` has already returned by the time the session exists — so it is measured here,
+    // around the call that performs it.
+    return new Session(inner, config, reporting, snapshot(config, reporting, Date.now() - begunAt));
   });
 }
 
@@ -116,7 +120,9 @@ class Session implements WatchSession {
     this.#queued = [initial];
     // Every rerun goes through the same reporters, and `onRunEnd` is the last thing a run does —
     // which makes it the one honest signal that a result is complete and ready to snapshot.
-    reporting.reporters.push({ onRunEnd: () => this.#publish() });
+    reporting.reporters.push({
+      onRunEnd: (_config, info) => this.#publish(info.durationMs),
+    });
   }
 
   get url(): string {
@@ -125,11 +131,12 @@ class Session implements WatchSession {
 
   async rerun(files?: string[]): Promise<RunResult> {
     const before = this.#published;
+    const startedAt = Date.now();
     await this.#inner.rerun(files);
     // A rerun that died in the bundler never reaches `onRunEnd`, so nothing was published.
     // Snapshot it anyway: the build error is on the result as a notice, which is precisely what
     // the caller needs, and returning the *previous* run's result would be a lie.
-    if (this.#published === before) this.#publish();
+    if (this.#published === before) this.#publish(Date.now() - startedAt);
 
     return this.#latest;
   }
@@ -165,9 +172,9 @@ class Session implements WatchSession {
   }
 
   /** Hands a finished run to whoever is iterating, or queues it until someone is. */
-  #publish(): void {
+  #publish(durationMs: number): void {
     this.#published++;
-    this.#latest = snapshot(this.#config, this.#reporting);
+    this.#latest = snapshot(this.#config, this.#reporting, durationMs);
     if (!this.#waiting) return void this.#queued.push(this.#latest);
 
     const resolve = this.#waiting;
@@ -183,11 +190,16 @@ class Session implements WatchSession {
  * nothing exits — but "did this rerun pass" is exactly as meaningful, and is the same question
  * `failCount` answers for the batch runner.
  */
-function snapshot(config: ResolvedConfig, reporting: ResolvedReporting): RunResult {
+function snapshot(
+  config: ResolvedConfig,
+  reporting: ResolvedReporting,
+  durationMs: number,
+): RunResult {
   const failed = config.state.results.counter.failCount > 0;
+  const finishedAt = Date.now();
   const result = buildResult(
     config,
-    { exitCode: failed ? 1 : 0, durationMs: 0 },
+    { exitCode: failed ? 1 : 0, durationMs, startedAt: finishedAt - durationMs, finishedAt },
     reporting.collector,
     junitXml(reporting.reporters),
   );

--- a/lib/api/watch.ts
+++ b/lib/api/watch.ts
@@ -1,0 +1,196 @@
+import * as Config from '../setup/config.ts';
+import * as Run from '../commands/run.ts';
+import { Task } from '../task/index.ts';
+import { unwrap } from '../result/result.ts';
+import { buildResult, type Collector, type RunResult } from './result.ts';
+import { normalizeOptions, resolveReporting, toConfigOptions, type RunOptions } from './options.ts';
+import { junitXml, type RunFailure } from './run.ts';
+import type { Reporter } from '../reporters/types.ts';
+import type { Config as ResolvedConfig } from '../types.ts';
+
+/** The reporter set plus the collector results are built from — what a session snapshots. */
+interface Reporting {
+  reporters: Reporter[];
+  collector: Collector;
+}
+
+/**
+ * A running watch session.
+ *
+ * Async-iterable, and that is the intended way to consume it: `for await (const result of
+ * session)` yields the initial run and then one {@link RunResult} per rerun, in order, ending
+ * when the session is closed. Every element is a complete result — counters, tests, diagnostics
+ * — rather than a delta, so nothing has to be accumulated to know where the suite stands.
+ *
+ * One consumer at a time. Two concurrent `for await` loops would race for each result rather
+ * than both seeing it; if you need to fan out, do it inside the one loop.
+ *
+ * ```ts
+ * // Defined, not invoked: a real session holds a browser open.
+ * async function untilGreen(session: WatchSession) {
+ *   for await (const result of session) {
+ *     if (result.ok) break; // breaking out closes the session
+ *   }
+ * }
+ * ```
+ */
+export interface WatchSession extends AsyncIterable<RunResult> {
+  /** Where the QUnit view is being served, e.g. `http://localhost:1234`. */
+  readonly url: string;
+  /** The initial run's result, available before anything has changed on disk. */
+  readonly initial: RunResult;
+  /** Re-runs now, optionally scoped to `files`, and resolves with that run's result. */
+  rerun(files?: string[]): Promise<RunResult>;
+  /** Stops watching, closes the browser and server, and ends the iteration. Idempotent. */
+  close(): Promise<void>;
+}
+
+/**
+ * Starts a watch session: builds once, runs once, then re-runs on every save until closed.
+ *
+ * Resolves as soon as that first run has finished and the watchers are armed, so there is no
+ * window in which a save could be missed. The process then stays alive because the session holds
+ * a browser and a bound port — `close()` is what releases both.
+ *
+ * Unlike the CLI's `--watch`, nothing is bound to stdin: no keyboard shortcuts are installed and
+ * the host's terminal is left alone.
+ *
+ * ```ts
+ * import { watch } from './watch.ts';
+ *
+ * // Defined, not invoked: launches a browser and leaves it watching.
+ * async function watchCart() {
+ *   const session = await watch({ inputs: ['test/'] });
+ *   await session.close();
+ *   return session.initial.counts.total;
+ * }
+ * ```
+ */
+export function watch(
+  options: RunOptions | string | string[] = {},
+): Task<WatchSession, RunFailure> {
+  return Task(async () => {
+    const resolved = normalizeOptions(options);
+    const reporting = resolveReporting(resolved);
+    const configOptions = toConfigOptions(resolved, reporting);
+    const config = unwrap(await Config.setup({ ...configOptions, watch: true }).result());
+    const inner = await Run.watch(config);
+
+    // Snapshotted here, before the session installs its own rerun listener: the initial run has
+    // already finished by the time `Run.watch` resolves, so it has no listener to fire and would
+    // otherwise be the one result that never reaches the iterator.
+    return new Session(inner, config, reporting, snapshot(config, reporting));
+  });
+}
+
+/**
+ * The live session. A class rather than an object literal because it owns a queue: reruns the
+ * *file watcher* triggers have no caller to hand a result to, so they are buffered for whoever
+ * is iterating — and a consumer that arrives late still sees every one of them.
+ */
+class Session implements WatchSession {
+  readonly initial: RunResult;
+  #inner: Run.WatchSession;
+  #config: ResolvedConfig;
+  #reporting: Reporting;
+  #queued: RunResult[];
+  #waiting: ((result: IteratorResult<RunResult>) => void) | null = null;
+  #latest: RunResult;
+  #published = 0;
+  #closed = false;
+
+  constructor(
+    inner: Run.WatchSession,
+    config: ResolvedConfig,
+    reporting: Reporting,
+    initial: RunResult,
+  ) {
+    this.#inner = inner;
+    this.#config = config;
+    this.#reporting = reporting;
+    this.initial = initial;
+    this.#latest = initial;
+    // The initial run is the iteration's first element, so a `for await` sees the whole history
+    // rather than starting from whatever happens to change next.
+    this.#queued = [initial];
+    // Every rerun goes through the same reporters, and `onRunEnd` is the last thing a run does —
+    // which makes it the one honest signal that a result is complete and ready to snapshot.
+    reporting.reporters.push({ onRunEnd: () => this.#publish() });
+  }
+
+  get url(): string {
+    return this.#inner.url;
+  }
+
+  async rerun(files?: string[]): Promise<RunResult> {
+    const before = this.#published;
+    await this.#inner.rerun(files);
+    // A rerun that died in the bundler never reaches `onRunEnd`, so nothing was published.
+    // Snapshot it anyway: the build error is on the result as a notice, which is precisely what
+    // the caller needs, and returning the *previous* run's result would be a lie.
+    if (this.#published === before) this.#publish();
+
+    return this.#latest;
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    await this.#inner.close();
+    // Wake a consumer parked on a rerun that is never going to come.
+    this.#waiting?.({ done: true, value: undefined });
+    this.#waiting = null;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<RunResult> {
+    return {
+      next: (): Promise<IteratorResult<RunResult>> => {
+        // Queue first, even when closed: results that arrived before shutdown are still results,
+        // and dropping them would make `close()` racy from the consumer's point of view.
+        const queued = this.#queued.shift();
+        if (queued) return Promise.resolve({ done: false, value: queued });
+        if (this.#closed) return Promise.resolve({ done: true, value: undefined });
+
+        return new Promise((resolve) => (this.#waiting = resolve));
+      },
+      return: async (): Promise<IteratorResult<RunResult>> => {
+        // `break` out of a for-await closes the session: leaving a browser running after the
+        // loop that was reading it has stopped is never what was meant.
+        await this.close();
+
+        return { done: true, value: undefined };
+      },
+    };
+  }
+
+  /** Hands a finished run to whoever is iterating, or queues it until someone is. */
+  #publish(): void {
+    this.#published++;
+    this.#latest = snapshot(this.#config, this.#reporting);
+    if (!this.#waiting) return void this.#queued.push(this.#latest);
+
+    const resolve = this.#waiting;
+    this.#waiting = null;
+    resolve({ done: false, value: this.#latest });
+  }
+}
+
+/**
+ * Freezes the run that just finished into a result, then clears the collector for the next one.
+ *
+ * The exit code is derived here rather than carried in: a watch rerun has no exit code, because
+ * nothing exits — but "did this rerun pass" is exactly as meaningful, and is the same question
+ * `failCount` answers for the batch runner.
+ */
+function snapshot(config: ResolvedConfig, reporting: Reporting): RunResult {
+  const failed = config.state.results.counter.failCount > 0;
+  const result = buildResult(
+    config,
+    { exitCode: failed ? 1 : 0, durationMs: 0 },
+    reporting.collector,
+    junitXml(reporting.reporters),
+  );
+  reporting.collector.reset();
+
+  return result;
+}

--- a/lib/api/watch.ts
+++ b/lib/api/watch.ts
@@ -3,6 +3,7 @@ import * as Run from '../commands/run.ts';
 import { Task } from '../task/index.ts';
 import { unwrap } from '../result/result.ts';
 import { buildResult, type RunResult } from './result.ts';
+import { Channel, eventReporter, type RunEvent } from './events.ts';
 import {
   normalizeOptions,
   resolveReporting,
@@ -39,8 +40,51 @@ export interface WatchSession extends AsyncIterable<RunResult> {
   readonly url: string;
   /** The initial run's result, available before anything has changed on disk. */
   readonly initial: RunResult;
+  /**
+   * The most recent run's result — `initial` until something re-runs.
+   *
+   * The session's current state, readable without consuming the iteration. A UI redrawing for
+   * some reason of its own (a resize, a keystroke) needs the last result again, and taking it
+   * from the iterator would steal it from the loop that is driving the redraws.
+   */
+  readonly latest: RunResult;
+  /** Whether a run is in flight right now. */
+  readonly running: boolean;
   /** Re-runs now, optionally scoped to `files`, and resolves with that run's result. */
-  rerun(files?: string[]): Promise<RunResult>;
+  run(files?: string[]): Promise<RunResult>;
+  /**
+   * Runs the whole suite, dropping any line-target selectors this session was scoped to.
+   *
+   * Not the same as `run()`: a session started from `test/cart-test.ts#34` stays pinned to that
+   * line until something clears the pin, and only this clears it. `-t`/`-m` survive — those are a
+   * standing instruction about which tests to run rather than a starting point.
+   */
+  runAll(): Promise<RunResult>;
+  /**
+   * Re-runs the files that last failed, or repeats the last run when nothing has failed yet —
+   * saying so as an `info` notice on the result rather than silently doing something else.
+   */
+  runFailed(): Promise<RunResult>;
+  /**
+   * Cuts the current run short: the browser drops the rest of its queue and the run ends where it
+   * is, with `aborted: true` on its result.
+   *
+   * Resolves once the interrupted run has settled, so `await session.abort()` leaves the session
+   * idle and ready for the next verb. Aborting while nothing is running is a no-op.
+   */
+  abort(): Promise<void>;
+  /**
+   * The fine-grained feed: every event of every run, flat and in order, until the session closes.
+   *
+   * The same events for a watch session as for a single run, so a UI written against one works
+   * against the other — `runStart` … `test` … `runEnd`, then again for the next rerun. Iterating
+   * the session itself gives the coarse view (one complete result per rerun); this gives the view
+   * a progress bar needs.
+   *
+   * Buffers from the first call, not from the first read, so events between calling this and
+   * starting to iterate are not lost. One consumer, like the session's own iteration.
+   */
+  events(): AsyncIterable<RunEvent>;
   /** Stops watching, closes the browser and server, and ends the iteration. Idempotent. */
   close(): Promise<void>;
 }
@@ -53,7 +97,10 @@ export interface WatchSession extends AsyncIterable<RunResult> {
  * a browser and a bound port — `close()` is what releases both.
  *
  * Unlike the CLI's `--watch`, nothing is bound to stdin: no keyboard shortcuts are installed and
- * the host's terminal is left alone.
+ * the host's terminal is left alone. The behaviours behind those shortcuts are still here as
+ * {@link WatchSession.runAll}, {@link WatchSession.runFailed} and {@link WatchSession.abort} —
+ * the CLI binds keys to the same methods, so a terminal UI built on this API is not reimplementing
+ * them.
  *
  * ```ts
  * import { watch } from './watch.ts';
@@ -84,7 +131,21 @@ export function watch(
     // The initial run's duration is the one number this path cannot recover after the fact —
     // `Run.watch` has already returned by the time the session exists — so it is measured here,
     // around the call that performs it.
-    return new Session(inner, config, reporting, snapshot(config, reporting, Date.now() - begunAt));
+    const session = new Session(
+      inner,
+      config,
+      reporting,
+      snapshot(config, reporting, Date.now() - begunAt),
+    );
+    // For a watch session `signal` means "stop watching" — there is no single run to cut short,
+    // and the session's own `abort()` covers the one in flight. An already-aborted signal still
+    // pays for the initial run, because the session's contract is that `initial` is a real result.
+    if (resolved.signal) {
+      if (resolved.signal.aborted) await session.close();
+      else resolved.signal.addEventListener('abort', () => void session.close(), { once: true });
+    }
+
+    return session;
   });
 }
 
@@ -98,8 +159,8 @@ class Session implements WatchSession {
   #inner: Run.WatchSession;
   #config: ResolvedConfig;
   #reporting: ResolvedReporting;
-  #queued: RunResult[];
-  #waiting: ((result: IteratorResult<RunResult>) => void) | null = null;
+  #results = new Channel<RunResult>();
+  #events: Channel<RunEvent> | null = null;
   #latest: RunResult;
   #published = 0;
   #closed = false;
@@ -117,7 +178,7 @@ class Session implements WatchSession {
     this.#latest = initial;
     // The initial run is the iteration's first element, so a `for await` sees the whole history
     // rather than starting from whatever happens to change next.
-    this.#queued = [initial];
+    this.#results.push(initial);
     // Every rerun goes through the same reporters, and `onRunEnd` is the last thing a run does —
     // which makes it the one honest signal that a result is complete and ready to snapshot.
     reporting.reporters.push({
@@ -129,38 +190,59 @@ class Session implements WatchSession {
     return this.#inner.url;
   }
 
-  async rerun(files?: string[]): Promise<RunResult> {
-    const before = this.#published;
-    const startedAt = Date.now();
-    await this.#inner.rerun(files);
-    // A rerun that died in the bundler never reaches `onRunEnd`, so nothing was published.
-    // Snapshot it anyway: the build error is on the result as a notice, which is precisely what
-    // the caller needs, and returning the *previous* run's result would be a lie.
-    if (this.#published === before) this.#publish(Date.now() - startedAt);
-
+  get latest(): RunResult {
     return this.#latest;
+  }
+
+  get running(): boolean {
+    return this.#inner.running;
+  }
+
+  run(files?: string[]): Promise<RunResult> {
+    return this.#drive(() => this.#inner.run(files));
+  }
+
+  runAll(): Promise<RunResult> {
+    return this.#drive(() => this.#inner.runAll());
+  }
+
+  runFailed(): Promise<RunResult> {
+    return this.#drive(() => this.#inner.runFailed());
+  }
+
+  async abort(): Promise<void> {
+    this.#inner.abort();
+    // Waiting for quiet, NOT driving a run: the interrupted run publishes its own truncated
+    // result through `onRunEnd` like any other, and `#drive` would have manufactured a second,
+    // empty one for an abort that arrived while nothing was running.
+    await this.#inner.settled();
+  }
+
+  events(): AsyncIterable<RunEvent> {
+    // Attached on the first call and kept: a second call must not hand back a feed that starts
+    // mid-run, and attaching a second reporter would double every event on the first feed.
+    if (!this.#events) {
+      const channel = new Channel<RunEvent>();
+      this.#events = channel;
+      this.#reporting.reporters.push(eventReporter(channel));
+    }
+
+    return this.#events;
   }
 
   async close(): Promise<void> {
     if (this.#closed) return;
     this.#closed = true;
     await this.#inner.close();
-    // Wake a consumer parked on a rerun that is never going to come.
-    this.#waiting?.({ done: true, value: undefined });
-    this.#waiting = null;
+    this.#results.close();
+    this.#events?.close();
   }
 
   [Symbol.asyncIterator](): AsyncIterator<RunResult> {
-    return {
-      next: (): Promise<IteratorResult<RunResult>> => {
-        // Queue first, even when closed: results that arrived before shutdown are still results,
-        // and dropping them would make `close()` racy from the consumer's point of view.
-        const queued = this.#queued.shift();
-        if (queued) return Promise.resolve({ done: false, value: queued });
-        if (this.#closed) return Promise.resolve({ done: true, value: undefined });
+    const inner = this.#results[Symbol.asyncIterator]();
 
-        return new Promise((resolve) => (this.#waiting = resolve));
-      },
+    return {
+      next: () => inner.next(),
       return: async (): Promise<IteratorResult<RunResult>> => {
         // `break` out of a for-await closes the session: leaving a browser running after the
         // loop that was reading it has stopped is never what was meant.
@@ -171,15 +253,29 @@ class Session implements WatchSession {
     };
   }
 
+  /**
+   * Runs one verb and answers with the result it produced.
+   *
+   * The `#published` comparison is what makes that "the result it produced" rather than "whatever
+   * is latest": a rerun that died in the bundler never reaches `onRunEnd`, so nothing was
+   * published, and returning the previous run's result would report a build error as the last
+   * green run.
+   */
+  async #drive(verb: () => Promise<void>): Promise<RunResult> {
+    const before = this.#published;
+    const startedAt = Date.now();
+    await verb();
+    if (this.#published === before) this.#publish(Date.now() - startedAt);
+
+    return this.#latest;
+  }
+
   /** Hands a finished run to whoever is iterating, or queues it until someone is. */
   #publish(durationMs: number): void {
     this.#published++;
     this.#latest = snapshot(this.#config, this.#reporting, durationMs);
-    if (!this.#waiting) return void this.#queued.push(this.#latest);
-
-    const resolve = this.#waiting;
-    this.#waiting = null;
-    resolve({ done: false, value: this.#latest });
+    this.#results.push(this.#latest);
+    this.#events?.push({ kind: 'runEnd', result: this.#latest });
   }
 }
 

--- a/lib/api/watch.ts
+++ b/lib/api/watch.ts
@@ -3,7 +3,13 @@ import * as Run from '../commands/run.ts';
 import { Task } from '../task/index.ts';
 import { unwrap } from '../result/result.ts';
 import { buildResult, type Collector, type RunResult } from './result.ts';
-import { normalizeOptions, resolveReporting, toConfigOptions, type RunOptions } from './options.ts';
+import {
+  normalizeOptions,
+  resolveReporting,
+  toConfigOptions,
+  validate,
+  type RunOptions,
+} from './options.ts';
 import { junitXml, type RunFailure } from './run.ts';
 import type { Reporter } from '../reporters/types.ts';
 import type { Config as ResolvedConfig } from '../types.ts';
@@ -71,6 +77,7 @@ export function watch(
 ): Task<WatchSession, RunFailure> {
   return Task(async () => {
     const resolved = normalizeOptions(options);
+    validate(resolved);
     const reporting = resolveReporting(resolved);
     const configOptions = toConfigOptions(resolved, reporting);
     const config = unwrap(await Config.setup({ ...configOptions, watch: true }).result());

--- a/lib/api/watch.ts
+++ b/lib/api/watch.ts
@@ -2,23 +2,17 @@ import * as Config from '../setup/config.ts';
 import * as Run from '../commands/run.ts';
 import { Task } from '../task/index.ts';
 import { unwrap } from '../result/result.ts';
-import { buildResult, type Collector, type RunResult } from './result.ts';
+import { buildResult, type RunResult } from './result.ts';
 import {
   normalizeOptions,
   resolveReporting,
   toConfigOptions,
   validate,
+  type ResolvedReporting,
   type RunOptions,
 } from './options.ts';
 import { junitXml, type RunFailure } from './run.ts';
-import type { Reporter } from '../reporters/types.ts';
 import type { Config as ResolvedConfig } from '../types.ts';
-
-/** The reporter set plus the collector results are built from — what a session snapshots. */
-interface Reporting {
-  reporters: Reporter[];
-  collector: Collector;
-}
 
 /**
  * A running watch session.
@@ -99,7 +93,7 @@ class Session implements WatchSession {
   readonly initial: RunResult;
   #inner: Run.WatchSession;
   #config: ResolvedConfig;
-  #reporting: Reporting;
+  #reporting: ResolvedReporting;
   #queued: RunResult[];
   #waiting: ((result: IteratorResult<RunResult>) => void) | null = null;
   #latest: RunResult;
@@ -109,7 +103,7 @@ class Session implements WatchSession {
   constructor(
     inner: Run.WatchSession,
     config: ResolvedConfig,
-    reporting: Reporting,
+    reporting: ResolvedReporting,
     initial: RunResult,
   ) {
     this.#inner = inner;
@@ -189,7 +183,7 @@ class Session implements WatchSession {
  * nothing exits — but "did this rerun pass" is exactly as meaningful, and is the same question
  * `failCount` answers for the batch runner.
  */
-function snapshot(config: ResolvedConfig, reporting: Reporting): RunResult {
+function snapshot(config: ResolvedConfig, reporting: ResolvedReporting): RunResult {
   const failed = config.state.results.counter.failCount > 0;
   const result = buildResult(
     config,

--- a/lib/args/index.ts
+++ b/lib/args/index.ts
@@ -1,5 +1,5 @@
 // Barrel assembling the `Args` namespace: import * as Args from '.../args/index.ts'.
-export { parse, InvalidFlag } from './parse.ts';
-export type { ParseFailure } from './parse.ts';
+export { parse, applyInputs, InvalidFlag } from './parse.ts';
+export type { ParseFailure, ParsedFlags } from './parse.ts';
 export { tokenize } from './tokenize.ts';
 export type { ArgToken, QueryToken, FlagToken, InputToken } from './tokenize.ts';

--- a/lib/args/parse.ts
+++ b/lib/args/parse.ts
@@ -64,7 +64,7 @@ const FILE_LOOKING = /\.(js|ts|jsx|tsx|html)$/;
  * ```
  */
 // { inputs: [], debug: true, watch: true, open: true, failFast: true, onlyFailed: true, htmlPaths: [], output }
-interface ParsedFlags {
+export interface ParsedFlags {
   inputs: string[];
   debug?: boolean;
   watch?: boolean;
@@ -94,42 +94,49 @@ interface ParsedFlags {
 }
 
 /**
- * Parses `process.argv` into a qunitx flag object (`inputs`, `debug`, `watch`, `failFast`, `timeout`, `output`, `port`, `before`, `after`).
+ * Parses an argv into a qunitx flag object (`inputs`, `debug`, `watch`, `failFast`, `timeout`, `output`, `port`, `before`, `after`).
+ *
+ * `argv` and `cwd` default to the live process, which is the CLI's call. They are parameters
+ * rather than reads so the daemon and the JS API can parse someone else's invocation without
+ * borrowing process globals to do it.
  *
  * ```ts
  * import * as Args from './index.ts';
  *
- * // Defined, not invoked: reads the live process.argv.
- * function example(projectRoot: string) {
- *   const parsed = Args.parse(projectRoot); // ParsedFlags | ParseFailure — a bad flag reports, never exits
- *   return Args.InvalidFlag.is(parsed) ? parsed.code : parsed.inputs; // 'InvalidFlag' | absolute inputs
- * }
+ * const parsed = Args.parse('/proj', ['--timeout=5000'], '/proj');
+ * Args.InvalidFlag.is(parsed) ? parsed.code : parsed.timeout; // 5000
  * ```
  * @returns {object}
  */
-export function parse(projectRoot: string): Result<ParsedFlags, ParseFailure> {
-  const providedFlags = { inputs: new Set<string>() } as ParsedFlags & { inputs: Set<string> };
+export function parse(
+  projectRoot: string,
+  argv: readonly string[] = process.argv.slice(2),
+  cwd: string = process.cwd(),
+): Result<ParsedFlags, ParseFailure> {
+  const flags: ParsedFlags = { inputs: [] };
+  const positional: string[] = [];
   // The tokenizer owns how many argv entries a query flag swallows (see tokenize.ts); this
   // loop only interprets the resulting tokens. Query values and inputs are their own token kinds,
   // so the flag chain below never has to guess whether a bare word is a value or a path.
-  for (const token of tokenize(process.argv.slice(2))) {
+  for (const token of tokenize(argv)) {
     if (token.kind === 'query') {
-      applyQuery(providedFlags, token);
+      applyQuery(flags, token);
     } else if (token.kind === 'input') {
-      addInput(providedFlags, projectRoot, token.raw);
+      positional.push(token.raw);
     } else {
       // First bad flag wins, matching the previous exit-on-first-error behaviour. Collecting
       // every complaint would be a different (and arguably better) UX, but it is not what the
       // exits did and is not this change's business.
-      const failed = applyFlag(providedFlags, token.raw);
+      const failed = applyFlag(flags, token.raw);
       if (failed) return failed;
     }
   }
+  applyInputs(flags, projectRoot, cwd, positional);
 
   // QUNITX_BROWSER env var is a lower-priority fallback: --browser flag wins if present.
   // Setting it in the environment lets all spawned child processes inherit the browser
   // without needing to pass --browser on every CLI invocation.
-  if (!providedFlags.browser && process.env.QUNITX_BROWSER) {
+  if (!flags.browser && process.env.QUNITX_BROWSER) {
     const envBrowser = process.env.QUNITX_BROWSER;
     if (!BROWSERS.includes(envBrowser)) {
       return InvalidFlag({
@@ -138,26 +145,53 @@ export function parse(projectRoot: string): Result<ParsedFlags, ParseFailure> {
         expected: `Must be one of: ${BROWSERS.join(', ')}`,
       });
     }
-    providedFlags.browser = envBrowser as 'chromium' | 'firefox' | 'webkit';
+    flags.browser = envBrowser as 'chromium' | 'firefox' | 'webkit';
   }
 
   // QUNITX_DEBUG env mirrors --debug: lower-priority than the explicit flag so
   // `--debug=false` still wins per-invocation. Lets CI / scripts opt every child
   // process into debug TAP comments without rewriting commands.
-  if (providedFlags.debug === undefined && process.env.QUNITX_DEBUG) {
-    providedFlags.debug = true;
+  if (flags.debug === undefined && process.env.QUNITX_DEBUG) {
+    flags.debug = true;
   }
 
-  return { ...providedFlags, inputs: Array.from(providedFlags.inputs) };
+  return flags;
 }
 
-type Flags = ParsedFlags & { inputs: Set<string> };
+/**
+ * Classifies raw positional targets into `flags`, exactly as the CLI does with argv positionals:
+ * `.html` fixtures become `htmlPaths`, a trailing `#34`/`:34` becomes a `lineTargets` entry, and
+ * everything else is an absolute path in `inputs` (deduplicated) plus a `wholeInputPaths` mention.
+ *
+ * Shared with the JS API so `run({ inputs: ['test/cart-test.ts#34'] })` means precisely what
+ * `qunitx test/cart-test.ts#34` means — the same targeting grammar, resolved by the same code.
+ * Idempotent for already-absolute inputs, so re-normalizing a parsed flag object is safe.
+ *
+ * ```ts
+ * import * as Args from './index.ts';
+ *
+ * const flags = Args.applyInputs({ inputs: [] }, '/proj', '/proj', ['test/a-test.ts#4']);
+ * flags.lineTargets; // { '/proj/test/a-test.ts': [4] } — the bare path still lands in `inputs`
+ * ```
+ */
+export function applyInputs(
+  flags: ParsedFlags,
+  projectRoot: string,
+  cwd: string,
+  positional: readonly string[],
+): ParsedFlags {
+  const inputs = new Set(flags.inputs);
+  for (const raw of positional) addInput(flags, inputs, projectRoot, cwd, raw);
+  flags.inputs = Array.from(inputs);
+
+  return flags;
+}
 
 /**
  * Interprets one non-query flag token (`token.raw` verbatim). This is the original prefix/`=`
  * matching chain, unchanged — the tokenizer only lifted `-t`/`-m` and positional inputs out of it.
  */
-function applyFlag(result: Flags, arg: string): ParseFailure | undefined {
+function applyFlag(result: ParsedFlags, arg: string): ParseFailure | undefined {
   // Every value flag reads the same `=`-suffix, so split once here. A bare boolean flag has no
   // suffix (value === undefined) and falls back to true via parseBoolean.
   const value = arg.split('=')[1];
@@ -271,7 +305,13 @@ function applyFlag(result: Flags, arg: string): ParseFailure | undefined {
 }
 
 /** Adds a positional target: an `.html` fixture, or a test path with an optional `#34` line suffix. */
-function addInput(result: Flags, projectRoot: string, arg: string): void {
+function addInput(
+  result: ParsedFlags,
+  inputs: Set<string>,
+  projectRoot: string,
+  cwd: string,
+  arg: string,
+): void {
   if (arg.endsWith('.html')) {
     (result.htmlPaths ??= []).push(arg);
     return;
@@ -286,7 +326,7 @@ function addInput(result: Flags, projectRoot: string, arg: string): void {
   const absolutePath = path.normalize(
     filePath.startsWith(projectRoot) || path.isAbsolute(filePath)
       ? filePath
-      : path.join(process.cwd(), filePath),
+      : path.join(cwd, filePath),
   );
   if (line !== null) {
     result.lineTargets = result.lineTargets ?? {};
@@ -298,7 +338,7 @@ function addInput(result: Flags, projectRoot: string, arg: string): void {
     // one entry, losing the fact that a whole-file mention was made.
     (result.wholeInputPaths ??= []).push(absolutePath);
   }
-  result.inputs.add(absolutePath);
+  inputs.add(absolutePath);
 }
 
 /**
@@ -306,7 +346,7 @@ function addInput(result: Flags, projectRoot: string, arg: string): void {
  * second one overrides the first (last-wins, as for any repeated scalar flag) — but says so rather
  * than silently dropping the earlier expression.
  */
-function applyQuery(result: Flags, token: QueryToken): void {
+function applyQuery(result: ParsedFlags, token: QueryToken): void {
   if (token.action === 'list') {
     // A bare --search/--print (no expression) lists everything; run.ts falls back to `filter`.
     result.search = token.value ?? true;

--- a/lib/args/parse.ts
+++ b/lib/args/parse.ts
@@ -22,7 +22,10 @@ import { type Result, Failure } from '../result/index.ts';
  * failure.data.flag; // '--port' — typed payload, no message parsing
  * ```
  */
-export const InvalidFlag = Failure.define(
+export const InvalidFlag: Failure.FailureFactory<
+  'InvalidFlag',
+  { flag: string; value: string; expected: string }
+> = Failure.define(
   'InvalidFlag',
   (data: { flag: string; value: string; expected: string }) =>
     `Invalid ${data.flag} value: "${data.value}". ${data.expected}`,

--- a/lib/args/parse.ts
+++ b/lib/args/parse.ts
@@ -63,31 +63,53 @@ const FILE_LOOKING = /\.(js|ts|jsx|tsx|html)$/;
  * }
  * ```
  */
-// { inputs: [], debug: true, watch: true, open: true, failFast: true, onlyFailed: true, htmlPaths: [], output }
 export interface ParsedFlags {
+  /** Absolute paths of the test targets, deduplicated. `.html` fixtures and `#line` suffixes
+   * are split out into `htmlPaths` and `lineTargets` rather than kept here. */
   inputs: string[];
+  /** `--debug`/`--console`: print the server URL and forward the page's console. */
   debug?: boolean;
+  /** `--watch`/`-w`: re-run on every save instead of exiting after one run. */
   watch?: boolean;
+  /** `--open`/`-o`: open the output in a browser; a string names a specific binary. */
   open?: boolean | string;
+  /** `--failFast`: stop at the first failing test. */
   failFast?: boolean;
+  /** `--only-failed`/`-f`: run only the files that failed on the previous run. */
   onlyFailed?: boolean;
+  /** `--timeout`: milliseconds a single test may take before the run is declared stalled. */
   timeout?: number;
+  /** `--output`: directory for the compiled bundle and HTML. */
   output?: string;
+  /** Positional `.html` fixtures the test bundle is injected into. */
   htmlPaths?: string[];
+  /** `--port`/`-p`: the port the local test server listens on. */
   port?: number;
+  /** `true` when `--port` was given explicitly, so a busy port fails instead of incrementing. */
   portExplicit?: boolean;
+  /** `--extensions`: file extensions treated as test files. */
   extensions?: string[];
+  /** `--browser`: the engine to run in. */
   browser?: 'chromium' | 'firefox' | 'webkit';
+  /** `--before`: module run before the tests, or `false` to disable a configured one. */
   before?: string | false;
+  /** `--after`: module run after the tests, or `false` to disable a configured one. */
   after?: string | false;
+  /** `--since`/`--changed`: run only files whose transitive imports changed since this git ref. */
   changedSince?: string;
+  /** `--reporter`/`-r`: the single stdout format. */
   reporter?: ReporterName;
+  /** `--junit`: write a JUnit report. `true` uses the default path; a string overrides it. */
   junit?: boolean | string;
+  /** `--coverage`: collect V8 line coverage. */
   coverage?: boolean;
+  /** Artifact formats beyond the terminal summary (`lcov`, `html`). */
   coverageFormats?: string[];
+  /** `-t`/`--filter`/`-m`/`--module`/`-n`: the one test-name matcher, in QUnit's own semantics. */
   filter?: string;
   /** `--search`/`--print` mode: the expression to preview, or `true` to list everything. */
   search?: string | true;
+  /** Absolute path → the `#34` line targets given for it. */
   lineTargets?: Record<string, number[]>;
   /** Absolute paths mentioned WITHOUT a line target — whole-file requests that supersede a line target. */
   wholeInputPaths?: string[];

--- a/lib/args/tokenize.ts
+++ b/lib/args/tokenize.ts
@@ -118,7 +118,7 @@ export type ArgToken = QueryToken | FlagToken | InputToken;
  * Args.tokenize(['-t', 'a b', '--', 'test/cart-test.ts']).at(-1); // { kind: 'input', raw: 'test/cart-test.ts' }
  * ```
  */
-export function tokenize(args: string[]): ArgToken[] {
+export function tokenize(args: readonly string[]): ArgToken[] {
   // The fold carries two bits of cross-entry state: `rest` (past the `--` marker, everything is a
   // positional input) and `greedy` (the bare query flag currently absorbing following words — held
   // by reference so its value grows in place, no rescan or post-pass join needed).

--- a/lib/chrome/prelaunch.ts
+++ b/lib/chrome/prelaunch.ts
@@ -5,63 +5,16 @@ import { killProcessGroup } from '../utils/kill-process-group.ts';
 import { CHROMIUM_ARGS } from './chromium-args.ts';
 import { perfLog } from '../utils/perf-log.ts';
 import * as Paths from '../commands/daemon/paths.ts';
-import type { ChromeHandle } from '../types.ts';
+import type { ChromeHandle, EarlyChrome } from '../types.ts';
 
-// This module is statically imported by cli.ts so its module-level code runs
-// at the very start of the process — before the IIFE, before playwright-core loads.
-// For run commands only, Chrome is spawned immediately via CDP so it is ready
-// (or nearly ready) by the time playwright-core finishes loading (~500ms later).
-// For help/init/generate, nothing is spawned and this module costs ~0ms.
-
-const NON_RUN_COMMANDS = new Set(['help', 'h', 'p', 'print', 'new', 'n', 'g', 'generate', 'init']);
-const cmd = process.argv[2];
-// `daemon _serve` is the daemon's own process — it DOES need Chrome. Other daemon
-// subcommands (start/stop/status) are pure client ops and never need Chrome.
-const isDaemonControlCmd = cmd === 'daemon' && process.argv[3] !== '_serve';
-const isRunCommand = Boolean(cmd) && !NON_RUN_COMMANDS.has(cmd) && !isDaemonControlCmd;
-// --search/--print lists tests from a static scan and exits — it never opens a browser. It also
-// finishes faster than Chrome's CDP becomes ready, so a prelaunch would not merely be wasted: the
-// shutdown handle does not exist yet when the process exits, leaving an orphaned Chrome and its
-// user-data-dir behind. Not spawning at all is both the fix and the fast path.
-// A deliberately local argv scan rather than the shared tokenizer: this module is statically
-// imported first so Chrome spawns at ~t=5ms, and it stays free of avoidable imports.
-const SEARCH_FLAG = /^(-s|--search|--print|--preview)(=|$)/;
-const { browserFromArgv, openFromArgv, watchFromArgv, searchFromArgv } = process.argv.reduce(
-  (flags, arg) => {
-    if (arg.startsWith('--browser=')) flags.browserFromArgv = arg.slice(10);
-    else if (arg === '--open' || arg === '-o') flags.openFromArgv = true;
-    else if (arg === '--watch' || arg === '-w') flags.watchFromArgv = true;
-    else if (SEARCH_FLAG.test(arg)) flags.searchFromArgv = true;
-    return flags;
-  },
-  // QUNITX_BROWSER env var seeds the default so prelaunch is skipped for firefox/webkit
-  // even when --browser is not passed on the command line (e.g. browser-compat CI).
-  {
-    browserFromArgv: process.env.QUNITX_BROWSER || 'chromium',
-    openFromArgv: false,
-    watchFromArgv: false,
-    searchFromArgv: false,
-  },
-);
-// If the run will go through the daemon (existing socket OR QUNITX_DAEMON=1
-// auto-spawn) and the invocation is daemon-eligible, no local Chrome is needed —
-// skipping the prelaunch saves the ~150ms spawn cost. CI is bypassed by default
-// but QUNITX_DAEMON=1 overrides (mirrors the precedence in client.ts).
-const isDaemonClientRun =
-  isRunCommand &&
-  cmd !== 'daemon' &&
-  !watchFromArgv &&
-  !openFromArgv &&
-  !process.env.QUNITX_NO_DAEMON &&
-  !process.argv.includes('--no-daemon') &&
-  (!process.env.CI || Boolean(process.env.QUNITX_DAEMON)) &&
-  // Check the info file rather than the socket path: on Windows the socket is a named
-  // pipe (\\.\pipe\...), which existsSync cannot see. The info file is always a regular
-  // file in os.tmpdir() and is created/removed in lockstep with the daemon's lifetime.
-  (Boolean(process.env.QUNITX_DAEMON) || existsSync(Paths.info()));
-// With --open --watch, Chrome is left alive after qunitx exits so the visible browser window persists.
-// With --open alone, qunitx exits after tests complete; the detached browser is opened separately.
-const openWatchMode = openFromArgv && watchFromArgv;
+// Chrome pre-launch: spawn the browser via CDP before playwright-core has even finished
+// loading, so its ~150ms start-up hides behind module evaluation instead of following it.
+//
+// Opt-in, via `startPrelaunch()`. It used to run on module evaluation, which was right for the
+// one process that has a qunitx argv and wrong for every other: importing the JS API would
+// sniff the *host's* argv, decide it looked like a run, and spawn a Chrome nobody asked for.
+// `cli.ts` calls this as its first statement, which is the same point in time — everything
+// between is its own static import graph, and playwright-core is not in it.
 
 // The pre-launched Chrome's handle, reachable by the process.on('exit') safety net and
 // shutdownPrelaunch(). Set synchronously the instant Chrome is spawned (via onSpawn below), so it
@@ -70,20 +23,6 @@ const openWatchMode = openFromArgv && watchFromArgv;
 // window where a parent process.exit() between spawn and CDP-ready would orphan Chrome (the
 // detached process group outlives the parent).
 let earlyChrome: ChromeHandle | null = null;
-
-if (!openWatchMode) {
-  process.on('exit', () => {
-    const proc = earlyChrome?.proc;
-    if (proc?.pid == null) return;
-    // Last-resort kill: fires in edge cases where process.exit() is called without going
-    // through shutdownPrelaunch() (e.g. FSTree.build ENOENT, signal kills, daemon
-    // shutdown mid-launch). The normal path calls shutdownPrelaunch() first, so Chrome
-    // is already dead here and this is a no-op. SIGKILL so Chrome cannot stall exit.
-    killProcessGroup(proc.pid);
-  });
-}
-
-perfLog('chrome-prelaunch.ts: module evaluated');
 
 /**
  * Kills the pre-launched Chrome process and awaits its async temp-dir cleanup.
@@ -103,37 +42,138 @@ export async function shutdownPrelaunch(): Promise<void> {
 }
 
 /**
- * Resolves to `{ proc, cdpEndpoint, shutdown }` when Chrome is pre-launched and ready,
- * or `null` if pre-launch was skipped (non-run command, non-chromium browser, or macOS).
- *
- * macOS: pre-launch is skipped because the CI runner installs playwright-core's
- * chromium-headless-shell (not Google Chrome for Testing) and its path is not
- * known at module-evaluation time. playwright-core's chromium.launch() resolves
- * the binary correctly and is used directly in browser.ts.
+ * The in-flight pre-launch, or a resolved `null` when {@link startPrelaunch} was never called
+ * or decided not to spawn (non-run command, `--search`, a daemon-routed run, non-chromium, or
+ * macOS — where the CI runner installs playwright's own headless shell and its path is not
+ * known this early).
  *
  * ```ts
- * const early = await prelaunchPromise;
- * early; // null here — this is not a run command, so no Chrome was pre-launched
+ * import { prelaunchPromise } from './prelaunch.ts';
+ *
+ * await prelaunchPromise(); // null — nothing was pre-launched in this process
  * ```
  */
-export const prelaunchPromise =
-  isRunCommand &&
-  !isDaemonClientRun &&
-  !searchFromArgv &&
-  browserFromArgv === 'chromium' &&
-  process.platform !== 'darwin'
-    ? find()
-        .then((chromePath) => {
-          perfLog('chrome-prelaunch.ts: Chrome.find resolved', chromePath);
-          // onSpawn fires synchronously inside spawn the instant Chrome is spawned,
-          // before the CDP-ready stderr match — so earlyChrome holds a fully-callable handle for
-          // the entire process lifetime, including the spawn→CDP-ready gap.
-          return spawn(chromePath, CHROMIUM_ARGS, !openWatchMode, (handle) => {
-            earlyChrome = handle;
-          });
-        })
-        .then((info) => {
-          perfLog('chrome-prelaunch.ts: Chrome CDP ready', info?.cdpEndpoint ?? null);
-          return info;
-        })
-    : Promise.resolve(null);
+export function prelaunchPromise(): Promise<EarlyChrome | null> {
+  return inFlight;
+}
+
+let inFlight: Promise<EarlyChrome | null> = Promise.resolve(null);
+
+/**
+ * Starts Chrome now, if this invocation is one that will need it.
+ *
+ * Call it as early as possible and exactly once: the whole benefit is the overlap with the
+ * module loading that follows, and a second call is a no-op rather than a second browser.
+ * The decision reads `process.argv` directly rather than going through the shared tokenizer —
+ * this runs at ~t=5ms and stays free of avoidable imports.
+ *
+ * ```ts
+ * import { startPrelaunch } from './prelaunch.ts';
+ *
+ * // Defined, not invoked: spawns a real Chrome process.
+ * function begin() {
+ *   startPrelaunch(); // resolves through prelaunchPromise() once CDP is ready
+ * }
+ * ```
+ */
+export function startPrelaunch(): void {
+  if (started) return;
+  started = true;
+
+  const NON_RUN_COMMANDS = new Set([
+    'help',
+    'h',
+    'p',
+    'print',
+    'new',
+    'n',
+    'g',
+    'generate',
+    'init',
+  ]);
+  const cmd = process.argv[2];
+  // `daemon _serve` is the daemon's own process — it DOES need Chrome. Other daemon
+  // subcommands (start/stop/status) are pure client ops and never need Chrome.
+  const isDaemonControlCmd = cmd === 'daemon' && process.argv[3] !== '_serve';
+  const isRunCommand = Boolean(cmd) && !NON_RUN_COMMANDS.has(cmd) && !isDaemonControlCmd;
+  // --search/--print lists tests from a static scan and exits — it never opens a browser. It also
+  // finishes faster than Chrome's CDP becomes ready, so a prelaunch would not merely be wasted: the
+  // shutdown handle does not exist yet when the process exits, leaving an orphaned Chrome and its
+  // user-data-dir behind. Not spawning at all is both the fix and the fast path.
+  // A deliberately local argv scan rather than the shared tokenizer: this module is statically
+  // imported first so Chrome spawns at ~t=5ms, and it stays free of avoidable imports.
+  const SEARCH_FLAG = /^(-s|--search|--print|--preview)(=|$)/;
+  const { browserFromArgv, openFromArgv, watchFromArgv, searchFromArgv } = process.argv.reduce(
+    (flags, arg) => {
+      if (arg.startsWith('--browser=')) flags.browserFromArgv = arg.slice(10);
+      else if (arg === '--open' || arg === '-o') flags.openFromArgv = true;
+      else if (arg === '--watch' || arg === '-w') flags.watchFromArgv = true;
+      else if (SEARCH_FLAG.test(arg)) flags.searchFromArgv = true;
+      return flags;
+    },
+    // QUNITX_BROWSER env var seeds the default so prelaunch is skipped for firefox/webkit
+    // even when --browser is not passed on the command line (e.g. browser-compat CI).
+    {
+      browserFromArgv: process.env.QUNITX_BROWSER || 'chromium',
+      openFromArgv: false,
+      watchFromArgv: false,
+      searchFromArgv: false,
+    },
+  );
+  // If the run will go through the daemon (existing socket OR QUNITX_DAEMON=1
+  // auto-spawn) and the invocation is daemon-eligible, no local Chrome is needed —
+  // skipping the prelaunch saves the ~150ms spawn cost. CI is bypassed by default
+  // but QUNITX_DAEMON=1 overrides (mirrors the precedence in client.ts).
+  const isDaemonClientRun =
+    isRunCommand &&
+    cmd !== 'daemon' &&
+    !watchFromArgv &&
+    !openFromArgv &&
+    !process.env.QUNITX_NO_DAEMON &&
+    !process.argv.includes('--no-daemon') &&
+    (!process.env.CI || Boolean(process.env.QUNITX_DAEMON)) &&
+    // Check the info file rather than the socket path: on Windows the socket is a named
+    // pipe (\\.\pipe\...), which existsSync cannot see. The info file is always a regular
+    // file in os.tmpdir() and is created/removed in lockstep with the daemon's lifetime.
+    (Boolean(process.env.QUNITX_DAEMON) || existsSync(Paths.info()));
+  // With --open --watch, Chrome is left alive after qunitx exits so the visible browser window persists.
+  // With --open alone, qunitx exits after tests complete; the detached browser is opened separately.
+  const openWatchMode = openFromArgv && watchFromArgv;
+
+  if (!openWatchMode) {
+    process.on('exit', () => {
+      const proc = earlyChrome?.proc;
+      if (proc?.pid == null) return;
+      // Last-resort kill: fires in edge cases where process.exit() is called without going
+      // through shutdownPrelaunch() (e.g. FSTree.build ENOENT, signal kills, daemon
+      // shutdown mid-launch). The normal path calls shutdownPrelaunch() first, so Chrome
+      // is already dead here and this is a no-op. SIGKILL so Chrome cannot stall exit.
+      killProcessGroup(proc.pid);
+    });
+  }
+
+  const shouldSpawn =
+    isRunCommand &&
+    !isDaemonClientRun &&
+    !searchFromArgv &&
+    browserFromArgv === 'chromium' &&
+    process.platform !== 'darwin';
+  if (!shouldSpawn) return;
+
+  inFlight = find()
+    .then((chromePath) => {
+      perfLog('chrome-prelaunch.ts: Chrome.find resolved', chromePath);
+      // onSpawn fires synchronously inside spawn the instant Chrome is spawned, before the
+      // CDP-ready stderr match — so earlyChrome holds a fully-callable handle for the entire
+      // process lifetime, including the spawn→CDP-ready gap.
+      return spawn(chromePath, CHROMIUM_ARGS, !openWatchMode, (handle) => {
+        earlyChrome = handle;
+      });
+    })
+    .then((info) => {
+      perfLog('chrome-prelaunch.ts: Chrome CDP ready', info?.cdpEndpoint ?? null);
+      return info;
+    });
+}
+
+let started = false;

--- a/lib/chrome/spawn.ts
+++ b/lib/chrome/spawn.ts
@@ -107,8 +107,11 @@ export async function spawn(
   // even though their FDs are already released, so the loop never exits.
   async function shutdown(): Promise<void> {
     proc.ref(); // re-ref so the close event fires while the event loop is still running
-    if (proc.exitCode === null) {
-      killProcessGroup(proc.pid!);
+    // `pid === undefined` means the spawn itself failed, so there is no group to kill and no
+    // `close` worth waiting for. It used to be a non-null assertion, which types away the one
+    // case where the value is genuinely absent.
+    if (proc.exitCode === null && proc.pid !== undefined) {
+      killProcessGroup(proc.pid);
       await new Promise<void>((resolve) => proc.once('close', resolve));
     }
     await cleanupDir(userDataDir);

--- a/lib/commands/daemon/client.ts
+++ b/lib/commands/daemon/client.ts
@@ -266,7 +266,13 @@ export function runOptionsVia(
   sink?: Output,
 ): Task<RunResult, RunViaFailure> {
   return Task(async () => {
-    const { result } = await dispatchRun({ options, sink });
+    // `stdout`/`stderr` are the CLIENT's sinks for the text streamed back — they are objects
+    // carrying a function, so they do not survive `JSON.stringify`. Sent anyway, the daemon
+    // received `{}`, built an `Output` whose `write` was `undefined`, and died on the first
+    // write — taking the daemon down and every run queued behind it. They are dropped here, at
+    // the one place that knows which half of the options crosses the socket.
+    const { stdout: _stdout, stderr: _stderr, ...overWire } = options;
+    const { result } = await dispatchRun({ options: overWire, sink });
     // The daemon sends `result` before `done` on every options-driven request, so its absence
     // means the daemon answered a request it did not understand — a version skew between a
     // running daemon and a newer client, which is exactly the case `fatal` cannot describe.

--- a/lib/commands/daemon/client.ts
+++ b/lib/commands/daemon/client.ts
@@ -163,7 +163,11 @@ export async function shutdown(cwd: string = process.cwd()): Promise<boolean> {
  * failure.message; // 'no daemon is listening for this project'
  * ```
  */
-export const DaemonUnreachable = Failure.define(
+export const DaemonUnreachable: Failure.FailureFactory<'DaemonUnreachable', undefined> &
+  ((
+    data?: undefined,
+    options?: Failure.FailureOptions,
+  ) => Failure.Failure<'DaemonUnreachable', undefined>) = Failure.define(
   'DaemonUnreachable',
   'no daemon is listening for this project',
 );
@@ -183,7 +187,10 @@ export const DaemonUnreachable = Failure.define(
  * // 'daemon closed the connection (close) without reporting a result'
  * ```
  */
-export const DaemonDisconnected = Failure.define(
+export const DaemonDisconnected: Failure.FailureFactory<
+  'DaemonDisconnected',
+  { reason: 'close' | 'error' | 'no-result' }
+> = Failure.define(
   'DaemonDisconnected',
   // 'no-result' is the version-skew case: a daemon older than the client answered an
   // options-driven request without the `result` chunk that request is defined by.

--- a/lib/commands/daemon/client.ts
+++ b/lib/commands/daemon/client.ts
@@ -7,6 +7,9 @@ import * as Socket from './socket.ts';
 import { Failure } from '../../result/index.ts';
 import { Task } from '../../task/index.ts';
 import { readJsonCache } from '../../utils/read-json-cache.ts';
+import { processOutput, type Output } from '../../reporters/output.ts';
+import type { DaemonRunOptions } from '../../api/options.ts';
+import type { RunResult } from '../../api/result.ts';
 import type { Request, ResponseChunk } from './protocol.ts';
 
 const CONNECT_TIMEOUT_MS = 1_000;
@@ -182,7 +185,9 @@ export const DaemonUnreachable = Failure.define(
  */
 export const DaemonDisconnected = Failure.define(
   'DaemonDisconnected',
-  (data: { reason: 'close' | 'error' }) =>
+  // 'no-result' is the version-skew case: a daemon older than the client answered an
+  // options-driven request without the `result` chunk that request is defined by.
+  (data: { reason: 'close' | 'error' | 'no-result' }) =>
     `daemon closed the connection (${data.reason}) without reporting a result`,
 );
 
@@ -227,9 +232,62 @@ export type RunViaFailure = Failure.Of<typeof DaemonUnreachable | typeof DaemonD
  * ```
  */
 export function runVia(argv: string[]): Task<number, RunViaFailure> {
+  return Task(async () => (await dispatchRun({ argv })).exitCode);
+}
+
+/**
+ * The options-driven twin of {@link runVia}: sends resolved options rather than an argv and
+ * resolves with the run's structured result.
+ *
+ * Streams the daemon's text back the same way — into `sink` when one is given, so a caller that
+ * asked for a reporter still gets its output locally — and additionally receives the `result`
+ * chunk the daemon sends just before `done`.
+ *
+ * ```ts
+ * import * as Client from './client.ts';
+ * import * as Failure from '../../result/failure.ts';
+ *
+ * // Defined, not invoked: dispatches a real run to the project's daemon.
+ * async function runOnDaemon() {
+ *   const outcome = await Client.runOptionsVia({ inputs: ['test/'] }).result();
+ *   return Failure.is(outcome) ? null : outcome.counts;
+ * }
+ * ```
+ */
+export function runOptionsVia(
+  options: DaemonRunOptions,
+  sink?: Output,
+): Task<RunResult, RunViaFailure> {
   return Task(async () => {
+    const { result } = await dispatchRun({ options, sink });
+    // The daemon sends `result` before `done` on every options-driven request, so its absence
+    // means the daemon answered a request it did not understand — a version skew between a
+    // running daemon and a newer client, which is exactly the case `fatal` cannot describe.
+    if (!result) throw DaemonDisconnected({ reason: 'no-result' });
+
+    return result;
+  });
+}
+
+/**
+ * One run over the socket. Shared by both entry points because everything except what is sent
+ * and what is read back — connect, SIGINT forwarding, terminal-chunk handling, the two ways a
+ * daemon can vanish — is identical between them.
+ */
+function dispatchRun({
+  argv = [],
+  options,
+  sink,
+}: {
+  argv?: string[];
+  options?: DaemonRunOptions;
+  sink?: Output;
+}): Promise<{ exitCode: number; result: RunResult | null }> {
+  return (async () => {
     const socket = await tryConnect();
     if (!socket) throw DaemonUnreachable();
+    const out = sink ?? processOutput;
+    let result: RunResult | null = null;
 
     // Per protocol.ts: exactly one terminal message ('done' or 'fatal') ends the
     // stream. close/error here are last-resort fallbacks for a daemon that drops
@@ -237,13 +295,14 @@ export function runVia(argv: string[]): Task<number, RunViaFailure> {
     // folded into the same exit code a failing test run produces.
     const outcome = new Promise<number>((resolve, reject) => {
       Socket.readMessages<ResponseChunk>(socket, (chunk) => {
-        if (chunk.type === 'stdout') process.stdout.write(chunk.data);
-        else if (chunk.type === 'stderr') process.stderr.write(chunk.data);
+        if (chunk.type === 'stdout') out.write(chunk.data);
+        else if (chunk.type === 'stderr') out.error(chunk.data);
+        else if (chunk.type === 'result') result = chunk.result;
         else if (chunk.type === 'done') resolve(chunk.exitCode);
         else if (chunk.type === 'fatal') {
           // A reported fatal IS a terminal result: the daemon ran, decided the run failed, and
           // said so. That is an exit code, not a transport failure.
-          process.stderr.write(`# [qunitx daemon] ${chunk.message}\n`);
+          out.error(`# [qunitx daemon] ${chunk.message}\n`);
           resolve(1);
         }
       });
@@ -260,17 +319,18 @@ export function runVia(argv: string[]): Task<number, RunViaFailure> {
     send(socket, {
       type: 'run',
       argv,
+      options,
       cwd: process.cwd(),
       env: { ...process.env },
       nodeVersion: process.version,
     });
 
     try {
-      return await outcome;
+      return { exitCode: await outcome, result };
     } finally {
       process.removeListener('SIGINT', onSigint);
     }
-  });
+  })();
 }
 
 /**

--- a/lib/commands/daemon/index.ts
+++ b/lib/commands/daemon/index.ts
@@ -282,5 +282,39 @@ async function buildDaemonSpawn(): Promise<{ bin: string; args: string[] }> {
     };
   }
 
-  return { bin: process.execPath, args: [process.argv[1], 'daemon', '_serve'] };
+  return { bin: process.execPath, args: [await selfEntryPoint(), 'daemon', '_serve'] };
+}
+
+/**
+ * qunitx's own entry point, for re-entering it as the detached daemon child.
+ *
+ * `process.argv[1]` is only qunitx's entry when qunitx is what started the process. Called from
+ * the JS API — an embedding app, a test worker — it is the *host's* entry, and spawning that runs
+ * the host program a second time instead of a daemon. The spawn then "succeeds" and the client
+ * waits out its whole timeout for an info file nobody is going to write.
+ *
+ * Resolved from this module's own location instead, most-specific first:
+ *
+ *   dist/cli.js   this file IS the bundle when installed from npm
+ *   cli.ts        a source checkout
+ *   dist/cli.js   a deep-imported source tree next to its bundle
+ *   bin/qunitx.js the npm bin, which re-dispatches
+ *
+ * `process.argv[1]` remains the last resort, so the CLI path behaves exactly as it always has
+ * even if the layout is one this does not recognise.
+ */
+async function selfEntryPoint(): Promise<string> {
+  const { fileURLToPath } = await import('node:url');
+  const here = fileURLToPath(import.meta.url);
+  if (here.endsWith(`${path.sep}dist${path.sep}cli.js`)) return here;
+
+  // lib/commands/daemon/index.ts → three levels up is the package root.
+  const root = path.resolve(path.dirname(here), '..', '..', '..');
+  const candidates = [
+    path.join(root, 'cli.ts'),
+    path.join(root, 'dist', 'cli.js'),
+    path.join(root, 'bin', 'qunitx.js'),
+  ];
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? process.argv[1];
 }

--- a/lib/commands/daemon/index.ts
+++ b/lib/commands/daemon/index.ts
@@ -263,22 +263,24 @@ async function buildDaemonSpawn(): Promise<{ bin: string; args: string[] }> {
   const sea = await import('node:sea').catch(() => null);
   if (sea?.isSea()) return { bin: process.execPath, args: ['daemon', '_serve'] };
 
-  const deno = (globalThis as { Deno?: { mainModule: string } }).Deno;
+  const deno = (globalThis as { Deno?: unknown }).Deno;
   if (deno) {
     // Inside a `deno compile`d binary `Deno.mainModule` is also a `file:` URL
-    // (a virtual path under `/tmp/deno-compile-<name>/`), so the previous
-    // mainModule-prefix check always fell into the `deno run` branch and tried
-    // to spawn `<binary> run -A <virtual-path> daemon _serve` — the binary has
-    // no `run` subcommand and the spawn silently failed. process.execPath
-    // ending in `deno` (or `deno.exe`) is the reliable signal: only `deno run`
-    // preserves the runtime's name on the path.
+    // (a virtual path under `/tmp/deno-compile-<name>/`), so a mainModule-prefix
+    // check always fell into the `deno run` branch and tried to spawn
+    // `<binary> run -A <virtual-path> daemon _serve` — the binary has no `run`
+    // subcommand and the spawn silently failed. process.execPath ending in
+    // `deno` (or `deno.exe`) is the reliable signal: only `deno run` preserves
+    // the runtime's name on the path.
     if (!/[/\\]deno(\.exe)?$/i.test(process.execPath)) {
       return { bin: process.execPath, args: ['daemon', '_serve'] };
     }
-    const { fileURLToPath } = await import('node:url');
+    // `selfEntryPoint()`, not `Deno.mainModule`: under `deno test` — or anywhere the JS API is
+    // driven from a host program — mainModule is the *caller's* entry, so this spawned the host
+    // again instead of a daemon. Same defect the Node branch had, in the other runtime.
     return {
       bin: process.execPath,
-      args: ['run', '-A', fileURLToPath(deno.mainModule), 'daemon', '_serve'],
+      args: ['run', '-A', await selfEntryPoint(), 'daemon', '_serve'],
     };
   }
 

--- a/lib/commands/daemon/protocol.ts
+++ b/lib/commands/daemon/protocol.ts
@@ -1,6 +1,11 @@
 // NDJSON protocol between daemon client and daemon server.
 // One JSON object per line. Client writes a single Request; daemon streams
 // any number of stdout/stderr chunks ending with a `done` (or `fatal`) message.
+//
+// Type-only imports: erased at runtime, so this leaf module stays free of the
+// api/ dependency it names in its types.
+import type { DaemonRunOptions } from '../../api/options.ts';
+import type { RunResult } from '../../api/result.ts';
 
 /**
  * Client → daemon: request to execute a test run with the given argv/env in the daemon's persistent Chrome.
@@ -18,6 +23,16 @@ export interface RunRequest {
   type: 'run';
   /** CLI arguments after `qunitx` (i.e. `process.argv.slice(2)`). */
   argv: string[];
+  /**
+   * Resolved options, when the request came from the JS API rather than a command line. Present
+   * means "build the config from these and answer with a `result` chunk"; absent means the
+   * daemon parses `argv` exactly as the CLI would.
+   *
+   * Only what survives JSON is here — no plugin objects, no reporter instances, no callbacks.
+   * {@link DaemonRunOptions} is the type that enforces that at the call site rather than
+   * discovering it at the socket.
+   */
+  options?: DaemonRunOptions;
   /** Client's working directory. The daemon rejects mismatched cwds (different project). */
   cwd: string;
   /** Client's full process environment, applied to the run and restored on completion. */
@@ -76,6 +91,8 @@ export type Request = RunRequest | PingRequest | ShutdownRequest;
 export type ResponseChunk =
   /** Forwarded `process.stdout.write` chunk from the run. */
   | { type: 'stdout'; data: string }
+  /** The run's structured result; sent just before `done`, only for an options-driven request. */
+  | { type: 'result'; result: RunResult }
   /** Forwarded `process.stderr.write` chunk from the run. */
   | { type: 'stderr'; data: string }
   /** Reply to a `PingRequest` with daemon identity + uptime fields. */

--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -691,12 +691,17 @@ async function runOnce(
   // An options-driven request answers with a structured result, which means it needs a collector
   // — and a reporter set built here rather than by `Reporter.create`, because the client asked
   // for specific ones by name.
-  const reporting = req.options ? resolveReporting(req.options) : null;
+  // `stdout`/`stderr` are stripped again here, not only by the client. They cannot survive JSON,
+  // so anything arriving under those keys is a `{}` from an older client — and building an
+  // `Output` from it would give the daemon a `write` of `undefined` and kill it on first use.
+  // The daemon serves every invocation in the project; it does not get to trust one of them.
+  const wireOptions = req.options && { ...req.options, stdout: undefined, stderr: undefined };
+  const reporting = wireOptions ? resolveReporting(wireOptions) : null;
   const configured = (await Config.setup(
     // `cwd` is forced to the daemon's: `handleRun` already rejected a mismatched client cwd, and
     // a daemon serving one project must not be talked into resolving another.
-    req.options && reporting
-      ? { ...toConfigOptions(req.options, reporting), cwd: state.cwd }
+    wireOptions && reporting
+      ? { ...toConfigOptions(wireOptions, reporting), cwd: state.cwd }
       : undefined,
   ).result()) as Result.Result<ResolvedConfig, Config.ConfigFailure>;
   // A bad flag from one client is that client's problem, not the daemon's. This is the whole

--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -14,6 +14,9 @@ import { run } from '../run.ts';
 import { borrowArgv, borrowEnv } from '../../utils/borrowed-globals.ts';
 import * as Result from '../../result/index.ts';
 import { Failure } from '../../result/index.ts';
+import { resolveReporting, toConfigOptions } from '../../api/options.ts';
+import { buildResult, type RunResult } from '../../api/result.ts';
+import { junitXml } from '../../api/run.ts';
 import type { Request, ResponseChunk, RunRequest, DaemonInfo } from './protocol.ts';
 import type { Browser as PlaywrightBrowser } from 'playwright-core';
 import { Task } from '../../task/index.ts';
@@ -531,7 +534,13 @@ async function handleRun(req: RunRequest, socket: net.Socket, state: DaemonState
 
   let exitCode = 0;
   try {
-    exitCode = await runOnce(req.argv, req.env, state);
+    const outcome = await runOnce(req, state);
+    exitCode = outcome.exitCode;
+    // Before `done`, so a client reading the stream in order has the result in hand by the time
+    // the terminal chunk tells it the run is over.
+    if (outcome.result && !socket.destroyed) {
+      writeChunk(socket, { type: 'result', result: outcome.result });
+    }
   } catch (err) {
     process.stderr.write = origStderrWrite;
     origStderrWrite(`# [qunitx daemon] run error: ${(err as Error).stack || err}\n`);
@@ -665,27 +674,37 @@ async function recoverBrowser(state: DaemonState): Promise<void> {
  * come for free from the shared run pipeline.
  */
 async function runOnce(
-  argv: string[],
-  env: Record<string, string | undefined>,
+  req: RunRequest,
   state: DaemonState,
-): Promise<number> {
+): Promise<{ exitCode: number; result: RunResult | null }> {
   // Both globals are lent for the whole call and given back however it ends. They used to be
   // restored by two separate mechanisms at three separate places, and `env` was not among them
   // when `Config.setup()` THREW — the argv `finally` ran, the exception left runOnce, and that
   // client's environment stayed on the daemon for every later run.
-  using _env = borrowEnv(env);
-  using _argv = borrowArgv(['node', process.argv[1] ?? 'cli.ts', ...argv]);
+  //
+  // An options-driven request needs neither, strictly — `Config.setup(options)` reads no globals
+  // — but `env` still shapes the run (QUNITX_BROWSER, TZ, anything a --before hook reads), so
+  // both stay lent for every request rather than only some of them.
+  using _env = borrowEnv(req.env);
+  using _argv = borrowArgv(['node', process.argv[1] ?? 'cli.ts', ...req.argv]);
 
-  const configured = (await Config.setup().result()) as Result.Result<
-    ResolvedConfig,
-    Config.ConfigFailure
-  >;
+  // An options-driven request answers with a structured result, which means it needs a collector
+  // — and a reporter set built here rather than by `Reporter.create`, because the client asked
+  // for specific ones by name.
+  const reporting = req.options ? resolveReporting(req.options) : null;
+  const configured = (await Config.setup(
+    // `cwd` is forced to the daemon's: `handleRun` already rejected a mismatched client cwd, and
+    // a daemon serving one project must not be talked into resolving another.
+    req.options && reporting
+      ? { ...toConfigOptions(req.options, reporting), cwd: state.cwd }
+      : undefined,
+  ).result()) as Result.Result<ResolvedConfig, Config.ConfigFailure>;
   // A bad flag from one client is that client's problem, not the daemon's. This is the whole
   // reason config assembly returns instead of exiting: `process.exit(1)` inside `Args.parse`
   // would have taken down a daemon serving every other invocation in the project.
   if (Failure.is(configured)) {
     process.stderr.write(`${Failure.format(configured)}\n`);
-    return 1;
+    return { exitCode: 1, result: null };
   }
   const config = configured;
 
@@ -703,7 +722,14 @@ async function runOnce(
   config.watch = false;
   config.open = false;
 
-  return (await run(config)).exitCode;
+  const outcome = await run(config);
+
+  return {
+    exitCode: outcome.exitCode,
+    result: reporting
+      ? buildResult(config, outcome, reporting.collector, junitXml(reporting.reporters))
+      : null,
+  };
 }
 
 async function readPkgMtime(cwd: string): Promise<number> {

--- a/lib/commands/daemon/server.ts
+++ b/lib/commands/daemon/server.ts
@@ -10,7 +10,6 @@ import { parseIdleTimeout } from './parse-idle-timeout.ts';
 import * as Socket from './socket.ts';
 import * as Config from '../../setup/config.ts';
 import * as Browser from '../../setup/browser.ts';
-import { DaemonRunError } from '../run/tests-in-browser.ts';
 import { run } from '../run.ts';
 import { borrowArgv, borrowEnv } from '../../utils/borrowed-globals.ts';
 import * as Result from '../../result/index.ts';
@@ -660,11 +659,10 @@ async function recoverBrowser(state: DaemonState): Promise<void> {
 }
 
 /**
- * Performs one test run inside the daemon by delegating to `run()` — the same code
- * path local non-watch invocations use, but with state.daemon set so it reuses the
- * daemon's persistent browser and throws `DaemonRunError` instead of `process.exit`.
- * Concurrent group orchestration, timing-cache persistence, and after-hook all come
- * for free from the shared run pipeline.
+ * Performs one test run inside the daemon by delegating to `run()` — the same code path local
+ * invocations use, with `state.daemon` set so it reuses the daemon's persistent browser and
+ * leaves it open. Concurrent group orchestration, timing-cache persistence, and after-hook all
+ * come for free from the shared run pipeline.
  */
 async function runOnce(
   argv: string[],
@@ -692,9 +690,8 @@ async function runOnce(
   const config = configured;
 
   // Lending the daemon's persistent handles to this run also marks it as a daemon run:
-  // a non-null state.daemon makes run() reuse the browser rather than launching one, throw
-  // DaemonRunError instead of calling process.exit, and leave the browser open at the end.
-  // watch/open are forced off — those modes don't make sense inside a daemon run.
+  // a non-null state.daemon makes run() reuse the browser rather than launching one, and leave
+  // it open at the end. watch/open are forced off — neither makes sense inside a daemon run.
   //
   // state.browser is non-null here — runOnce only fires from handleRun after awaitBrowser
   // has resolved (and recoverBrowser, if it ran, reassigned it).
@@ -706,15 +703,7 @@ async function runOnce(
   config.watch = false;
   config.open = false;
 
-  try {
-    await run(config);
-    // run() throws DaemonRunError on success in daemon mode; reaching here means it
-    // returned without exiting — fall back on the counter.
-    return config.state.results.counter.failCount > 0 ? 1 : 0;
-  } catch (err) {
-    if (err instanceof DaemonRunError) return err.exitCode;
-    throw err;
-  }
+  return (await run(config)).exitCode;
 }
 
 async function readPkgMtime(cwd: string): Promise<number> {

--- a/lib/commands/generate.ts
+++ b/lib/commands/generate.ts
@@ -1,42 +1,70 @@
 import fs from 'node:fs/promises';
-import { green } from '../utils/color.ts';
 import { findProjectRoot } from '../utils/find-project-root.ts';
 import { pathExists } from '../utils/path-exists.ts';
 import { readTemplate } from '../utils/read-template.ts';
 import { convertToPascalCase } from '../utils/convert-to-pascal-case.ts';
 
 /**
- * Generates a new test file from the boilerplate template.
+ * What `generate` did: the file it wrote, or the one it refused to overwrite.
+ *
+ * ```ts
+ * const result: GenerateResult = { path: '/proj/test/login-test.js', created: true };
+ * result.created; // false would mean the file was already there and was left alone
+ * ```
+ */
+export interface GenerateResult {
+  /** Absolute path of the target file. */
+  path: string;
+  /** `false` when the file already existed and nothing was written. */
+  created: boolean;
+}
+
+/**
+ * Where to scaffold a test file. `target` is a project-relative path; a missing `.js`/`.ts`
+ * extension becomes `.js`, and missing directories are created.
+ *
+ * ```ts
+ * const options: GenerateOptions = { target: 'test/login-test' };
+ * options.target; // written as test/login-test.js
+ * ```
+ */
+export interface GenerateOptions {
+  /** Project-relative path of the test file to write. */
+  target: string;
+  /** Directory to find the project root from. Defaults to `process.cwd()`. */
+  cwd?: string;
+}
+
+/**
+ * Writes a new test file from the boilerplate template, deriving the QUnit module name from
+ * the path. Never overwrites an existing file.
  *
  * ```ts
  * import * as Generate from './generate.ts';
  *
- * // Defined, not invoked: `qunitx new test/login-test.ts` — reads argv[3], writes the file.
+ * // Defined, not invoked: writes into a real project directory.
  * async function generateCommand() {
- *   await Generate.run(); // /project/test/login-test.ts written
+ *   const { path, created } = await Generate.run({ target: 'test/login-test.ts' });
+ *   return created ? path : `${path} already exists`;
  * }
  * ```
- * @returns {Promise<void>}
  */
-export async function run() {
-  const projectRoot = await findProjectRoot();
-  const moduleName = pathToModuleName(process.argv[3]);
-  const path =
-    process.argv[3].endsWith('.js') || process.argv[3].endsWith('.ts')
-      ? `${projectRoot}/${process.argv[3]}`
-      : `${projectRoot}/${process.argv[3]}.js`;
+export async function run(options?: GenerateOptions): Promise<GenerateResult> {
+  const target = options?.target ?? process.argv[3];
+  const projectRoot = await findProjectRoot(options?.cwd);
+  const moduleName = pathToModuleName(target);
+  const filePath =
+    target.endsWith('.js') || target.endsWith('.ts')
+      ? `${projectRoot}/${target}`
+      : `${projectRoot}/${target}.js`;
 
-  if (await pathExists(path)) return console.log(`${path} already exists!`);
+  if (await pathExists(filePath)) return { path: filePath, created: false };
 
   const testJSContent = await readTemplate('test.js');
-  const targetFolderPaths = path.split('/');
+  await fs.mkdir(filePath.split('/').slice(0, -1).join('/'), { recursive: true });
+  await fs.writeFile(filePath, testJSContent.replace('{{moduleName}}', moduleName));
 
-  targetFolderPaths.pop();
-
-  await fs.mkdir(targetFolderPaths.join('/'), { recursive: true });
-  await fs.writeFile(path, testJSContent.replace('{{moduleName}}', moduleName));
-
-  console.log(green(`${path} written`));
+  return { path: filePath, created: true };
 }
 
 function pathToModuleName(filePath: string): string {

--- a/lib/commands/init.ts
+++ b/lib/commands/init.ts
@@ -6,61 +6,105 @@ import { defaultProjectConfigValues } from '../setup/default-project-config-valu
 import { readTemplate } from '../utils/read-template.ts';
 
 /**
- * Bootstraps a new qunitx project: writes the test HTML template, updates package.json, and optionally writes tsconfig.json.
+ * What `init` did, so the caller can report it. Returned rather than printed: the CLI turns
+ * these into its messages, and a programmatic caller gets the same facts as data.
  *
  * ```ts
- * // Defined, not invoked: `qunitx init` — writes test/tests.html + qunitx config into package.json.
+ * const result: InitResult = { written: ['/proj/test/tests.html'], skipped: [] };
+ * result.written.length; // 1 — the fixture did not exist yet
+ * ```
+ */
+export interface InitResult {
+  /** Absolute paths of the files this call created. */
+  written: string[];
+  /** Paths that already existed and were left alone. */
+  skipped: string[];
+}
+
+/**
+ * Bootstraps a qunitx project: writes the test HTML template, updates package.json, and writes
+ * tsconfig.json when there isn't one.
+ *
+ * Never overwrites: an existing fixture is reported in `skipped` and left exactly as it was.
+ *
+ * ```ts
+ * import * as Init from './init.ts';
+ *
+ * // Defined, not invoked: writes into a real project directory.
  * async function initCommand() {
- *   await run(); // /project/test/tests.html written
+ *   const { written } = await Init.run(); // ['/project/test/tests.html', '/project/tsconfig.json']
+ *   return written;
  * }
  * ```
  */
-export async function run() {
-  const projectRoot = await findProjectRoot();
+export async function run(options: InitOptions = {}): Promise<InitResult> {
+  const projectRoot = await findProjectRoot(options.cwd);
   const oldPackageJSON = JSON.parse(await fs.readFile(`${projectRoot}/package.json`, 'utf8'));
   const existingQunitx = oldPackageJSON.qunitx || {};
-  const cliHtmlPaths = process.argv.slice(2).filter((arg) => arg.endsWith('.html'));
+  const requestedHtmlPaths =
+    options.htmlPaths ?? process.argv.slice(2).filter((arg) => arg.endsWith('.html'));
   const config = Object.assign({}, defaultProjectConfigValues, existingQunitx, {
     htmlPaths:
-      cliHtmlPaths.length > 0 ? cliHtmlPaths : existingQunitx.htmlPaths || ['test/tests.html'],
+      requestedHtmlPaths.length > 0
+        ? requestedHtmlPaths
+        : existingQunitx.htmlPaths || ['test/tests.html'],
   });
 
-  await Promise.all([
+  const [html, , tsconfig] = await Promise.all([
     writeTestsHTML(projectRoot, config, oldPackageJSON),
     rewritePackageJSON(projectRoot, config, oldPackageJSON),
     writeTSConfigIfNeeded(projectRoot),
   ]);
+
+  return {
+    written: [...html.written, ...(tsconfig ? [tsconfig] : [])],
+    skipped: html.skipped,
+  };
+}
+
+/**
+ * Where to bootstrap, and which HTML fixtures to write. Both default the way the CLI does:
+ * the working directory, and whatever `.html` arguments were passed.
+ *
+ * ```ts
+ * const options: InitOptions = { cwd: '/proj', htmlPaths: ['test/index.html'] };
+ * options.htmlPaths; // ['test/index.html'] — written relative to the project root
+ * ```
+ */
+export interface InitOptions {
+  /** Directory to find the project root from. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** HTML fixtures to create, relative to the project root. Defaults to `['test/tests.html']`. */
+  htmlPaths?: string[];
 }
 
 async function writeTestsHTML(
   projectRoot: string,
   config: { htmlPaths: string[]; output: string },
   oldPackageJSON: Record<string, unknown>,
-): Promise<unknown[]> {
+): Promise<InitResult> {
   const testHTMLTemplateBuffer = await readTemplate('setup/tests.hbs');
-
-  return await Promise.all(
-    config.htmlPaths.map(async (htmlPath) => {
+  const outcomes = await Promise.all(
+    config.htmlPaths.map(async (htmlPath): Promise<InitResult> => {
       const targetPath = `${projectRoot}/${htmlPath}`;
-      if (await pathExists(targetPath)) {
-        return console.log(`${htmlPath} already exists`);
-      } else {
-        const targetDirectory = path.dirname(targetPath);
-        const _targetOutputPath = path.relative(
-          targetDirectory,
-          path.join(path.resolve(projectRoot, config.output), 'tests.js'),
-        );
-        const testHTMLTemplate = testHTMLTemplateBuffer
-          .toString()
-          .replace('{{applicationName}}', String(oldPackageJSON.name));
+      // A skip reports the path as given, because that is what the CLI has always printed
+      // ("test/tests.html already exists"), while a write reports where it landed.
+      if (await pathExists(targetPath)) return { written: [], skipped: [htmlPath] };
 
-        await fs.mkdir(targetDirectory, { recursive: true });
-        await fs.writeFile(targetPath, testHTMLTemplate);
+      const testHTMLTemplate = testHTMLTemplateBuffer
+        .toString()
+        .replace('{{applicationName}}', String(oldPackageJSON.name));
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      await fs.writeFile(targetPath, testHTMLTemplate);
 
-        console.log(`${targetPath} written`);
-      }
+      return { written: [targetPath], skipped: [] };
     }),
   );
+
+  return {
+    written: outcomes.flatMap((outcome) => outcome.written),
+    skipped: outcomes.flatMap((outcome) => outcome.skipped),
+  };
 }
 
 async function rewritePackageJSON(
@@ -73,13 +117,11 @@ async function rewritePackageJSON(
   await fs.writeFile(`${projectRoot}/package.json`, JSON.stringify(newPackageJSON, null, 2));
 }
 
-async function writeTSConfigIfNeeded(projectRoot: string): Promise<void> {
+async function writeTSConfigIfNeeded(projectRoot: string): Promise<string | null> {
   const targetPath = `${projectRoot}/tsconfig.json`;
-  if (!(await pathExists(targetPath))) {
-    const tsConfigTemplate = await readTemplate('setup/tsconfig.json');
+  if (await pathExists(targetPath)) return null;
 
-    await fs.writeFile(targetPath, tsConfigTemplate);
+  await fs.writeFile(targetPath, await readTemplate('setup/tsconfig.json'));
 
-    console.log(`${targetPath} written`);
-  }
+  return targetPath;
 }

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -164,9 +164,10 @@ export async function watch(config: Config): Promise<WatchSession> {
 // firefox/webkit, warn once and disable so the rest of the pipeline treats it as off.
 function disableUnsupportedCoverage(config: Config): void {
   if (!config.coverage || config.browser === 'chromium') return;
-  console.log(
-    `# Warning: --coverage requires the chromium browser; skipping coverage for ${config.browser}.`,
-  );
+  Reporter.notice(config, {
+    level: 'warning',
+    message: `Warning: --coverage requires the chromium browser; skipping coverage for ${config.browser}.`,
+  });
   config.coverage = false;
 }
 
@@ -234,28 +235,29 @@ async function runWatchMode(config: Config): Promise<WatchSession> {
     );
     if (failed && failed.length > 0) {
       initialFilter = failed;
-      console.log(
-        '#',
-        blue(
+      Reporter.notice(config, {
+        level: 'info',
+        message: blue(
           `qunitx --only-failed: first run scoped to ${failed.length} previously-failing test file${failed.length === 1 ? '' : 's'} — press "qa" to run all`,
         ),
-      );
+      });
     } else {
-      console.log('#', blue(`qunitx --only-failed: no cached failures — running all tests`));
+      Reporter.notice(config, {
+        level: 'info',
+        message: blue(`qunitx --only-failed: no cached failures — running all tests`),
+      });
     }
   } else if (config.changedSince) {
     // getChangedFsTree logs its own affected/fallback counts and returns the full tree on
     // fallback (cold metafile / git failure / blast-radius); scope only when it narrowed.
-    const changed = Object.keys(
-      await getChangedFsTree(config.fsTree, config.projectRoot, config.changedSince),
-    );
+    const changed = Object.keys(await getChangedFsTree(config.fsTree, config, config.changedSince));
     if (changed.length < Object.keys(config.fsTree).length) {
       initialFilter = changed;
       if (changed.length > 0) {
-        console.log(
-          '#',
-          blue(`qunitx --changed/--since: first run scoped — press "qa" to run all`),
-        );
+        Reporter.notice(config, {
+          level: 'info',
+          message: blue(`qunitx --changed/--since: first run scoped — press "qa" to run all`),
+        });
       }
     }
   }
@@ -298,9 +300,10 @@ async function runWatchMode(config: Config): Promise<WatchSession> {
         // may catch the file in a transient empty/partial state and produce a broken rerun.
         RunState.clearBundles(build);
         if (config.debug) {
-          console.log(
-            `# Rerun triggered: ${event} → ${file.replace(`${config.projectRoot}/`, '')}`,
-          );
+          Reporter.notice(config, {
+            level: 'info',
+            message: `Rerun triggered: ${event} → ${file.replace(`${config.projectRoot}/`, '')}`,
+          });
         }
         // Kick off rebuild immediately so it races Chrome navigation (same pattern as the
         // initial watch-mode build). runInBrowser picks up the promise from
@@ -311,7 +314,10 @@ async function runWatchMode(config: Config): Promise<WatchSession> {
         return await runInBrowser(config, connections);
       }
       if (config.debug) {
-        console.log(`# Rerun triggered: ${event} → ${file.replace(`${config.projectRoot}/`, '')}`);
+        Reporter.notice(config, {
+          level: 'info',
+          message: `Rerun triggered: ${event} → ${file.replace(`${config.projectRoot}/`, '')}`,
+        });
       }
       await runInBrowser(config, connections, [file]);
     },
@@ -577,7 +583,14 @@ async function runConcurrentMode(
     (code, result) => {
       // `reason` only exists on the rejected arm of the union, so narrow before reading it.
       if (result.status !== 'rejected') return code;
-      console.error(result.reason);
+      // Raw and stderr-only: a rejected group's reason is an Error whose stack IS the diagnostic,
+      // and un-prefixed multi-line text on stdout would corrupt the TAP document.
+      Reporter.notice(config, {
+        level: 'error',
+        raw: true,
+        stream: 'error',
+        message: `${(result.reason as Error)?.stack ?? String(result.reason)}\n`,
+      });
       return 1;
     },
     config.state.results.counter.failCount > 0 ? 1 : 0,
@@ -587,13 +600,17 @@ async function runConcurrentMode(
     if (isFilteredRun(config)) {
       // A filter matching nothing is a typo, not a green run — every neighbouring runner
       // fails here, and passing CI on a mistyped -t is the worst outcome available.
-      console.log(`# No tests matched ${describeActiveFilters(config)}`);
+      Reporter.notice(config, {
+        level: 'warning',
+        message: `No tests matched ${describeActiveFilters(config)}`,
+      });
       exitCode = 1;
     } else {
       const fileWord = allFiles.length === 1 ? 'file' : 'files';
-      console.log(
-        `# Warning: 0 tests registered — no QUnit test cases found in ${allFiles.length} ${fileWord}`,
-      );
+      Reporter.notice(config, {
+        level: 'warning',
+        message: `Warning: 0 tests registered — no QUnit test cases found in ${allFiles.length} ${fileWord}`,
+      });
     }
   }
 
@@ -684,12 +701,12 @@ async function resolveHtmlFixtures(config: Config): Promise<void> {
       htmlAssets.dynamicContentHTMLs[filePath] = html;
       result.htmlPathsToRunTests.push(filePath.replace(config.projectRoot, ''));
     } else {
-      console.log(
-        '#',
-        yellow(
+      Reporter.notice(config, {
+        level: 'warning',
+        message: yellow(
           `WARNING: Static html file with no {{qunitxScript}} or handlebars-style tokens detected. Therefore ignoring ${filePath}`,
         ),
-      );
+      });
       htmlAssets.staticHTMLs[filePath] = html;
     }
 

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -86,10 +86,14 @@ export interface RunOutcome {
  * the CLI — the JS API, a test of the watcher itself — can drive reruns and then shut the whole
  * thing down deterministically.
  *
+ * The verbs are here rather than in the CLI's keyboard bindings because there is more than one
+ * caller now: `qa` and `session.runAll()` must mean the same thing, and they only do if there is
+ * one implementation. Binding a keystroke to it is `keyboard-events.ts`'s whole remaining job.
+ *
  * ```ts
  * // Defined, not invoked: a real session owns a browser and a bound port.
  * async function restartOnce(session: WatchSession) {
- *   await session.rerun(); // same rerun the file watcher performs
+ *   await session.run(); // same rerun the file watcher performs
  *   await session.close();
  * }
  * ```
@@ -101,8 +105,29 @@ export interface WatchSession {
   connections: Connections;
   /** Where the QUnit view is being served, e.g. `http://localhost:1234`. */
   url: string;
+  /** Whether a run is executing or queued — true from the moment one is asked for. */
+  readonly running: boolean;
   /** Re-runs now, optionally scoped to `files`; resolves when that run finishes. */
-  rerun(files?: string[]): Promise<void>;
+  run(files?: string[]): Promise<void>;
+  /** Runs the whole suite, dropping any line-target selectors this session was scoped to. */
+  runAll(): Promise<void>;
+  /** Re-runs the files that last failed, or repeats the last run when nothing has failed yet. */
+  runFailed(): Promise<void>;
+  /**
+   * Tells the browser to drop the rest of the current run's queue.
+   *
+   * Fire-and-forget by design: it is a message to a page that may not be running anything, and
+   * the run it interrupts settles through its own normal path. Awaiting the interrupted run is
+   * what the caller already holds a promise for.
+   */
+  abort(): void;
+  /**
+   * Resolves once nothing is in flight — a no-op at the back of the rerun queue.
+   *
+   * What `abort()` is awaited through: queueing a real rerun to wait for quiet would start the
+   * very thing the caller just asked to stop.
+   */
+  settled(): Promise<void>;
   /** Stops the watchers and closes the browser and server. Idempotent. */
   close(): Promise<void>;
 }
@@ -302,12 +327,28 @@ async function runWatchMode(config: Config): Promise<WatchSession> {
   //
   // A scoped rerun already compiles the files it was handed straight from disk, so it picks up
   // edits without the full rebuild — paying for one would just make every `add` slower.
-  const rerun = (files?: string[]) =>
-    reruns(() =>
-      files
-        ? runInBrowser(config, connections, files).then(() => {})
-        : rebuildAndRun(config, connections),
-    );
+  let inFlight = 0;
+  // One place that counts what is in flight, because every rerun shape goes through it. Nesting
+  // these instead — `runAll` calling `rerun` inside its own `serialize` — deadlocks: the inner
+  // call queues behind the outer one that is awaiting it.
+  //
+  // Counted at the call, not inside the queued work: the serializer defers `work` to a microtask,
+  // so a caller checking `running` on the line after asking for a rerun would be told the session
+  // was idle. "Requested but not finished" is also the more useful reading — a queued rerun is
+  // work the session owes, and a UI showing a spinner wants it up from the keystroke.
+  const serialize = (work: () => Promise<void>) => {
+    inFlight++;
+
+    return reruns(work).finally(() => inFlight--);
+  };
+  const runFiles = (files?: string[]) =>
+    files
+      ? runInBrowser(config, connections, files).then(() => {})
+      : rebuildAndRun(config, connections);
+  const rerun = (files?: string[]) => serialize(() => runFiles(files));
+  // Through the shared registry rather than `connections.server` directly: one abort mechanism
+  // for watch, batch and `signal`, so a fix to any of them is a fix to all three.
+  const abort = () => RunState.requestAbort(config.state);
 
   const { ready: watcherReady, killFileWatchers } = FileWatcher.setup(
     config.testFileLookupPaths,
@@ -360,10 +401,54 @@ async function runWatchMode(config: Config): Promise<WatchSession> {
     config,
     connections,
     url: `http://localhost:${config.port}`,
+    get running() {
+      return inFlight > 0;
+    },
     // Rebuilds first, like the watcher's own change path: a caller asking for a rerun means
     // "run what is on disk now", and re-serving the cached bundle would answer with what was on
     // disk when the session started.
-    rerun,
+    run: rerun,
+    abort,
+    // Through `reruns`, not `serialize`: a no-op is not a run, and counting it as one would make
+    // `running` true for anyone who merely asked whether the session was busy.
+    settled: () => reruns(() => Promise.resolve()),
+    runAll: () => {
+      abort();
+
+      // Cleared inside the serialized work, not before it: clearing here would also unscope a
+      // rerun already queued ahead of this one, which asked for a scoped run and would silently
+      // get a whole-suite one instead.
+      return serialize(() => {
+        // "Run all" means all: drop the line-target selections that scoped this session. `-t`/`-m`
+        // stay — those are a standing instruction about which tests to run, not a starting point.
+        config.state.group.selectors = undefined;
+
+        return runFiles();
+      });
+    },
+    // Both reads happen inside the serialized work so they see the run this one just aborted:
+    // asking for "the files that failed" before that run has recorded its failures answers with
+    // the previous run's set.
+    runFailed: () => {
+      abort();
+
+      return serialize(() => {
+        // `results.failedFiles`, NOT `group.lastFailedFiles`: the latter is assigned the whole
+        // `lastRanFiles` set whenever any test fails, so "re-run what failed" re-ran everything.
+        // This one is the per-file attribution the result reports, so the rerun is actually scoped.
+        const failed = Array.from(config.state.results.failedFiles);
+        if (failed.length === 0) {
+          Reporter.notice(config, {
+            level: 'info',
+            message: 'QUnitX: No tests failed in the last run, so repeating it',
+          });
+        }
+
+        return runFiles(
+          failed.length > 0 ? failed : (config.state.group.lastRanFiles ?? undefined),
+        );
+      });
+    },
     close: () => closeSession(connections, killFileWatchers),
   };
 }
@@ -518,6 +603,7 @@ async function runConcurrentMode(
     groupCount > 1 && build.htmlPathsToRunTests[0] === '/' && build.htmlPathsToRunTests.length === 1
       ? (() => {
           const s = new HTTPServer();
+          config.state.aborters.add(() => s.publish('abort'));
           WebServer.setupGroupWSHandler(s, groupConfigs);
           groupConfigs.forEach((gc) => WebServer.registerGroupRoutes(s, gc));
           WebServer.registerSharedStaticHandler(s, groupConfigs);

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -290,7 +290,19 @@ async function runWatchMode(config: Config): Promise<WatchSession> {
   // JS context mid-run, and both then wait out the startup timeout. The watcher has an internal
   // guard for its OWN events, but nothing coordinated it with a rerun asked for from outside.
   const reruns = serializer();
-  const rerun = (files?: string[]) => reruns(() => rebuildAndRun(config, connections, files));
+  // The two rerun shapes are NOT interchangeable, and collapsing them broke the rename tests:
+  //
+  //   whole-suite  drops the cached bundle and rebuilds it, because the file set changed
+  //   scoped       serves a freshly-built FILTERED bundle and leaves the full one alone
+  //
+  // A scoped rerun already compiles the files it was handed straight from disk, so it picks up
+  // edits without the full rebuild — paying for one would just make every `add` slower.
+  const rerun = (files?: string[]) =>
+    reruns(() =>
+      files
+        ? runInBrowser(config, connections, files).then(() => {})
+        : rebuildAndRun(config, connections),
+    );
 
   const { ready: watcherReady, killFileWatchers } = FileWatcher.setup(
     config.testFileLookupPaths,
@@ -302,10 +314,10 @@ async function runWatchMode(config: Config): Promise<WatchSession> {
         // before `rename` (→ `add`) when a file is first created. The `add` event
         // will follow and trigger the correct filtered re-run.
         if (event === 'change' && !(file in config.fsTree)) return;
-        // The cached bundles are dropped inside `rebuildAndRun`, at the moment the rebuild
-        // starts — not here, when the event arrives. Clearing on arrival nulled `allTestCode`
-        // out from under a run that was already in flight, which then bailed out of its own
-        // post-navigation check having registered nothing.
+        // The cached bundle is dropped inside `rebuildAndRun`, when the rebuild starts — not
+        // here, when the event arrives. Clearing on arrival nulled `allTestCode` out from under
+        // a run already in flight, which then bailed out of its own post-navigation check having
+        // registered nothing. Serialized reruns make "at the start of the work" the safe moment.
         if (config.debug) {
           Reporter.notice(config, {
             level: 'info',
@@ -382,14 +394,14 @@ function serializer(): <T>(work: () => Promise<T>) => Promise<T> {
  * inside `runInBrowser`'s own try/catch, and an esbuild failure between here and there would
  * otherwise reach Node as an unhandled rejection and take the watch process down.
  */
-function rebuildAndRun(config: Config, connections: Connections, files?: string[]): Promise<void> {
+function rebuildAndRun(config: Config, connections: Connections): Promise<void> {
   const build = config.state.group.build;
   RunState.clearBundles(build);
   const rebuild = buildTestBundle(config);
   Task(rebuild).ignore('watch rebuild rejection — re-awaited by runInBrowser');
   build.preBuildPromise = rebuild;
 
-  return runInBrowser(config, connections, files).then(() => {});
+  return runInBrowser(config, connections).then(() => {});
 }
 
 /**

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -63,7 +63,8 @@ const DAEMON_CONNECT_TIMEOUT_MS = 30_000;
  * return value, and no `process.exit` between them.
  *
  * ```ts
- * const outcome: RunOutcome = { exitCode: 1, durationMs: 1240 };
+ * const outcome: RunOutcome =
+ *   { exitCode: 1, durationMs: 1240, startedAt: 1_760_000_000_000, finishedAt: 1_760_000_001_240 };
  * outcome.exitCode === 0; // false — at least one test failed, or a group rejected
  * ```
  */
@@ -72,6 +73,10 @@ export interface RunOutcome {
   exitCode: number;
   /** Wall-clock duration of the test phase in milliseconds. */
   durationMs: number;
+  /** Epoch ms when the test phase began — after the bundle, at the first navigation. */
+  startedAt: number;
+  /** Epoch ms when it ended. `finishedAt - startedAt` is `durationMs` modulo clock resolution. */
+  finishedAt: number;
 }
 
 /**
@@ -446,7 +451,8 @@ async function runConcurrentMode(
     if (!config.state.daemon) {
       await closeWithGrace([(await browserPromise).close(), shutdownPrelaunch()]);
     }
-    return { exitCode: 0, durationMs: 0 };
+    const now = Date.now();
+    return { exitCode: 0, durationMs: 0, startedAt: now, finishedAt: now };
   }
   // Line-targeted files run as their own single-file groups, each carrying its own selectors.
   // A group is one page with one QUnit config, so this is what lets `a.ts#34 b.ts` mean "the
@@ -544,6 +550,7 @@ async function runConcurrentMode(
     void openOutputInBrowser(config);
   }
   const timer = TimeCounter.start();
+  const startedAt = Date.now();
   const wallTimes = new Map<number, number>();
 
   // 3-minute per-group deadline. Firefox/WebKit can hang indefinitely in any Playwright
@@ -672,6 +679,7 @@ async function runConcurrentMode(
   }
 
   const durationMs = timer.stop();
+  const finishedAt = Date.now();
   await Reporter.runEnd(config, { durationMs });
 
   if (config.coverage) await Coverage.Report.write(config, allFiles);
@@ -708,7 +716,7 @@ async function runConcurrentMode(
   if (config.state.daemon) {
     await closeWithGrace([Task(sharedServer?.close()).ignore('server.close')]);
     clearInterval(keepAlive);
-    return { exitCode, durationMs };
+    return { exitCode, durationMs, startedAt, finishedAt };
   }
 
   // First-time discoverability nudge for the daemon — only on local-mode runs that
@@ -733,7 +741,7 @@ async function runConcurrentMode(
   ]);
   clearInterval(keepAlive);
 
-  return { exitCode, durationMs };
+  return { exitCode, durationMs, startedAt, finishedAt };
 }
 
 /**

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -285,6 +285,13 @@ async function runWatchMode(config: Config): Promise<WatchSession> {
     ).ignore('headed watch-mode navigation to the fallback page');
   }
 
+  // Every rerun — the watcher's, the CLI's keyboard shortcuts', the session's — goes through one
+  // chain. Two runs sharing a page cannot overlap: the second's `page.goto` tears down the first's
+  // JS context mid-run, and both then wait out the startup timeout. The watcher has an internal
+  // guard for its OWN events, but nothing coordinated it with a rerun asked for from outside.
+  const reruns = serializer();
+  const rerun = (files?: string[]) => reruns(() => rebuildAndRun(config, connections, files));
+
   const { ready: watcherReady, killFileWatchers } = FileWatcher.setup(
     config.testFileLookupPaths,
     config,
@@ -295,23 +302,17 @@ async function runWatchMode(config: Config): Promise<WatchSession> {
         // before `rename` (→ `add`) when a file is first created. The `add` event
         // will follow and trigger the correct filtered re-run.
         if (event === 'change' && !(file in config.fsTree)) return;
-        // Clear the cached bundles so the next re-run rebuilds without the deleted file.
-        // `change` events can fire while a file is being rewritten, so a filtered bundle
-        // may catch the file in a transient empty/partial state and produce a broken rerun.
-        RunState.clearBundles(build);
+        // The cached bundles are dropped inside `rebuildAndRun`, at the moment the rebuild
+        // starts — not here, when the event arrives. Clearing on arrival nulled `allTestCode`
+        // out from under a run that was already in flight, which then bailed out of its own
+        // post-navigation check having registered nothing.
         if (config.debug) {
           Reporter.notice(config, {
             level: 'info',
             message: `Rerun triggered: ${event} → ${file.replace(`${config.projectRoot}/`, '')}`,
           });
         }
-        // Kick off rebuild immediately so it races Chrome navigation (same pattern as the
-        // initial watch-mode build). runInBrowser picks up the promise from
-        // preBuildPromise and sets activeRebuild so /tests.js can await it.
-        const rebuildPromise = buildTestBundle(config);
-        Task(rebuildPromise).ignore('watch rebuild rejection — re-awaited by runInBrowser');
-        build.preBuildPromise = rebuildPromise;
-        return await runInBrowser(config, connections);
+        return await rerun();
       }
       if (config.debug) {
         Reporter.notice(config, {
@@ -319,7 +320,7 @@ async function runWatchMode(config: Config): Promise<WatchSession> {
           message: `Rerun triggered: ${event} → ${file.replace(`${config.projectRoot}/`, '')}`,
         });
       }
-      await runInBrowser(config, connections, [file]);
+      await rerun([file]);
     },
     async (_path, _event) => {
       connections.server.publish('refresh');
@@ -342,9 +343,53 @@ async function runWatchMode(config: Config): Promise<WatchSession> {
     config,
     connections,
     url: `http://localhost:${config.port}`,
-    rerun: async (files?: string[]) => void (await runInBrowser(config, connections, files)),
+    // Rebuilds first, like the watcher's own change path: a caller asking for a rerun means
+    // "run what is on disk now", and re-serving the cached bundle would answer with what was on
+    // disk when the session started.
+    rerun,
     close: () => closeSession(connections, killFileWatchers),
   };
+}
+
+/**
+ * A one-at-a-time queue for work that cannot overlap.
+ *
+ * Each call waits for the previous one to settle — succeed or fail — and resolves or rejects
+ * with its own outcome. A rejected run must not poison the queue for the next one, which is why
+ * the stored tail swallows while the returned promise does not.
+ */
+function serializer(): <T>(work: () => Promise<T>) => Promise<T> {
+  let tail: Promise<unknown> = Promise.resolve();
+
+  return <T>(work: () => Promise<T>): Promise<T> => {
+    const next = tail.then(work, work);
+    tail = next.then(
+      () => {},
+      () => {},
+    );
+
+    return next;
+  };
+}
+
+/**
+ * Drops the cached bundles, starts a rebuild, and runs — the rerun every path through watch mode
+ * performs.
+ *
+ * The build is kicked off rather than awaited so it races Chrome's navigation: `runInBrowser`
+ * picks the promise up from `preBuildPromise` and the `/tests.js` route awaits it before serving,
+ * which is what lets the two overlap. The rejection is pre-ignored because it is re-awaited
+ * inside `runInBrowser`'s own try/catch, and an esbuild failure between here and there would
+ * otherwise reach Node as an unhandled rejection and take the watch process down.
+ */
+function rebuildAndRun(config: Config, connections: Connections, files?: string[]): Promise<void> {
+  const build = config.state.group.build;
+  RunState.clearBundles(build);
+  const rebuild = buildTestBundle(config);
+  Task(rebuild).ignore('watch rebuild rejection — re-awaited by runInBrowser');
+  build.preBuildPromise = rebuild;
+
+  return runInBrowser(config, connections, files).then(() => {});
 }
 
 /**

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -180,7 +180,7 @@ async function runWatchMode(config: Config): Promise<void> {
   }
 
   if (config.before) {
-    await runUserModule(`${process.cwd()}/${config.before}`, config, 'before');
+    await runUserModule(`${config.cwd}/${config.before}`, config, 'before');
   }
 
   // A run-narrowing flag (--only-failed / --changed / --since) scopes only the FIRST run in
@@ -487,7 +487,7 @@ async function runConcurrentMode(
         groupConfig.webServer = connections.server;
 
         if (config.before) {
-          await runUserModule(`${process.cwd()}/${config.before}`, groupConfig, 'before');
+          await runUserModule(`${config.cwd}/${config.before}`, groupConfig, 'before');
         }
 
         try {
@@ -576,7 +576,7 @@ async function runConcurrentMode(
   if (config.debug) Timings.print(fileTimes, config.projectRoot);
 
   if (config.after) {
-    await runUserModule(`${process.cwd()}/${config.after}`, config.state.results.counter, 'after');
+    await runUserModule(`${config.cwd}/${config.after}`, config.state.results.counter, 'after');
   }
 
   // Daemon mode: close the per-run shared server (if any) but never the browser

--- a/lib/commands/run.ts
+++ b/lib/commands/run.ts
@@ -10,14 +10,13 @@ import { availableParallelism } from 'node:os';
 // node:timers returns Timer objects with .unref()/.ref() in both Node and Deno.
 // The bare `setTimeout` global in Deno is the Web platform variant, which returns
 // a number with no unref method.
-import { setTimeout, clearTimeout, setInterval, clearInterval } from 'node:timers';
+import { setTimeout, setInterval, clearInterval } from 'node:timers';
 import { blue, yellow } from '../utils/color.ts';
 import {
   run as runInBrowser,
   buildTestBundle,
   buildAllGroupBundles,
   flushConsoleHandlers,
-  DaemonRunError,
 } from './run/tests-in-browser.ts';
 
 import * as RunState from '../setup/run-state.ts';
@@ -25,7 +24,6 @@ import * as FileWatcher from '../setup/file-watcher.ts';
 import { getChangedFsTree } from '../setup/get-changed-fs-tree.ts';
 import { findInternalAssetsFromHTML } from '../utils/find-internal-assets-from-html.ts';
 import { runUserModule } from '../utils/run-user-module.ts';
-import * as KeyboardEvents from '../setup/keyboard-events.ts';
 import { writeOutputStaticFiles } from '../setup/write-output-static-files.ts';
 import * as TimeCounter from '../utils/time-counter.ts';
 import * as Reporter from '../reporters/index.ts';
@@ -39,22 +37,11 @@ import { isFilteredRun, describeActiveFilters } from '../selection/filter.ts';
 import * as Timings from './run/timings.ts';
 import { applyWatchLineTargets, resolveTargetedFiles, splitIntoGroups } from './run/grouping.ts';
 import type { QUnitSelector } from '../selection/line-targets.ts';
-import type { Config, HtmlAssets } from '../types.ts';
+import type { Config, Connections, HtmlAssets } from '../types.ts';
 import { Task } from '../task/index.ts';
 
 // Playwright navigation timeout for headed watch-mode reloads (not test execution).
 const WATCH_NAV_TIMEOUT_MS = 5_000;
-// Maximum ms to wait for the `process.stdout.write` drain callback to fire before
-// forcing process.exit(). On Windows under concurrent CI load (16 parallel tests)
-// the drain callback can take far longer than expected: the parent reader is busy,
-// the OS pipe buffer fills, Node's userland write queue stalls until the reader
-// catches up. The original 5s was too tight — exitTimer fired first and process.exit
-// dropped pending writes (the `--after works when it needs to be awaited` flake
-// reported only the pre-await TAP-13 header). 30s gives realistic headroom; nothing
-// in node:fs can force-drain Node's userland queue (fsync would only flush the OS
-// pipe buffer, not Node's queue — and pipes have no backing store on POSIX anyway),
-// so the only honest fix is to wait longer for the natural drain.
-const STDOUT_FLUSH_GRACE_MS = 30_000;
 // setInterval period that keeps the event loop alive while Promise.allSettled runs.
 const KEEP_ALIVE_INTERVAL_MS = 10_000;
 // Daemon-only bound on the "connecting" phase (Browser.setup → newPage on the reused
@@ -66,65 +53,130 @@ const KEEP_ALIVE_INTERVAL_MS = 10_000;
 // deadline, so it only ever fires on a genuine wedge; the daemon then recovers for the next
 // run. Local runs launch a fresh browser per invocation, so this race can't apply there.
 const DAEMON_CONNECT_TIMEOUT_MS = 30_000;
-// Conventional exit code for a process terminated by SIGTERM (128 + signal number 15).
-const EXIT_CODE_SIGTERM = 128 + 15;
 
 /**
- * Runs qunitx tests in headless Chrome, either in watch mode or concurrent batch mode.
+ * How a one-shot run ended. Everything a caller needs to decide what happens next, and nothing
+ * about how it should be announced — {@link run} neither writes a summary nor exits.
+ *
+ * That is the point of the shape: it is what `cli.ts` turns into an exit code, what the daemon
+ * ships back over its socket, and what the JS API builds its result from. Three consumers, one
+ * return value, and no `process.exit` between them.
+ *
+ * ```ts
+ * const outcome: RunOutcome = { exitCode: 1, durationMs: 1240 };
+ * outcome.exitCode === 0; // false — at least one test failed, or a group rejected
+ * ```
+ */
+export interface RunOutcome {
+  /** `0` when every test passed, `1` for any failure, group rejection, or empty filtered run. */
+  exitCode: number;
+  /** Wall-clock duration of the test phase in milliseconds. */
+  durationMs: number;
+}
+
+/**
+ * A live watch session: the run's browser, server and file watchers, kept open.
+ *
+ * Returned rather than "the process stays alive and you figure it out", so a caller other than
+ * the CLI — the JS API, a test of the watcher itself — can drive reruns and then shut the whole
+ * thing down deterministically.
+ *
+ * ```ts
+ * // Defined, not invoked: a real session owns a browser and a bound port.
+ * async function restartOnce(session: WatchSession) {
+ *   await session.rerun(); // same rerun the file watcher performs
+ *   await session.close();
+ * }
+ * ```
+ */
+export interface WatchSession {
+  /** The resolved config this session runs with; its `state` carries the live counters. */
+  config: Config;
+  /** The session's browser, page and HTTP server. */
+  connections: Connections;
+  /** Where the QUnit view is being served, e.g. `http://localhost:1234`. */
+  url: string;
+  /** Re-runs now, optionally scoped to `files`; resolves when that run finishes. */
+  rerun(files?: string[]): Promise<void>;
+  /** Stops the watchers and closes the browser and server. Idempotent. */
+  close(): Promise<void>;
+}
+
+/**
+ * Runs the whole suite once in headless Chrome and resolves with its {@link RunOutcome}.
  *
  * ```ts
  * import type { run } from './run.ts';
  * import type { Config } from '../types.ts';
  * // Defined, not invoked: launches Chrome and runs the whole suite.
  * async function runSuite(runTests: typeof run, config: Config) {
- *   await runTests(config); // batch mode exits the process itself; watch mode returns, process alive
+ *   const { exitCode } = await runTests(config); // returns; deciding what that means is the caller's
+ *   return exitCode;
  * }
  * ```
- * @returns {Promise<void>}
  */
-export async function run(config: Config): Promise<void> {
-  // Coverage is V8-precise-coverage over CDP, which only the chromium engine exposes. For
-  // firefox/webkit, warn once and disable so the rest of the pipeline treats it as off.
-  if (config.coverage && config.browser !== 'chromium') {
-    console.log(
-      `# Warning: --coverage requires the chromium browser; skipping coverage for ${config.browser}.`,
-    );
-    config.coverage = false;
-  }
+export async function run(config: Config): Promise<RunOutcome> {
+  disableUnsupportedCoverage(config);
 
   // Kick off all I/O that doesn't need the HTML fixtures in parallel with resolveHtmlFixtures:
   //   Browser.launch: CDP connect to pre-launched Chrome (~30-50ms)
   //   Timings.read: reads tmp/test-timings.json (~2ms)
   //   resolveHtmlFixtures: reads HTML template from disk (~5-10ms)
   // Chrome is typically fully connected by the time resolveHtmlFixtures + splitIntoGroups resolve.
-  // Daemon mode reuses its persistent browser; non-watch local runs launch their own;
-  // watch mode defers launch until Browser.setup inside the watch path.
+  // Daemon mode reuses its persistent browser; local runs launch their own.
   const daemonBrowser = config.state.daemon?.browser;
-  const browserPromise = daemonBrowser
-    ? Promise.resolve(daemonBrowser)
-    : config.watch
-      ? null
-      : Browser.launch(config);
+  const browserPromise = daemonBrowser ? Promise.resolve(daemonBrowser) : Browser.launch(config);
   const [, timings] = await Promise.all([
     resolveHtmlFixtures(config),
-    config.watch
-      ? Promise.resolve(null as Record<string, number> | null)
-      : Timings.read(config.projectRoot),
+    Timings.read(config.projectRoot),
   ]);
 
-  if (config.watch) {
-    await runWatchMode(config);
-  } else {
-    await runConcurrentMode(config, timings, browserPromise);
-  }
+  return await runConcurrentMode(config, timings, browserPromise);
+}
+
+/**
+ * Starts a watch session: one browser, one page, every test file in a single bundle, behind an
+ * HTTP server that stays up. Resolves once the initial run has finished and the watchers are
+ * armed — the returned {@link WatchSession} is how the caller stops it again.
+ *
+ * ```ts
+ * import type { watch } from './run.ts';
+ * import type { Config } from '../types.ts';
+ * // Defined, not invoked: launches Chrome and leaves it watching.
+ * async function watchSuite(startWatching: typeof watch, config: Config) {
+ *   const session = await startWatching(config);
+ *   return session.url; // 'http://localhost:1234'
+ * }
+ * ```
+ */
+export async function watch(config: Config): Promise<WatchSession> {
+  disableUnsupportedCoverage(config);
+  // Load-bearing for the whole function: `runInBrowser`, the file watcher and the keyboard
+  // shortcuts all branch on it, and a session started through the JS API arrives here with the
+  // flag unset because nobody typed `--watch`.
+  config.watch = true;
+  await resolveHtmlFixtures(config);
+
+  return await runWatchMode(config);
+}
+
+// Coverage is V8-precise-coverage over CDP, which only the chromium engine exposes. For
+// firefox/webkit, warn once and disable so the rest of the pipeline treats it as off.
+function disableUnsupportedCoverage(config: Config): void {
+  if (!config.coverage || config.browser === 'chromium') return;
+  console.log(
+    `# Warning: --coverage requires the chromium browser; skipping coverage for ${config.browser}.`,
+  );
+  config.coverage = false;
 }
 
 /**
  * WATCH MODE: one browser, one page, every test file in a single bundle, behind an HTTP server
- * that stays up so the QUnit view can be kept open. Reruns are driven by the file watcher and the
- * keyboard shortcuts, so this returns with the process still alive.
+ * that stays up so the QUnit view can be kept open. Reruns are driven by the file watcher; the
+ * caller owns whatever else drives them (the CLI adds keyboard shortcuts) and owns shutting the
+ * session down.
  */
-async function runWatchMode(config: Config): Promise<void> {
+async function runWatchMode(config: Config): Promise<WatchSession> {
   const build = config.state.group.build;
   // Line targets scope the whole watch session, so they have to narrow fsTree BEFORE the
   // bundle below is built from it — see applyWatchLineTargets. Guarded so the common path
@@ -154,19 +206,6 @@ async function runWatchMode(config: Config): Promise<void> {
     writeOutputStaticFiles(config, config.state.htmlAssets),
   ]);
   config.webServer = connections.server;
-  KeyboardEvents.setup(config, connections);
-
-  // Explicitly close the HTTP server on SIGTERM before the process exits. This ensures
-  // the port is reclaimed by application code (not as a side effect of OS process cleanup),
-  // guaranteeing the port is free from the moment waitpid() returns in the parent process.
-  // Without this, macOS can lag a few ms between waitpid() and socket reclamation, making
-  // the port appear in-use immediately after the child exits.
-  // Note: on Windows child.kill('SIGTERM') calls TerminateProcess() so this handler never
-  // runs there — but TerminateProcess() is fully synchronous so the race doesn't exist on
-  // Windows anyway. Exit with 143 (128 + SIGTERM) to preserve the conventional exit code.
-  process.once('SIGTERM', () => {
-    closeWithGrace([connections.server.close()]).finally(() => process.exit(EXIT_CODE_SIGTERM));
-  });
 
   // In headed watch mode (bare --open + --watch), chrome-prelaunch.ts launches Chrome
   // without --headless=new so the Playwright-controlled window IS the visible browser.
@@ -244,93 +283,107 @@ async function runWatchMode(config: Config): Promise<void> {
     ).ignore('headed watch-mode navigation to the fallback page');
   }
 
-  if (config.watch) {
-    const { ready: watcherReady } = FileWatcher.setup(
-      config.testFileLookupPaths,
-      config,
-      async (event, file) => {
-        if (event === 'addDir') return;
-        if (['change', 'unlink', 'unlinkDir'].includes(event)) {
-          // Ignore `change` events for files not yet in fsTree: fs.watch fires `change`
-          // before `rename` (→ `add`) when a file is first created. The `add` event
-          // will follow and trigger the correct filtered re-run.
-          if (event === 'change' && !(file in config.fsTree)) return;
-          // Clear the cached bundles so the next re-run rebuilds without the deleted file.
-          // `change` events can fire while a file is being rewritten, so a filtered bundle
-          // may catch the file in a transient empty/partial state and produce a broken rerun.
-          RunState.clearBundles(build);
-          if (config.debug) {
-            console.log(
-              `# Rerun triggered: ${event} → ${file.replace(`${config.projectRoot}/`, '')}`,
-            );
-          }
-          // Kick off rebuild immediately so it races Chrome navigation (same pattern as the
-          // initial watch-mode build). runInBrowser picks up the promise from
-          // preBuildPromise and sets activeRebuild so /tests.js can await it.
-          const rebuildPromise = buildTestBundle(config);
-          Task(rebuildPromise).ignore('watch rebuild rejection — re-awaited by runInBrowser');
-          build.preBuildPromise = rebuildPromise;
-          return await runInBrowser(config, connections);
-        }
+  const { ready: watcherReady, killFileWatchers } = FileWatcher.setup(
+    config.testFileLookupPaths,
+    config,
+    async (event, file) => {
+      if (event === 'addDir') return;
+      if (['change', 'unlink', 'unlinkDir'].includes(event)) {
+        // Ignore `change` events for files not yet in fsTree: fs.watch fires `change`
+        // before `rename` (→ `add`) when a file is first created. The `add` event
+        // will follow and trigger the correct filtered re-run.
+        if (event === 'change' && !(file in config.fsTree)) return;
+        // Clear the cached bundles so the next re-run rebuilds without the deleted file.
+        // `change` events can fire while a file is being rewritten, so a filtered bundle
+        // may catch the file in a transient empty/partial state and produce a broken rerun.
+        RunState.clearBundles(build);
         if (config.debug) {
           console.log(
             `# Rerun triggered: ${event} → ${file.replace(`${config.projectRoot}/`, '')}`,
           );
         }
-        await runInBrowser(config, connections, [file]);
-      },
-      async (_path, _event) => {
-        connections.server.publish('refresh');
-        // In headed watch mode the Playwright page IS the visible browser (navigator.webdriver=true
-        // means it ignores the WS 'refresh' message). Navigate it directly after a build error
-        // or a 0-tests warning so it shows the correct HTML rather than stale test results.
-        if (isHeadedWatchMode && build.fallbackPage) {
-          await Task(
-            connections.page.goto(`http://localhost:${config.port}/`, {
-              waitUntil: 'commit',
-              timeout: WATCH_NAV_TIMEOUT_MS,
-            }),
-          ).ignore('headed watch-mode re-navigation after a rebuild');
-        }
-      },
-    );
-    await watcherReady;
-  }
+        // Kick off rebuild immediately so it races Chrome navigation (same pattern as the
+        // initial watch-mode build). runInBrowser picks up the promise from
+        // preBuildPromise and sets activeRebuild so /tests.js can await it.
+        const rebuildPromise = buildTestBundle(config);
+        Task(rebuildPromise).ignore('watch rebuild rejection — re-awaited by runInBrowser');
+        build.preBuildPromise = rebuildPromise;
+        return await runInBrowser(config, connections);
+      }
+      if (config.debug) {
+        console.log(`# Rerun triggered: ${event} → ${file.replace(`${config.projectRoot}/`, '')}`);
+      }
+      await runInBrowser(config, connections, [file]);
+    },
+    async (_path, _event) => {
+      connections.server.publish('refresh');
+      // In headed watch mode the Playwright page IS the visible browser (navigator.webdriver=true
+      // means it ignores the WS 'refresh' message). Navigate it directly after a build error
+      // or a 0-tests warning so it shows the correct HTML rather than stale test results.
+      if (isHeadedWatchMode && build.fallbackPage) {
+        await Task(
+          connections.page.goto(`http://localhost:${config.port}/`, {
+            waitUntil: 'commit',
+            timeout: WATCH_NAV_TIMEOUT_MS,
+          }),
+        ).ignore('headed watch-mode re-navigation after a rebuild');
+      }
+    },
+  );
+  await watcherReady;
 
-  logWatcherAndKeyboardShortcutInfo(config, connections.server);
+  return {
+    config,
+    connections,
+    url: `http://localhost:${config.port}`,
+    rerun: async (files?: string[]) => void (await runInBrowser(config, connections, files)),
+    close: () => closeSession(connections, killFileWatchers),
+  };
+}
+
+/**
+ * Stops a watch session's watchers and closes its browser and server. Bounded by
+ * `closeWithGrace`, and safe to call twice — every step tolerates an already-closed handle.
+ */
+async function closeSession(
+  connections: Connections,
+  killFileWatchers: () => unknown,
+): Promise<void> {
+  killFileWatchers();
+  await closeWithGrace([
+    Task(connections.server?.close()).ignore('watch session server.close'),
+    Task(connections.page?.close()).ignore('watch session page.close'),
+    Task(connections.browser?.close()).ignore('watch session browser.close'),
+    shutdownPrelaunch(),
+  ]);
 }
 
 /**
  * CONCURRENT MODE: the one-shot batch run. Files are split across groups, each group getting its
- * own page inside one shared browser so esbuild time hides behind Chrome start-up. Ends the
- * process itself — reporting, cache persistence and cleanup all happen here.
+ * own page inside one shared browser so esbuild time hides behind Chrome start-up. Reporting,
+ * cache persistence and cleanup all happen here; the exit code is returned, not applied.
  */
 async function runConcurrentMode(
   config: Config,
   timings: Record<string, number> | null,
-  browserPromise: ReturnType<typeof Browser.launch> | null,
-): Promise<void> {
+  browserPromise: Promise<Awaited<ReturnType<typeof Browser.launch>>>,
+): Promise<RunOutcome> {
   const build = config.state.group.build;
   // CONCURRENT MODE: split test files across N groups = availableParallelism().
   // All group bundles are built while Chrome is starting up, so esbuild time
   // is hidden behind the ~1.2s Chrome launch. Each group then gets its own
   // HTTP server and Playwright page inside one shared browser instance.
   const allFiles = Object.keys(config.fsTree);
-  // Empty fsTree (e.g. --changed filtered out every test, or the inputs
-  // matched no files): emit a clean TAP plan and exit 0. The downstream
-  // group/build pipeline assumes ≥1 file and would crash on undefined
-  // groupConfigs[0]. In daemon mode, throw DaemonRunError so the daemon's
-  // run handler closes the run cleanly and stays alive for the next call.
+  // Empty fsTree (e.g. --changed filtered out every test, or the inputs matched no files): emit
+  // a clean TAP plan and report success. The downstream group/build pipeline assumes ≥1 file and
+  // would crash on undefined groupConfigs[0].
   if (allFiles.length === 0) {
     Reporter.runStart(config, { fileCount: 0, groupCount: 0 });
-    if (config.state.daemon) throw new DaemonRunError(0);
-    if (!config.watch) {
-      // Daemon runs threw above, so this is always a browser this run owns and must close.
-      const browser = await browserPromise!;
-      await closeWithGrace([browser.close(), shutdownPrelaunch()]);
-      return process.exit(0);
+    // The daemon owns its browser across runs and must keep it; a local run owns this one.
+    if (!config.state.daemon) {
+      await closeWithGrace([(await browserPromise).close(), shutdownPrelaunch()]);
     }
-    return;
+    return { exitCode: 0, durationMs: 0 };
   }
   // Line-targeted files run as their own single-file groups, each carrying its own selectors.
   // A group is one page with one QUnit config, so this is what lets `a.ts#34 b.ts` mean "the
@@ -544,11 +597,8 @@ async function runConcurrentMode(
     }
   }
 
-  // Set after the zero-match block above, which can flip exitCode to 1 for a filter that
-  // matched nothing.
-  process.exitCode = exitCode;
-
-  await Reporter.runEnd(config, { durationMs: timer.stop() });
+  const durationMs = timer.stop();
+  await Reporter.runEnd(config, { durationMs });
 
   if (config.coverage) await Coverage.Report.write(config, allFiles);
 
@@ -579,13 +629,12 @@ async function runConcurrentMode(
     await runUserModule(`${config.cwd}/${config.after}`, config.state.results.counter, 'after');
   }
 
-  // Daemon mode: close the per-run shared server (if any) but never the browser
-  // (the daemon owns it across runs). Throw DaemonRunError so the daemon's run
-  // handler captures the exit code instead of hitting process.exit.
+  // Daemon mode: close the per-run shared server (if any) but never the browser — the daemon
+  // owns it across runs, and the next run reuses it.
   if (config.state.daemon) {
-    clearInterval(keepAlive);
     await closeWithGrace([Task(sharedServer?.close()).ignore('server.close')]);
-    throw new DaemonRunError(exitCode);
+    clearInterval(keepAlive);
+    return { exitCode, durationMs };
   }
 
   // First-time discoverability nudge for the daemon — only on local-mode runs that
@@ -593,31 +642,24 @@ async function runConcurrentMode(
   // the suppression matrix (CI / env opt-outs / TTY / sentinel).
   await Hint.maybePrint({ durationMs: process.uptime() * 1000 });
 
-  // Flush stdout, shut down Chrome cleanly, then exit.
-  // keepAlive holds the event loop open until this callback fires, at which point
-  // process.exit() takes over — so clearInterval happens here, not earlier.
-  // If the write callback never fires (theoretical), the unref'd exitTimer is the fallback.
-  const exitTimer = setTimeout(() => process.exit(exitCode), STDOUT_FLUSH_GRACE_MS);
-  exitTimer.unref();
+  // Cleanup happens here, before returning, rather than inside a `process.stdout.write` drain
+  // callback racing an unref'd exit timer. The old shape existed because this function ended the
+  // process; now that the caller does, "finish cleaning up, then hand back the outcome" is both
+  // simpler and stricter — the failure cache can no longer be lost to an exit that fires first.
+  //
+  // keepAlive is cleared AFTER cleanup so the interval holds the event loop open throughout,
+  // preventing a premature drain if every close resolves instantly (e.g. Chrome already dead)
+  // before proc.ref() takes effect inside shutdownPrelaunch. closeWithGrace bounds the other
+  // side: Playwright's browser.close() can deadlock on Firefox + Windows.
+  await closeWithGrace([
+    failureCacheWrite,
+    Task(sharedServer?.close()).ignore('server.close'),
+    Task(browser.close()).ignore('browser.close'),
+    shutdownPrelaunch(),
+  ]);
+  clearInterval(keepAlive);
 
-  process.stdout.write('\n', async () => {
-    clearTimeout(exitTimer);
-    // keepAlive is cleared AFTER cleanup so the interval holds the event loop open
-    // throughout, preventing premature drain if every close resolves instantly (e.g.
-    // Chrome already dead) before proc.ref() takes effect inside shutdownPrelaunch.
-    //
-    // closeWithGrace bounds this race: Playwright's browser.close() can deadlock on
-    // Firefox + Windows, leaving the CLI alive but silent until the test runner
-    // SIGTERMs it ~60 s later. Best-effort cleanup, exit anyway.
-    await closeWithGrace([
-      failureCacheWrite,
-      Task(sharedServer?.close()).ignore('server.close'),
-      Task(browser.close()).ignore('browser.close'),
-      shutdownPrelaunch(),
-    ]);
-    clearInterval(keepAlive);
-    process.exit(exitCode);
-  });
+  return { exitCode, durationMs };
 }
 
 /**
@@ -680,20 +722,6 @@ async function resolveMainHTML(projectRoot: string, htmlAssets: HtmlAssets): Pro
     // copy — see the /node_modules/qunitx/vendor/qunit.css route in web-server.ts. It is no longer
     // copied out of the consumer's node_modules, so projects need not install `qunitx`.
   }
-}
-
-function logWatcherAndKeyboardShortcutInfo(config: Config, _server: unknown): void {
-  const prefix = 'Watching files...';
-  console.log(
-    '#',
-    blue(`${prefix} You can browse the tests on http://localhost:${config.port} ...`),
-  );
-  console.log(
-    '#',
-    blue(
-      `Shortcuts: Press "qq" to abort running tests, "qa" to run all the tests, "qf" to run last failing test, "ql" to repeat last test`,
-    ),
-  );
 }
 
 function normalizeInternalAssetPathFromHTML(

--- a/lib/commands/run/grouping.ts
+++ b/lib/commands/run/grouping.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { blue } from '../../utils/color.ts';
+import * as Reporter from '../../reporters/index.ts';
 import * as LineTargets from '../../selection/line-targets.ts';
 import type { QUnitSelector } from '../../selection/line-targets.ts';
 import type { Config } from '../../types.ts';
@@ -36,14 +37,17 @@ export async function applyWatchLineTargets(config: Config): Promise<void> {
   config.fsTree = Object.fromEntries([...targetedPaths].map((file) => [file, config.fsTree[file]]));
   config.state.group.selectors = targets.flatMap((target) => target.selectors);
   if (dropped.length > 0) {
-    console.log(
-      '#',
-      blue(
+    Reporter.notice(config, {
+      level: 'info',
+      message: blue(
         `qunitx: --watch with a line target runs only the targeted file${targetedPaths.size === 1 ? '' : 's'} — ${dropped.length} other file${dropped.length === 1 ? '' : 's'} excluded from this session`,
       ),
-    );
+    });
   }
-  console.log('#', blue(`qunitx: press "qa" to run every test in the watched file(s)`));
+  Reporter.notice(config, {
+    level: 'info',
+    message: blue(`qunitx: press "qa" to run every test in the watched file(s)`),
+  });
 }
 
 /**
@@ -95,7 +99,9 @@ export async function resolveTargetedFiles(
   );
   // Logged after the parallel resolve so warnings print in input order, not resolution order.
   resolved.forEach((entry) => {
-    entry.warnings.forEach((warning) => console.log('#', blue(`qunitx: ${warning}`)));
+    entry.warnings.forEach((warning) =>
+      Reporter.notice(config, { level: 'warning', message: blue(`qunitx: ${warning}`) }),
+    );
   });
 
   // Null selectors mean the target degraded to "run the whole file" — there is nothing to scope,

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -1,8 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { blue, yellow } from '../../utils/color.ts';
-import { shutdownPrelaunch } from '../../chrome/prelaunch.ts';
-import { closeWithGrace } from '../../utils/close-with-grace.ts';
 import esbuild from 'esbuild';
 import * as TimeCounter from '../../utils/time-counter.ts';
 import { runUserModule } from '../../utils/run-user-module.ts';
@@ -25,7 +23,6 @@ import type {
   EsbuildCache,
   QUnitResult,
 } from '../../types.ts';
-import type { HTTPServer } from '../../web/index.ts';
 import { Task } from '../../task/index.ts';
 
 /**
@@ -424,26 +421,13 @@ export async function run(
         await runUserModule(`${config.cwd}/${config.after}`, config.state.results.counter, 'after');
       }
 
-      if (!config.watch) {
-        await flushConsoleHandlers(config.state.group.pendingConsoleHandlers, connections.page);
-        // Daemon mode: the daemon owns the browser and server lifetimes, so we
-        // must not close them here. Throw instead so the daemon's run handler
-        // captures the exit code and keeps the process alive for the next run.
-        if (config.state.daemon) {
-          throw new DaemonRunError(config.state.results.counter.failCount > 0 ? 1 : 0);
-        }
-        await closeWithGrace([
-          connections.server?.close(),
-          connections.browser?.close(),
-          shutdownPrelaunch(),
-        ]);
-        return process.exit(config.state.results.counter.failCount > 0 ? 1 : 0);
-      }
+      // There is no non-watch branch here. Every non-watch run reaches this function through
+      // `runConcurrentMode`, which sets `groupMode` on all of its group configs — so this whole
+      // block only ever executes in watch mode, and reporting, cleanup and the exit code belong
+      // to the orchestrator either way. The unreachable branch that used to close this block
+      // held the last `process.exit` on the run path.
     }
   } catch (error) {
-    // DaemonRunError signals normal completion in daemon mode (replaces process.exit);
-    // pass it through unchanged so the daemon's run handler can capture the exit code.
-    if (error instanceof DaemonRunError) throw error;
     build.activeRebuild = null;
     config.state.group.lastFailedFiles = config.state.group.lastRanFiles;
     const exception = new BundleError(error);
@@ -686,28 +670,6 @@ export async function buildAllGroupBundles(groupConfigs: Config[]): Promise<void
   }
 }
 
-/**
- * Thrown in daemon mode in place of `process.exit(code)` so the caller (the daemon
- * server's run handler) can capture the exit code, restore stdout interception, and
- * keep the daemon process alive for the next run.
- *
- * ```ts
- * const error = new DaemonRunError(1);
- * error.exitCode; // 1
- * error instanceof Error; // true — passes through catch blocks unchanged
- * ```
- */
-export class DaemonRunError extends Error {
-  /** The exit code that the run would have passed to `process.exit()` outside of daemon mode. */
-  exitCode: number;
-  /** Constructs a DaemonRunError carrying the run's exit code. */
-  constructor(exitCode: number) {
-    super(`daemon run finished with exit code ${exitCode}`);
-    this.name = 'DaemonRunError';
-    this.exitCode = exitCode;
-  }
-}
-
 function buildFilteredTests(
   filteredTests: string[],
   outputPath: string,
@@ -836,7 +798,7 @@ function esbuildTarget(browser?: string): string[] {
 
 async function runTestInsideHTMLFile(
   filePath: string,
-  { page, server, browser }: Connections,
+  { page }: Connections,
   config: Config,
 ): Promise<void> {
   let QUNIT_RESULT: QUnitResult | null | undefined;
@@ -878,8 +840,8 @@ async function runTestInsideHTMLFile(
   // startupMs / 80s testsJsMs / 25s per-test timer — a 60s hang is the exact window where
   // the test runner's 60s SIGTERM beats the daemon's 'done' message, leaving the client
   // with code=null instead of an exit code. Catch-block diagnostics then fire as for any
-  // other timeout, and (in daemon mode) failOnNonWatchMode throws DaemonRunError so the
-  // daemon writes 'done' to its socket fast.
+  // other timeout, and failOnNonWatchMode rejects the group so the orchestrator finishes the
+  // run promptly — which is what lets the daemon write 'done' to its socket fast.
   page.on('close', resolveTestRace);
 
   try {
@@ -1003,14 +965,7 @@ async function runTestInsideHTMLFile(
   }
 
   const outcome = classifyRunOutcome(QUNIT_RESULT, doneReceived);
-  const failRun = () =>
-    failOnNonWatchMode(
-      config.watch,
-      { server, browser, page },
-      config.state.group.groupMode,
-      config.state.group.pendingConsoleHandlers,
-      !!config.state.daemon,
-    );
+  const failRun = () => failOnNonWatchMode(config.watch);
 
   if (outcome.kind === 'no-tests-ran') {
     // No 'done' arrived: either no QUnit tally at all, or a zero tally the runtime pre-initialised
@@ -1024,7 +979,7 @@ async function runTestInsideHTMLFile(
     console.log(`# TIMEOUT: ${wsReason}`);
     console.log('BROWSER: runtime error thrown during executing tests');
     console.error('BROWSER: runtime error thrown during executing tests');
-    await failRun();
+    failRun();
   } else if (outcome.kind === 'empty') {
     // QUnit fired 'done' with zero registered tests — a genuinely empty file (e.g. a helper).
     // Not a failure — handled at the run level as a warning.
@@ -1036,7 +991,7 @@ async function runTestInsideHTMLFile(
     );
     console.log(`BROWSER: TEST TIMED OUT: ${QUNIT_RESULT!.currentTest}`);
     console.error(`BROWSER: TEST TIMED OUT: ${QUNIT_RESULT!.currentTest}`);
-    await failRun();
+    failRun();
   } else if (config.state.groupCount === 1) {
     // Every registered test finished. The WebSocket testEnd stream is the only channel that
     // feeds the counter, and under load (a CPU-starved CI runner, a dropped or duplicated
@@ -1068,11 +1023,11 @@ async function runTestInsideHTMLFile(
  * How a browser run ended, decided from QUnit's tally plus whether a WS `done` arrived.
  *
  * ```ts
- * const outcome: RunOutcome = classifyRunOutcome(null, false);
+ * const outcome: BrowserRunOutcome = classifyRunOutcome(null, false);
  * outcome.kind; // 'no-tests-ran'
  * ```
  */
-export type RunOutcome =
+export type BrowserRunOutcome =
   | { kind: 'completed' } // every registered test finished; the caller reconciles the counter
   | { kind: 'empty' } // QUnit fired `done` with zero registered tests — a genuinely empty file
   | { kind: 'no-tests-ran' } // no `done`: a timeout that never executed tests (fail, not green)
@@ -1099,7 +1054,7 @@ export type RunOutcome =
 export function classifyRunOutcome(
   result: QUnitResult | null | undefined,
   doneReceived: boolean,
-): RunOutcome {
+): BrowserRunOutcome {
   if (!result) return { kind: 'no-tests-ran' };
   if (result.totalTests === 0) return doneReceived ? { kind: 'empty' } : { kind: 'no-tests-ran' };
   if (result.totalTests > result.finishedTests) return { kind: 'stalled' };
@@ -1137,29 +1092,14 @@ export function reconcileUndeliveredResults(counter: Counter, result: QUnitResul
   return undelivered;
 }
 
-async function failOnNonWatchMode(
-  watchMode: boolean = false,
-  connections: { server?: HTTPServer; browser?: { close(): Promise<void> }; page?: Page } = {},
-  groupMode: boolean = false,
-  pendingHandlers?: Set<Promise<void>> | null,
-  daemonMode: boolean = false,
-): Promise<void> {
-  if (watchMode) return;
-  if (groupMode) {
-    // Parent orchestrator handles cleanup and exit; signal failure via throw.
-    throw new Error('Browser test run failed');
-  }
-  await flushConsoleHandlers(pendingHandlers, connections.page);
-  if (daemonMode) {
-    // Daemon owns browser/server lifetimes — throw so its run handler captures the code.
-    throw new DaemonRunError(1);
-  }
-  await closeWithGrace([
-    connections.server?.close(),
-    connections.browser?.close(),
-    shutdownPrelaunch(),
-  ]);
-  process.exit(1);
+/**
+ * A run that timed out or stalled. Watch mode keeps going — the next save is the retry. Anything
+ * else throws, and `runConcurrentMode` turns the rejected group into an exit code. It owns the
+ * browser, the server and the process's fate; this function owns none of the three, which is why
+ * the cleanup-and-exit arms it used to carry are gone.
+ */
+function failOnNonWatchMode(watchMode: boolean | undefined): void {
+  if (!watchMode) throw new Error('Browser test run failed');
 }
 
 // Converts an absolute file path to a relative import path esbuild can resolve from the run's

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -41,10 +41,18 @@ const ancestorNodeModules = (dir: string): string[] =>
       path.join(parts.slice(0, parts.length - i).join(path.sep) || path.sep, 'node_modules'),
     );
 
-// process.cwd() is fixed for the lifetime of the process — compute once and reuse
-// across every buildTestBundle / buildFilteredTests call rather than reallocating
-// the array of ancestor paths on every esbuild invocation.
-const ANCESTOR_NODE_MODULES = ancestorNodeModules(process.cwd());
+// Memoized per directory: a process almost always runs from one cwd, so this is the same
+// compute-once it replaces — but the JS API can resolve a different project per call, and
+// recomputing the ancestor list on every esbuild invocation would be pure waste.
+const nodePathsCache = new Map<string, string[]>();
+function nodePathsFrom(cwd: string): string[] {
+  const cached = nodePathsCache.get(cwd);
+  if (cached) return cached;
+  const paths = ancestorNodeModules(cwd);
+  nodePathsCache.set(cwd, paths);
+
+  return paths;
+}
 
 const RETRY_DELAY_MS = 100;
 const MAX_RETRIES = 3;
@@ -202,14 +210,14 @@ export async function buildTestBundle(config: Config): Promise<void> {
   const buildOptions: esbuild.BuildOptions = {
     stdin: {
       contents: allTestFilePaths
-        .map((filePath) => `import "${toEsbuildImportPath(filePath)}";`)
+        .map((filePath) => `import "${toEsbuildImportPath(filePath, config.cwd)}";`)
         .join(''),
-      resolveDir: process.cwd(),
+      resolveDir: config.cwd,
     },
     // Allow test files outside the project root (e.g. /tmp/my-test.ts) to import
     // packages from any node_modules on the ancestor chain of cwd — the same lookup
-    // order Node itself uses when resolving require() from process.cwd().
-    nodePaths: ANCESTOR_NODE_MODULES,
+    // order Node itself uses when resolving require() from the run's cwd.
+    nodePaths: nodePathsFrom(config.cwd),
     bundle: true,
     logLevel: 'silent',
     outfile,
@@ -221,7 +229,7 @@ export async function buildTestBundle(config: Config): Promise<void> {
     // `import { jsx } from 'react/jsx-runtime'` for .tsx/.jsx files. Per-file overrides via
     // tsconfig's `jsxImportSource` or a `@jsxImportSource <pkg>` pragma cover Vue/Preact/Solid.
     jsx: 'automatic',
-    plugins: [qunitxRuntimePlugin(), ...(config.plugins ?? [])],
+    plugins: [qunitxRuntimePlugin(config.cwd), ...(config.plugins ?? [])],
     // Required for --changed/--since dep-graph filter on subsequent runs (cache
     // populates here, reads in Config.setup). Inputs map carries the full reverse-dep
     // graph; output cost is negligible.
@@ -260,7 +268,7 @@ export async function buildTestBundle(config: Config): Promise<void> {
     config.state.group.sourceMapDecoder = SourceMap.extractInline(allTestCode, outDir);
     // Persist metafile for the next --changed run. Best-effort; cache miss
     // on subsequent reads degrades to "run all tests."
-    if (metafile) void MetafileCache.write(projectRoot, process.cwd(), metafile);
+    if (metafile) void MetafileCache.write(projectRoot, config.cwd, metafile);
     build.lastBuildErrored = false;
   } catch (error) {
     build.lastBuildErrored = true;
@@ -413,11 +421,7 @@ export async function run(
       if (config.coverage) await Coverage.Report.write(config, allTestFilePaths);
 
       if (config.after) {
-        await runUserModule(
-          `${process.cwd()}/${config.after}`,
-          config.state.results.counter,
-          'after',
-        );
+        await runUserModule(`${config.cwd}/${config.after}`, config.state.results.counter, 'after');
       }
 
       if (!config.watch) {
@@ -529,7 +533,7 @@ export async function buildAllGroupBundles(groupConfigs: Config[]): Promise<void
     groupConfig.state.group.build.fallbackPage = null;
   });
 
-  const { projectRoot, browser } = groupConfigs[0];
+  const { projectRoot, browser, cwd } = groupConfigs[0];
 
   // Build each group's descriptor in one pass, skipping empty groups (overlayfs race).
   // Their build.allTestCode stays null so run's early-return handles them.
@@ -579,9 +583,9 @@ export async function buildAllGroupBundles(groupConfigs: Config[]): Promise<void
         const slotIndex = parseInt(args.path.replace('group-entry-', ''));
         return {
           contents: activeGroups[slotIndex].files
-            .map((filePath) => `import "${toEsbuildImportPath(filePath)}";`)
+            .map((filePath) => `import "${toEsbuildImportPath(filePath, cwd)}";`)
             .join(''),
-          resolveDir: process.cwd(),
+          resolveDir: cwd,
         };
       });
     },
@@ -598,8 +602,8 @@ export async function buildAllGroupBundles(groupConfigs: Config[]): Promise<void
     // groupEntryPlugin must run first — it owns the virtual entry-point modules every other
     // plugin sees. User plugins follow and apply to the resolved test files just like in
     // single-group mode (`buildTestBundle`).
-    plugins: [groupEntryPlugin, qunitxRuntimePlugin(), ...(groupConfigs[0].plugins ?? [])],
-    nodePaths: ANCESTOR_NODE_MODULES,
+    plugins: [groupEntryPlugin, qunitxRuntimePlugin(cwd), ...(groupConfigs[0].plugins ?? [])],
+    nodePaths: nodePathsFrom(cwd),
     bundle: true,
     logLevel: 'silent',
     // outdir only labels the paths in outputFiles[].path — nothing is written to disk
@@ -662,7 +666,7 @@ export async function buildAllGroupBundles(groupConfigs: Config[]): Promise<void
     );
     // Persist metafile for the next --changed run (same cache as single-group path).
     if (result.metafile) {
-      void MetafileCache.write(projectRoot, process.cwd(), result.metafile as AffectedMetafile);
+      void MetafileCache.write(projectRoot, cwd, result.metafile as AffectedMetafile);
     }
   } catch (error) {
     const buildError = { type: deriveBuildErrorType(error), formatted: formatBuildErrors(error) };
@@ -719,9 +723,9 @@ function buildFilteredTests(
         contents: filteredTests
           .map((filePath) => `import "${filePath.replace(/\\/g, '/')}";`)
           .join(''),
-        resolveDir: process.cwd(),
+        resolveDir: config.cwd,
       },
-      nodePaths: ANCESTOR_NODE_MODULES,
+      nodePaths: nodePathsFrom(config.cwd),
       bundle: true,
       logLevel: 'silent',
       outfile: outputPath,
@@ -729,7 +733,7 @@ function buildFilteredTests(
       target: esbuildTarget(config.browser),
       sourcemap,
       jsx: 'automatic',
-      plugins: [qunitxRuntimePlugin(), ...(config.plugins ?? [])],
+      plugins: [qunitxRuntimePlugin(config.cwd), ...(config.plugins ?? [])],
       footer: { js: 'window.dispatchEvent(new CustomEvent("qunitx:tests-ready"));' },
     },
     needsDisk,
@@ -1158,11 +1162,11 @@ async function failOnNonWatchMode(
   process.exit(1);
 }
 
-// Converts an absolute file path to a relative import path esbuild can resolve from
-// process.cwd(). On Windows, absolute paths like "D:/..." are treated as bare module
-// specifiers in stdin content, so we must use relative paths instead.
-function toEsbuildImportPath(filePath: string): string {
-  const rel = path.relative(process.cwd(), filePath);
+// Converts an absolute file path to a relative import path esbuild can resolve from the run's
+// cwd. On Windows, absolute paths like "D:/..." are treated as bare module specifiers in stdin
+// content, so we must use relative paths instead.
+function toEsbuildImportPath(filePath: string, cwd: string): string {
+  const rel = path.relative(cwd, filePath);
   const normalized = rel.replace(/\\/g, '/');
   if (path.isAbsolute(rel)) return filePath.replace(/\\/g, '/');
   return normalized.startsWith('.') ? normalized : './' + normalized;

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -434,7 +434,6 @@ export async function run(
     }
   } catch (error) {
     build.activeRebuild = null;
-    config.state.group.lastFailedFiles = config.state.group.lastRanFiles;
     const exception = new BundleError(error);
 
     // buildTestBundle's own catch sets the build-error fallback for full-bundle failures before rethrowing.

--- a/lib/commands/run/tests-in-browser.ts
+++ b/lib/commands/run/tests-in-browser.ts
@@ -189,9 +189,10 @@ export async function buildTestBundle(config: Config): Promise<void> {
   // with no test modules. The pending-trigger mechanism will fire a correct rebuild once
   // the IN_CREATE event re-adds the file to fsTree.
   if (allTestFilePaths.length === 0) {
-    return console.log(
-      '# [buildTestBundle] fsTree is empty — skipping build (no test files found)',
-    );
+    return Reporter.notice(config, {
+      level: 'warning',
+      message: '[buildTestBundle] fsTree is empty — skipping build (no test files found)',
+    });
   }
 
   const outDir = path.resolve(projectRoot, output);
@@ -249,8 +250,8 @@ export async function buildTestBundle(config: Config): Promise<void> {
   try {
     const [{ js: allTestCode, metafile }] = await Promise.all([
       config.watch || config.state.daemon
-        ? buildIncrementally(buildOptions, fileKey, cacheHolder, needsDisk)
-        : buildWithOverlayfsRetry(buildOptions, needsDisk),
+        ? buildIncrementally(buildOptions, fileKey, cacheHolder, needsDisk, config)
+        : buildWithOverlayfsRetry(buildOptions, needsDisk, config),
       Promise.all(
         build.htmlPathsToRunTests.map(async (htmlPath) => {
           const targetPath = path.join(outDir, htmlPath);
@@ -374,11 +375,14 @@ export async function run(
       build.activeRebuild = null;
       if (!build.allTestCode) {
         const fallback = build.fallbackPage;
-        config.watch &&
-          fallback?.kind === 'build-error' &&
-          console.log(
-            `# esbuild Bundle Error: ${fallback.error.formatted}`.split('\n').join('\n# '),
-          );
+        if (config.watch && fallback?.kind === 'build-error') {
+          // Every line of the block gets its own `#`, so a multi-line esbuild message stays
+          // inside the TAP document rather than breaking out of it.
+          Reporter.notice(config, {
+            level: 'error',
+            message: `esbuild Bundle Error: ${fallback.error.formatted}`.split('\n').join('\n# '),
+          });
+        }
         return connections;
       }
     }
@@ -396,9 +400,10 @@ export async function run(
         );
         build.fallbackPage = { kind: 'no-tests', files: displayFiles };
         const fileWord = allTestFilePaths.length === 1 ? 'file' : 'files';
-        console.log(
-          `# Warning: 0 tests registered — no QUnit test cases found in ${allTestFilePaths.length} ${fileWord}`,
-        );
+        Reporter.notice(config, {
+          level: 'warning',
+          message: `Warning: 0 tests registered — no QUnit test cases found in ${allTestFilePaths.length} ${fileWord}`,
+        });
         Task(
           fs.writeFile(path.join(outDir, 'index.html'), WebServer.buildNoTestsHTML(displayFiles)),
         ).ignore('no-tests fallback page write');
@@ -449,7 +454,7 @@ export async function run(
     }
 
     if (config.watch) {
-      console.log(`# ${exception}`);
+      Reporter.notice(config, { level: 'error', message: String(exception) });
     } else {
       throw exception;
     }
@@ -542,9 +547,10 @@ export async function buildAllGroupBundles(groupConfigs: Config[]): Promise<void
   );
 
   if (activeGroups.length === 0)
-    return console.log(
-      '# [buildAllGroupBundles] all groups empty — skipping build (no test files found)',
-    );
+    return Reporter.notice(groupConfigs[0], {
+      level: 'warning',
+      message: '[buildAllGroupBundles] all groups empty — skipping build (no test files found)',
+    });
 
   await Promise.all(
     activeGroups.map((group) =>
@@ -699,6 +705,7 @@ function buildFilteredTests(
       footer: { js: 'window.dispatchEvent(new CustomEvent("qunitx:tests-ready"));' },
     },
     needsDisk,
+    config,
   ).then((r) => r.js);
 }
 
@@ -714,6 +721,7 @@ function buildFilteredTests(
 async function runWithOverlayfsRetry(
   getContents: () => Promise<{ result: esbuild.BuildResult; js: Buffer }>,
   needsDisk: boolean,
+  config: Config,
 ): Promise<{ js: Buffer; metafile?: AffectedMetafile }> {
   let { result, js } = await getContents();
   const initialSize = js.length;
@@ -729,9 +737,10 @@ async function runWithOverlayfsRetry(
   // If the size never moved from the initial value, the file is just legitimately small
   // (no QUnit imports, tree-shaken to the footer only) and no warning is needed.
   if (js.length < EMPTY_BUNDLE_THRESHOLD && js.length !== initialSize) {
-    console.log(
-      `# [buildWithOverlayfsRetry] bundle is ${js.length} bytes after ${MAX_RETRIES} retries — proceeding`,
-    );
+    Reporter.notice(config, {
+      level: 'warning',
+      message: `[buildWithOverlayfsRetry] bundle is ${js.length} bytes after ${MAX_RETRIES} retries — proceeding`,
+    });
   }
 
   if (needsDisk) {
@@ -746,13 +755,18 @@ async function runWithOverlayfsRetry(
 function buildWithOverlayfsRetry(
   options: esbuild.BuildOptions,
   needsDisk: boolean,
+  config: Config,
 ): Promise<{ js: Buffer; metafile?: AffectedMetafile }> {
   const buildOpts: esbuild.BuildOptions = { ...options, write: false };
-  return runWithOverlayfsRetry(async () => {
-    const result = await esbuild.build(buildOpts);
-    const jsFile = result.outputFiles!.find((f) => !f.path.endsWith('.map'))!;
-    return { result, js: Buffer.from(jsFile.contents) };
-  }, needsDisk);
+  return runWithOverlayfsRetry(
+    async () => {
+      const result = await esbuild.build(buildOpts);
+      const jsFile = result.outputFiles!.find((f) => !f.path.endsWith('.map'))!;
+      return { result, js: Buffer.from(jsFile.contents) };
+    },
+    needsDisk,
+    config,
+  );
 }
 
 // Uses an esbuild incremental context so the module graph stays warm between rebuilds.
@@ -767,6 +781,7 @@ async function buildIncrementally(
   fileKey: string,
   cache: EsbuildCache,
   needsDisk: boolean,
+  config: Config,
 ): Promise<{ js: Buffer; metafile?: AffectedMetafile }> {
   const buildOpts: esbuild.BuildOptions = { ...options, write: false };
 
@@ -777,11 +792,15 @@ async function buildIncrementally(
   }
 
   const ctx = cache.context!;
-  return runWithOverlayfsRetry(async () => {
-    const result = await ctx.rebuild();
-    const jsFile = result.outputFiles!.find((f) => !f.path.endsWith('.map'))!;
-    return { result, js: Buffer.from(jsFile.contents) };
-  }, needsDisk);
+  return runWithOverlayfsRetry(
+    async () => {
+      const result = await ctx.rebuild();
+      const jsFile = result.outputFiles!.find((f) => !f.path.endsWith('.map'))!;
+      return { result, js: Buffer.from(jsFile.contents) };
+    },
+    needsDisk,
+    config,
+  );
 }
 
 /**
@@ -806,7 +825,6 @@ async function runTestInsideHTMLFile(
   // this is what tells a genuinely-empty run (done, 0 tests) apart from a timeout that never ran
   // tests (no done, but the runtime pre-initialised window.QUNIT_RESULT to a 0 tally).
   let doneReceived = false;
-  let targetError: unknown;
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   // wsConnected is set by config.state.group.signals.onWsOpen when Chrome's WS socket opens (< 1s after navigation,
   // before test bundle compilation finishes). Distinguishes "WS never opened" from "WS opened
@@ -849,7 +867,10 @@ async function runTestInsideHTMLFile(
     // spec/dot/github run. --debug forces it on regardless: the URL is the whole point of
     // debug mode (open it in a real browser), whatever the reporter.
     if (config.reporter === 'tap' || config.debug) {
-      console.log('#', blue(`QUnitX running: http://localhost:${config.port}${filePath}`));
+      Reporter.notice(config, {
+        level: 'info',
+        message: blue(`QUnitX running: http://localhost:${config.port}${filePath}`),
+      });
     }
 
     // navMs is the budget Playwright gets to commit the navigation. Startup race timers must
@@ -944,9 +965,9 @@ async function runTestInsideHTMLFile(
       config.state.group.lastQUnitResult ??
       (await page.evaluate(() => (globalThis as { QUNIT_RESULT?: QUnitResult }).QUNIT_RESULT));
   } catch (error) {
-    targetError = error;
-    console.log(error);
-    console.error(error);
+    // Dumped once, here. The outcome branches below used to re-log the same error before their
+    // own `# TIMEOUT:` line, printing every navigation failure twice.
+    dumpError(config, error);
   } finally {
     clearTimeout(timeoutHandle);
     page.off('close', resolveTestRace);
@@ -972,25 +993,32 @@ async function runTestInsideHTMLFile(
     // before tests.js ran (a CPU-starved page load whose race timer fired first). Both mean the
     // tests never executed — a timeout, not a green run. This used to slip through as a silent
     // exit-0 when the pre-initialised {totalTests:0} looked like a genuinely empty file.
-    if (targetError) console.log(targetError);
     const wsReason = !wsConnected
       ? 'WebSocket connection never received — Chrome may be CPU-starved or the page failed to load'
       : 'WebSocket connected but no tests ran — QUnit may have failed to start';
-    console.log(`# TIMEOUT: ${wsReason}`);
-    console.log('BROWSER: runtime error thrown during executing tests');
-    console.error('BROWSER: runtime error thrown during executing tests');
+    Reporter.notice(config, { level: 'error', message: `TIMEOUT: ${wsReason}` });
+    Reporter.notice(config, {
+      level: 'error',
+      raw: true,
+      stream: 'both',
+      message: 'BROWSER: runtime error thrown during executing tests\n',
+    });
     failRun();
   } else if (outcome.kind === 'empty') {
     // QUnit fired 'done' with zero registered tests — a genuinely empty file (e.g. a helper).
     // Not a failure — handled at the run level as a warning.
     return;
   } else if (outcome.kind === 'stalled') {
-    if (targetError) console.log(targetError);
-    console.log(
-      `# TIMEOUT: test stalled after ${QUNIT_RESULT!.finishedTests}/${QUNIT_RESULT!.totalTests} finished — last active: ${QUNIT_RESULT!.currentTest}`,
-    );
-    console.log(`BROWSER: TEST TIMED OUT: ${QUNIT_RESULT!.currentTest}`);
-    console.error(`BROWSER: TEST TIMED OUT: ${QUNIT_RESULT!.currentTest}`);
+    Reporter.notice(config, {
+      level: 'error',
+      message: `TIMEOUT: test stalled after ${QUNIT_RESULT!.finishedTests}/${QUNIT_RESULT!.totalTests} finished — last active: ${QUNIT_RESULT!.currentTest}`,
+    });
+    Reporter.notice(config, {
+      level: 'error',
+      raw: true,
+      stream: 'both',
+      message: `BROWSER: TEST TIMED OUT: ${QUNIT_RESULT!.currentTest}\n`,
+    });
     failRun();
   } else if (config.state.groupCount === 1) {
     // Every registered test finished. The WebSocket testEnd stream is the only channel that
@@ -1003,13 +1031,15 @@ async function runTestInsideHTMLFile(
     // tally cannot safely rewrite it (the multi-group failure safety net below still applies).
     const undelivered = reconcileUndeliveredResults(config.state.results.counter, QUNIT_RESULT!);
     if (undelivered > 0) {
-      const warning =
-        `# [qunitx] WARNING: ${undelivered} test result(s) finished in the browser but never ` +
-        `reached the runner — the WebSocket stream under-delivered (CPU-starved runner or a ` +
-        `dropped connection). Reconciled from QUnit's own tally so the summary and exit code ` +
-        `are correct; re-run to get the per-test lines back.\n`;
-      process.stdout.write(warning);
-      process.stderr.write(warning);
+      Reporter.notice(config, {
+        level: 'warning',
+        stream: 'both',
+        message:
+          `[qunitx] WARNING: ${undelivered} test result(s) finished in the browser but never ` +
+          `reached the runner — the WebSocket stream under-delivered (CPU-starved runner or a ` +
+          `dropped connection). Reconciled from QUnit's own tally so the summary and exit code ` +
+          `are correct; re-run to get the per-test lines back.`,
+      });
     }
   } else if (QUNIT_RESULT!.failedTests > config.state.results.counter.failCount) {
     // Multi-group safety net: the shared counter aggregates every group, so we cannot rewrite
@@ -1090,6 +1120,19 @@ export function reconcileUndeliveredResults(counter: Counter, result: QUnitResul
     counter.testCount - counter.failCount - counter.skipCount - counter.todoCount,
   );
   return undelivered;
+}
+
+/**
+ * Emits a caught error verbatim on both streams — the shape `console.log(err)` +
+ * `console.error(err)` produced, minus the `#` prefix a stack must not carry.
+ */
+function dumpError(config: Config, error: unknown): void {
+  Reporter.notice(config, {
+    level: 'error',
+    raw: true,
+    stream: 'both',
+    message: `${(error as Error)?.stack ?? String(error)}\n`,
+  });
 }
 
 /**

--- a/lib/commands/search.ts
+++ b/lib/commands/search.ts
@@ -27,7 +27,7 @@ interface ScannedFile {
 }
 
 /** One test found by the static scan, named exactly as QUnit would name it. */
-interface FoundTest {
+export interface FoundTest {
   /** Absolute path of the file it was declared in — used to apply that file's line targets. */
   file: string;
   /** Module path, ' > '-joined; '' for a top-level test. */
@@ -65,6 +65,103 @@ interface FoundTest {
  * @returns the process exit code: 0 when something matched, 1 when nothing did (as `grep` does).
  */
 export async function run(config: Config): Promise<number> {
+  const report = await scan(config);
+  const { output } = config.state;
+  // Folded rather than `Math.max(0, ...matches.map(…))`: the spread passes one argument per match,
+  // which throws RangeError once a suite is large enough, and the map allocates an array to throw
+  // away. One write rather than one per line — a big listing is thousands of syscalls otherwise.
+  const width = report.matches.reduce((widest, test) => Math.max(widest, test.fullName.length), 0);
+  output.write(
+    report.matches
+      .map((test) => `${test.fullName.padEnd(width)}  ${blue(test.location)}\n`)
+      .join(''),
+  );
+
+  output.write(
+    `\n${report.matches.length} of ${report.total} test${report.total === 1 ? '' : 's'}` +
+      `${report.filter ? ` match ${JSON.stringify(report.filter)}` : ''}` +
+      ` in ${report.files} file${report.files === 1 ? '' : 's'}\n`,
+  );
+  for (const warning of report.warnings) {
+    output.write(yellow(`# qunitx: ${warning}\n`));
+  }
+  if (report.computedNames > 0) {
+    // Deliberately "declaration", not "test": one `test(`case ${i}`)` inside a loop is a single
+    // declaration that becomes N tests at runtime, and the scan cannot know N.
+    output.write(
+      yellow(
+        `# ${report.computedNames} test declaration${report.computedNames === 1 ? '' : 's'} named at runtime ` +
+          `(e.g. test(\`case \${i}\`)) cannot be listed without running — they may still match.\n`,
+      ),
+    );
+  }
+  if (report.unparseable > 0) {
+    output.write(
+      yellow(
+        `# ${report.unparseable} file${report.unparseable === 1 ? '' : 's'} could not be parsed.\n`,
+      ),
+    );
+  }
+  if (report.silent > 0) {
+    output.write(
+      yellow(
+        `# ${report.silent} file${report.silent === 1 ? '' : 's'} declared no tests the scan could see — a ` +
+          `declarator reached through a local alias (const t = QUnit.test) is invisible to it.\n`,
+      ),
+    );
+  }
+
+  return report.matches.length > 0 ? 0 : 1;
+}
+
+/**
+ * What the static scan found, before anything is printed.
+ *
+ * Separated from {@link run} so the same answer can be a value: `run` is this plus a listing,
+ * and the JS API's `search()` is this plus nothing.
+ *
+ * ```ts
+ * const report: SearchReport = {
+ *   matches: [], total: 12, files: 3, filter: 'Cart',
+ *   warnings: [], computedNames: 0, unparseable: 0, silent: 0,
+ * };
+ * report.matches.length; // 0 of 12 — the filter matched nothing
+ * ```
+ */
+export interface SearchReport {
+  /** The tests the current selection matches, in declaration order. */
+  matches: FoundTest[];
+  /** Every listable test found, matched or not. */
+  total: number;
+  /** How many files were scanned. */
+  files: number;
+  /** The expression matched against, or `undefined` when everything was listed. */
+  filter?: string;
+  /** Line-target resolution warnings, in input order. */
+  warnings: string[];
+  /** Declarations whose name is computed at runtime, and so cannot be listed. */
+  computedNames: number;
+  /** Files that could not be read or parsed. */
+  unparseable: number;
+  /** Files that declared no test the scan could see (e.g. via a local declarator alias). */
+  silent: number;
+}
+
+/**
+ * Scans the selected files and resolves which of their tests the current selection matches —
+ * no browser, no bundle, no execution.
+ *
+ * ```ts
+ * import type { Config } from '../types.ts';
+ *
+ * // Defined, not invoked: reads and parses every selected file.
+ * async function preview(config: Config) {
+ *   const report = await scan(config);
+ *   return `${report.matches.length} of ${report.total}`;
+ * }
+ * ```
+ */
+export async function scan(config: Config): Promise<SearchReport> {
   // A bare --search/--print has no expression of its own, so it previews whatever -t/-m set; with
   // neither, an undefined filter matches everything and the command lists the whole suite.
   const filter = typeof config.search === 'string' ? config.search : config.filter;
@@ -89,7 +186,7 @@ export async function run(config: Config): Promise<number> {
 
   for (const record of scanned) {
     // Pushed one at a time rather than spread: `push(...tests)` passes one argument per test and
-    // throws RangeError once a suite is large enough — the same trap as the `Math.max` below.
+    // throws RangeError once a suite is large enough.
     for (const test of record.tests) found.push(test);
     computedNames += record.computedNames;
 
@@ -104,50 +201,18 @@ export async function run(config: Config): Promise<number> {
     }
   }
 
-  const matches = found.filter(
-    (test) => matchQUnitFilter(filter, test.fullName) && matchesLineTargets(test, lineSelectors),
-  );
-  // Folded rather than `Math.max(0, ...matches.map(…))`: the spread passes one argument per match,
-  // which throws RangeError once a suite is large enough, and the map allocates an array to throw
-  // away. One write rather than one per line — a big listing is thousands of syscalls otherwise.
-  const width = matches.reduce((widest, test) => Math.max(widest, test.fullName.length), 0);
-  process.stdout.write(
-    matches.map((test) => `${test.fullName.padEnd(width)}  ${blue(test.location)}\n`).join(''),
-  );
-
-  process.stdout.write(
-    `\n${matches.length} of ${found.length} test${found.length === 1 ? '' : 's'}` +
-      `${filter ? ` match ${JSON.stringify(filter)}` : ''}` +
-      ` in ${files.length} file${files.length === 1 ? '' : 's'}\n`,
-  );
-  for (const warning of warnings) {
-    process.stdout.write(yellow(`# qunitx: ${warning}\n`));
-  }
-  if (computedNames > 0) {
-    // Deliberately "declaration", not "test": one `test(`case ${i}`)` inside a loop is a single
-    // declaration that becomes N tests at runtime, and the scan cannot know N.
-    process.stdout.write(
-      yellow(
-        `# ${computedNames} test declaration${computedNames === 1 ? '' : 's'} named at runtime ` +
-          `(e.g. test(\`case \${i}\`)) cannot be listed without running — they may still match.\n`,
-      ),
-    );
-  }
-  if (unparseable > 0) {
-    process.stdout.write(
-      yellow(`# ${unparseable} file${unparseable === 1 ? '' : 's'} could not be parsed.\n`),
-    );
-  }
-  if (silent > 0) {
-    process.stdout.write(
-      yellow(
-        `# ${silent} file${silent === 1 ? '' : 's'} declared no tests the scan could see — a ` +
-          `declarator reached through a local alias (const t = QUnit.test) is invisible to it.\n`,
-      ),
-    );
-  }
-
-  return matches.length > 0 ? 0 : 1;
+  return {
+    matches: found.filter(
+      (test) => matchQUnitFilter(filter, test.fullName) && matchesLineTargets(test, lineSelectors),
+    ),
+    total: found.length,
+    files: files.length,
+    filter,
+    warnings,
+    computedNames,
+    unparseable,
+    silent,
+  };
 }
 
 /** Per-file resolved line targets. `selectors: null` means "run the whole file" (no restriction). */

--- a/lib/coverage/report.ts
+++ b/lib/coverage/report.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { green, red, yellow } from '../utils/color.ts';
 import type { Config, CoverageFileMap, FileCoverage } from '../types.ts';
+import * as Reporter from '../reporters/index.ts';
 
 /**
  * Renders the run's accumulated line coverage: an always-on terminal summary, plus the optional
@@ -65,19 +66,24 @@ const ARTIFACTS = [
 export async function write(config: Config, testFiles: string[]): Promise<void> {
   const collector = config.state.results.coverage;
   if (!collector || collector.size === 0) {
-    process.stdout.write(
-      '# Coverage: no coverable sources found (bundle mapped only to node_modules / test files)\n',
-    );
+    Reporter.notice(config, {
+      level: 'info',
+      message:
+        'Coverage: no coverable sources found (bundle mapped only to node_modules / test files)',
+    });
     return;
   }
 
   const rows = buildRows(collector, new Set(testFiles), config.projectRoot);
   if (rows.length === 0) {
-    process.stdout.write('# Coverage: no non-test sources found to report\n');
+    Reporter.notice(config, {
+      level: 'info',
+      message: 'Coverage: no non-test sources found to report',
+    });
     return;
   }
 
-  printTerminalSummary(rows);
+  printTerminalSummary(config, rows);
 
   const formats = config.coverageFormats ?? [];
   if (formats.length === 0) return;
@@ -95,7 +101,11 @@ export async function write(config: Config, testFiles: string[]): Promise<void> 
       return `# wrote coverage ${format} to ${toDisplayPath(filePath, config.projectRoot)}\n`;
     },
   );
-  process.stdout.write((await Promise.all(formatWrites)).join(''));
+  Reporter.notice(config, {
+    level: 'info',
+    raw: true,
+    message: (await Promise.all(formatWrites)).join(''),
+  });
 }
 
 /**
@@ -140,7 +150,7 @@ export function buildRows(
     .sort((a, b) => a.displayPath.localeCompare(b.displayPath));
 }
 
-function printTerminalSummary(rows: FileRow[]): void {
+function printTerminalSummary(config: Config, rows: FileRow[]): void {
   const { totalLines, coveredLines, overallPct } = overallCoverage(rows);
 
   const pathWidth = Math.min(
@@ -150,9 +160,12 @@ function printTerminalSummary(rows: FileRow[]): void {
   const divider = `# ${'-'.repeat(pathWidth + 20)}`;
 
   // Assemble, then write once. The table is one frame of output, and a concurrent group's TAP
-  // interleaving between rows would tear it apart — a per-row write invites exactly that.
-  process.stdout.write(
-    [
+  // interleaving between rows would tear it apart — a per-row write invites exactly that. Raw,
+  // because every line already carries the `#` its own alignment depends on.
+  Reporter.notice(config, {
+    level: 'info',
+    raw: true,
+    message: [
       '#',
       '# Coverage (V8 line coverage)',
       divider,
@@ -164,7 +177,7 @@ function printTerminalSummary(rows: FileRow[]): void {
       divider,
       '',
     ].join('\n'),
-  );
+  });
 }
 
 function formatRow(

--- a/lib/reporters/dot.ts
+++ b/lib/reporters/dot.ts
@@ -46,16 +46,16 @@ export class DotReporter implements Reporter {
    * }
    * ```
    */
-  onRunStart(_config: Config, info: RunStartInfo): void {
+  onRunStart(config: Config, info: RunStartInfo): void {
     this.#column = 0;
     this.#failures = [];
     if (info.fileCount === null) return;
     if (info.fileCount === 0) {
-      process.stdout.write('\nNo test files found.\n');
+      config.state.output.write('\nNo test files found.\n');
       return;
     }
     const files = `${info.fileCount} test file${info.fileCount === 1 ? '' : 's'}`;
-    process.stdout.write(`\nRunning ${files} across ${info.groupCount} worker(s)\n\n`);
+    config.state.output.write(`\nRunning ${files} across ${info.groupCount} worker(s)\n\n`);
   }
 
   /**
@@ -76,7 +76,9 @@ export class DotReporter implements Reporter {
     // group's output between the character and its own newline.
     const wrapped = ++this.#column >= LINE_WIDTH;
     if (wrapped) this.#column = 0;
-    process.stdout.write(wrapped ? `${statusDot(details.status)}\n` : statusDot(details.status));
+    config.state.output.write(
+      wrapped ? `${statusDot(details.status)}\n` : statusDot(details.status),
+    );
 
     if (details.status !== 'failed') return;
     this.#failures.push({
@@ -119,7 +121,7 @@ export class DotReporter implements Reporter {
       : '';
 
     // Leading newline closes the dot matrix when it ends mid-line.
-    process.stdout.write(`${this.#column > 0 ? '\n' : ''}${counts}\n${recap}\n`);
+    config.state.output.write(`${this.#column > 0 ? '\n' : ''}${counts}\n${recap}\n`);
   }
 }
 

--- a/lib/reporters/github.ts
+++ b/lib/reporters/github.ts
@@ -68,7 +68,7 @@ export class GithubReporter implements Reporter {
     // One annotation per failing assertion: each has its own location, and GitHub renders
     // them at their exact line. Emitted as one write so the block can't be split apart.
     const title = details.fullName.join(' | ');
-    process.stdout.write(
+    config.state.output.write(
       failedAssertions(details, config.state.group.sourceMapDecoder, config.projectRoot)
         .map((failure) => `${annotation(title, failure)}\n`)
         .join(''),

--- a/lib/reporters/index.ts
+++ b/lib/reporters/index.ts
@@ -60,7 +60,7 @@ export function create(config: Config): Reporter[] {
  * ```
  */
 export function runStart(config: Config, info: RunStartInfo): void {
-  config.state.reporters.forEach((reporter) => reporter.onRunStart?.(config, info));
+  fanOut(config, 'onRunStart', (reporter) => reporter.onRunStart?.(config, info));
 }
 
 /**
@@ -82,7 +82,7 @@ export function runStart(config: Config, info: RunStartInfo): void {
  */
 export function testEnd(config: Config, details: TestDetails): void {
   updateCounter(config.state.results.counter, details);
-  config.state.reporters.forEach((reporter) => reporter.onTestEnd?.(config, details));
+  fanOut(config, 'onTestEnd', (reporter) => reporter.onTestEnd?.(config, details));
 }
 
 /**
@@ -102,7 +102,13 @@ export function testEnd(config: Config, details: TestDetails): void {
  */
 export async function runEnd(config: Config, info: RunEndInfo): Promise<void> {
   for (const reporter of config.state.reporters) {
-    await reporter.onRunEnd?.(config, info);
+    // Awaited one at a time, and isolated the same way the sync hooks are: JUnit writes a file
+    // here, and a third-party reporter that rejects must not cost the run its artifacts.
+    try {
+      await reporter.onRunEnd?.(config, info);
+    } catch (error) {
+      reportReporterFailure(config, 'onRunEnd', error);
+    }
   }
 }
 
@@ -131,7 +137,7 @@ export function notice(config: Config, notice: Notice): void {
   const stream = notice.stream ?? 'output';
   if (stream !== 'error') config.state.output.write(line);
   if (stream !== 'output') config.state.output.error(line);
-  config.state.reporters.forEach((reporter) => reporter.onNotice?.(config, notice));
+  fanOut(config, 'onNotice', (reporter) => reporter.onNotice?.(config, notice));
 }
 
 /**
@@ -156,7 +162,34 @@ export function browserLog(config: Config, log: BrowserLog): void {
   // for an uncaught pageerror, so a crashed page is visible in a stdout-only or stderr-only log.
   if (log.type === 'pageerror') config.state.output.error(line);
   else config.state.output.write(line);
-  config.state.reporters.forEach((reporter) => reporter.onBrowserLog?.(config, log));
+  fanOut(config, 'onBrowserLog', (reporter) => reporter.onBrowserLog?.(config, log));
+}
+
+/**
+ * Delivers one event to every reporter, isolating each from the others.
+ *
+ * `Reporter` is public surface, so a reporter is third-party code, and a plain `forEach` gives
+ * the first one that throws the power to stop delivery to the rest — including the collector the
+ * JS API builds its result from, and the counter reconciliation that depends on it. A reporter
+ * that throws should cost its own output and nothing else.
+ */
+function fanOut(config: Config, hook: string, deliver: (reporter: Reporter) => void): void {
+  for (const reporter of config.state.reporters) {
+    try {
+      deliver(reporter);
+    } catch (error) {
+      reportReporterFailure(config, hook, error);
+    }
+  }
+}
+
+/**
+ * Reports a throwing reporter straight to the output rather than through `notice` — a reporter
+ * that throws from `onNotice` would otherwise be handed the notice about itself, and throw again.
+ */
+function reportReporterFailure(config: Config, hook: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  config.state.output.error(`# [qunitx] reporter ${hook} threw: ${message}\n`);
 }
 
 // Exactly one stdout reporter per run. `--reporter` is validated in Args.parse, so an

--- a/lib/reporters/index.ts
+++ b/lib/reporters/index.ts
@@ -4,7 +4,15 @@ import { DotReporter } from './dot.ts';
 import { GithubReporter } from './github.ts';
 import { JUnitReporter } from './junit.ts';
 import { updateCounter } from './types.ts';
-import type { Reporter, ReporterName, RunStartInfo, RunEndInfo, TestDetails } from './types.ts';
+import type {
+  BrowserLog,
+  Notice,
+  Reporter,
+  ReporterName,
+  RunStartInfo,
+  RunEndInfo,
+  TestDetails,
+} from './types.ts';
 import type { Config } from '../types.ts';
 
 // The `--reporter` value -> stdout reporter. Keyed by ReporterName so adding a name to
@@ -96,6 +104,59 @@ export async function runEnd(config: Config, info: RunEndInfo): Promise<void> {
   for (const reporter of config.state.reporters) {
     await reporter.onRunEnd?.(config, info);
   }
+}
+
+/**
+ * Emits one of qunitx's own diagnostics: renders it to the run's output as a TAP `#` comment,
+ * then hands the structured form to any reporter that wants it.
+ *
+ * Both halves matter. The rendering is what every `console.log('#', …)` scattered through the
+ * run pipeline used to do inline — which meant a run could not be made quiet, and a caller
+ * could not read the diagnostics back. Going through here, silence is a matter of the run's
+ * `output`, and capture is a matter of a reporter.
+ *
+ * ```ts
+ * import * as Reporter from './index.ts';
+ *
+ * import type { Config } from '../types.ts';
+ *
+ * // Defined, not invoked: writes '# No tests matched …' to the run's output.
+ * function warnNoMatches(config: Config, filter: string) {
+ *   Reporter.notice(config, { level: 'warning', message: `No tests matched ${filter}` });
+ * }
+ * ```
+ */
+export function notice(config: Config, notice: Notice): void {
+  const line = notice.raw ? notice.message : `# ${notice.message}\n`;
+  const stream = notice.stream ?? 'output';
+  if (stream !== 'error') config.state.output.write(line);
+  if (stream !== 'output') config.state.output.error(line);
+  config.state.reporters.forEach((reporter) => reporter.onNotice?.(config, notice));
+}
+
+/**
+ * Emits one `console.*` call or uncaught error from the page under test. Rendered verbatim —
+ * no `#` prefix — because it is the page's output, not qunitx's, and prefixing it would corrupt
+ * whatever the page was deliberately printing.
+ *
+ * ```ts
+ * import * as Reporter from './index.ts';
+ *
+ * import type { Config } from '../types.ts';
+ *
+ * // Defined, not invoked: writes the page's own line to the run's output.
+ * function forward(config: Config) {
+ *   Reporter.browserLog(config, { type: 'error', text: 'boom', args: [] });
+ * }
+ * ```
+ */
+export function browserLog(config: Config, log: BrowserLog): void {
+  const line = `${log.text}\n`;
+  // Matches what the page-event handlers did directly: console.log for everything, console.error
+  // for an uncaught pageerror, so a crashed page is visible in a stdout-only or stderr-only log.
+  if (log.type === 'pageerror') config.state.output.error(line);
+  else config.state.output.write(line);
+  config.state.reporters.forEach((reporter) => reporter.onBrowserLog?.(config, log));
 }
 
 // Exactly one stdout reporter per run. `--reporter` is validated in Args.parse, so an

--- a/lib/reporters/junit.ts
+++ b/lib/reporters/junit.ts
@@ -70,11 +70,26 @@ export class JUnitReporter implements Reporter {
    * }
    * ```
    */
+  /**
+   * The XML document as it stands. `onRunEnd` writes exactly this to disk; the JS API reads it
+   * back so a caller can ship the report somewhere other than the filesystem.
+   *
+   * ```ts
+   * const reporter = new JUnitReporter();
+   * reporter.xml().startsWith('<?xml'); // true — an empty but well-formed document
+   * ```
+   */
+  xml(): string {
+    return buildXML(this.#cases);
+  }
+
   async onRunEnd(config: Config, _info: RunEndInfo): Promise<void> {
     const file = outputPath(config);
     await fs.mkdir(path.dirname(file), { recursive: true });
-    await fs.writeFile(file, buildXML(this.#cases));
-    process.stdout.write(`# wrote JUnit report to ${relativeToRoot(file, config.projectRoot)}\n`);
+    await fs.writeFile(file, this.xml());
+    config.state.output.write(
+      `# wrote JUnit report to ${relativeToRoot(file, config.projectRoot)}\n`,
+    );
   }
 }
 

--- a/lib/reporters/junit.ts
+++ b/lib/reporters/junit.ts
@@ -83,6 +83,19 @@ export class JUnitReporter implements Reporter {
     return buildXML(this.#cases);
   }
 
+  /**
+   * Serializes the accumulated cases and writes the XML document to disk.
+   *
+   * ```ts
+   * import type { Config } from '../types.ts';
+   *
+   * // Defined, not invoked: writes the XML document to disk.
+   * async function example(reporter: JUnitReporter, config: Config) {
+   *   await reporter.onRunEnd(config, { durationMs: 40 });
+   *   // "# wrote JUnit report to tmp/junit.xml" on the run's output
+   * }
+   * ```
+   */
   async onRunEnd(config: Config, _info: RunEndInfo): Promise<void> {
     const file = outputPath(config);
     await fs.mkdir(path.dirname(file), { recursive: true });

--- a/lib/reporters/output.ts
+++ b/lib/reporters/output.ts
@@ -1,0 +1,78 @@
+/**
+ * Where a run's text goes.
+ *
+ * Every reporter and every `#` diagnostic writes through the run's {@link Output} rather than
+ * touching `process.stdout` directly, which is what makes "run these tests and don't print
+ * anything" expressible at all — and what lets a caller point the built-in TAP reporter at a
+ * file, a socket, or a string buffer without the run knowing the difference.
+ *
+ * Two methods rather than one Writable, because the only two things the run does are "say
+ * something" and "say something that also belongs on stderr". A `Writable` would additionally
+ * drag in backpressure, encodings and a close lifecycle that no caller here has to think about.
+ *
+ * ```ts
+ * const lines: string[] = [];
+ * const output: Output = { write: (text) => void lines.push(text), error: () => {} };
+ * output.write('ok 1 Math | adds\n');
+ * lines; // ['ok 1 Math | adds\n']
+ * ```
+ */
+export interface Output {
+  /** Writes to the primary stream — the TAP/spec/dot document itself. */
+  write(text: string): void;
+  /** Writes to the error stream. Diagnostics that must survive a swallowed stdout go here too. */
+  error(text: string): void;
+}
+
+/**
+ * The CLI's output: the real process streams.
+ *
+ * ```ts
+ * import { processOutput } from './output.ts';
+ *
+ * // Defined, not invoked: writes to the host process's stdout.
+ * function announce() {
+ *   processOutput.write('TAP version 13\n');
+ * }
+ * ```
+ */
+export const processOutput: Output = {
+  write: (text) => void process.stdout.write(text),
+  error: (text) => void process.stderr.write(text),
+};
+
+/**
+ * An output that discards everything. The JS API's default, so a programmatic run is silent
+ * unless the caller asks for a reporter and somewhere to put it.
+ *
+ * ```ts
+ * import { silentOutput } from './output.ts';
+ *
+ * silentOutput.write('nothing happens'); // undefined — and nothing is printed
+ * ```
+ */
+export const silentOutput: Output = { write: () => {}, error: () => {} };
+
+/**
+ * Adapts anything with a `write(string)` method — a `node:fs` write stream, a socket, an
+ * `http.ServerResponse` — into an {@link Output}. `stderr` defaults to `stdout`, so passing one
+ * stream collects the whole run into it.
+ *
+ * ```ts
+ * import { streamOutput } from './output.ts';
+ *
+ * const chunks: string[] = [];
+ * const output = streamOutput({ write: (text: string) => void chunks.push(text) });
+ * output.error('# warning\n');
+ * chunks; // ['# warning\n'] — with no stderr given, both channels land in the one stream
+ * ```
+ */
+export function streamOutput(
+  stdout: { write(text: string): unknown },
+  stderr: { write(text: string): unknown } = stdout,
+): Output {
+  return {
+    write: (text) => void stdout.write(text),
+    error: (text) => void stderr.write(text),
+  };
+}

--- a/lib/reporters/spec.ts
+++ b/lib/reporters/spec.ts
@@ -44,16 +44,16 @@ export class SpecReporter implements Reporter {
    * }
    * ```
    */
-  onRunStart(_config: Config, info: RunStartInfo): void {
+  onRunStart(config: Config, info: RunStartInfo): void {
     this.#lastModule = null;
     this.#failures = [];
     if (info.fileCount === null) return;
     if (info.fileCount === 0) {
-      process.stdout.write('\nNo test files found.\n');
+      config.state.output.write('\nNo test files found.\n');
       return;
     }
     const files = `${info.fileCount} test file${info.fileCount === 1 ? '' : 's'}`;
-    process.stdout.write(`\nRunning ${files} across ${info.groupCount} worker(s)\n`);
+    config.state.output.write(`\nRunning ${files} across ${info.groupCount} worker(s)\n`);
   }
 
   /**
@@ -77,7 +77,7 @@ export class SpecReporter implements Reporter {
     const line = `  ${statusMark(details.status)} ${details.fullName.at(-1) ?? ''}${duration(details)}\n`;
 
     if (details.status !== 'failed') {
-      process.stdout.write(header + line);
+      config.state.output.write(header + line);
       return;
     }
 
@@ -86,7 +86,7 @@ export class SpecReporter implements Reporter {
     const block = formatFailureBlock(
       failedAssertions(details, config.state.group.sourceMapDecoder, config.projectRoot),
     );
-    process.stdout.write(header + line + (block ? indentString(block, 4) : ''));
+    config.state.output.write(header + line + (block ? indentString(block, 4) : ''));
     // Remember the headline for the end-of-run recap so a failure buried thousands of lines
     // up is still actionable.
     this.#failures.push(details.fullName.join(' | '));
@@ -119,7 +119,7 @@ export class SpecReporter implements Reporter {
       ? `\n${red('Failures:')}\n${this.#failures.map((name, index) => `  ${index + 1}) ${name}`).join('\n')}\n`
       : '';
 
-    process.stdout.write(`${counts}\n${recap}\n`);
+    config.state.output.write(`${counts}\n${recap}\n`);
   }
 }
 

--- a/lib/reporters/tap.ts
+++ b/lib/reporters/tap.ts
@@ -35,7 +35,7 @@ export class TAPReporter implements Reporter {
    * ```
    */
   onRunStart(config: Config, info: RunStartInfo): void {
-    process.stdout.write('TAP version 13\n');
+    config.state.output.write('TAP version 13\n');
     // Watch mode emits the header per browser connection and has no file/group counts to
     // report at that point.
     if (info.fileCount === null) return;
@@ -44,12 +44,12 @@ export class TAPReporter implements Reporter {
     if (info.fileCount === 0) {
       // No test files matched (e.g. --changed filtered everything out): emit a complete,
       // valid TAP document — header plus an empty plan — so parsers see a clean zero run.
-      process.stdout.write(`# Running 0 test files${daemon}\n1..0\n`);
+      config.state.output.write(`# Running 0 test files${daemon}\n1..0\n`);
       return;
     }
     const files = `${info.fileCount} test file${info.fileCount === 1 ? '' : 's'}`;
     const groups = `${info.groupCount} group${info.groupCount === 1 ? '' : 's'}`;
-    process.stdout.write(`# Running ${files} across ${groups}${daemon}\n`);
+    config.state.output.write(`# Running ${files} across ${groups}${daemon}\n`);
   }
 
   /**
@@ -74,7 +74,12 @@ export class TAPReporter implements Reporter {
       details.status === 'failed'
         ? failedAssertions(details, config.state.group.sourceMapDecoder, config.projectRoot)
         : [];
-    TAP.displayTestResult(config.state.results.counter.testCount, details, failures);
+    TAP.displayTestResult(
+      config.state.results.counter.testCount,
+      details,
+      failures,
+      config.state.output,
+    );
   }
 
   /**
@@ -90,6 +95,6 @@ export class TAPReporter implements Reporter {
    * ```
    */
   onRunEnd(config: Config, info: RunEndInfo): void {
-    TAP.displayFinalResult(config.state.results.counter, info.durationMs);
+    TAP.displayFinalResult(config.state.results.counter, info.durationMs, config.state.output);
   }
 }

--- a/lib/reporters/types.ts
+++ b/lib/reporters/types.ts
@@ -24,18 +24,21 @@ export const REPORTERS = ['tap', 'spec', 'dot', 'github'] as const;
 export type ReporterName = (typeof REPORTERS)[number];
 
 /**
- * The internal reporter contract. Reporters render a run to stdout (or to a file, for
- * additive artifact reporters like JUnit). This is deliberately **not** public API — it is
- * not exported from the package entry point and carries no stability promise. Custom
- * reporters are expected to arrive later via the JS API's event stream, not by freezing
- * QUnit's `testEnd` payload as third-party surface.
+ * The reporter contract — the public extension point for observing a run. Reporters render it
+ * to text (the built-in `tap`/`spec`/`dot`/`github`), write an artifact (`junit`), or simply
+ * collect, which is how the JS API turns a run into a value.
  *
- * Lifecycle: `onRunStart` → `onTestEnd` (× N) → `onRunEnd`. In watch mode the whole cycle
- * repeats per rerun, so stateful reporters must reset in `onRunStart`.
+ * Every method is optional, so a reporter is any object carrying the handlers it cares about.
+ *
+ * Lifecycle: `onRunStart` → (`onTestEnd` | `onNotice` | `onBrowserLog`)* → `onRunEnd`. In watch
+ * mode the whole cycle repeats per rerun, so stateful reporters must reset in `onRunStart`.
  *
  * Concurrency: one reporter instance is shared across all concurrent groups (the group
  * configs are spread off the parent config, so `state.reporters` is the same array). `onTestEnd`
  * therefore arrives interleaved across groups.
+ *
+ * Text goes through `config.state.output`, never `process.stdout` — that indirection is what
+ * lets a caller redirect or silence a built-in reporter.
  *
  * ```ts
  * import type { Config } from '../types.ts';
@@ -57,6 +60,69 @@ export interface Reporter {
   onTestEnd?(config: Config, details: TestDetails): void;
   /** Called once when the run finishes, with the final counts on `config.state.results.counter`. */
   onRunEnd?(config: Config, info: RunEndInfo): void | Promise<void>;
+  /**
+   * Called for each of qunitx's own diagnostics — the `# …` lines about what it decided to run,
+   * what it could not find, what timed out. The default rendering has already gone to
+   * `config.state.output`; implement this only to capture them as data.
+   */
+  onNotice?(config: Config, notice: Notice): void;
+  /**
+   * Called for each `console.*` call and uncaught error from the page under test. Only warnings
+   * and errors arrive unless `debug` is on — the same selection the CLI prints.
+   */
+  onBrowserLog?(config: Config, log: BrowserLog): void;
+}
+
+/**
+ * One diagnostic from qunitx itself: which files a narrowing flag scoped the run to, a filter
+ * that matched nothing, a build error, a timeout.
+ *
+ * Distinct from a test result, and distinct from the program failing — a notice is qunitx
+ * explaining what it did. The CLI renders these as TAP `#` comments, which is what they have
+ * always been; a programmatic caller reads them as a list.
+ *
+ * ```ts
+ * const notice: Notice = { level: 'warning', message: 'No tests matched --filter "Crat"' };
+ * notice.level; // 'warning' — an 'error' additionally goes to the error stream
+ * ```
+ */
+export interface Notice {
+  /** `info` is a decision, `warning` a surprise, `error` a diagnostic that also hits stderr. */
+  level: 'info' | 'warning' | 'error';
+  /** The text, already colored where the CLI colors it, with no `#` prefix and no newline. */
+  message: string;
+  /**
+   * Write `message` verbatim rather than as a `# `-prefixed comment. For pre-formatted blocks —
+   * the coverage table, a stack trace — whose own layout is the point.
+   */
+  raw?: boolean;
+  /**
+   * Which of the run's two streams the default rendering goes to; `output` by default.
+   *
+   * Separate from `level` because the two answer different questions: `level` is what kind of
+   * thing this is, which is what a consumer filters on, while this is where the CLI has always
+   * put it. A raw stack belongs on `error` alone — un-prefixed multi-line text on stdout would
+   * corrupt the TAP document — and a few diagnostics go to `both` deliberately, so a reader
+   * watching only one stream still sees them.
+   */
+  stream?: 'output' | 'error' | 'both';
+}
+
+/**
+ * A `console.*` call or an uncaught error from the page under test.
+ *
+ * ```ts
+ * const log: BrowserLog = { type: 'error', text: 'TypeError: x is not a function', args: [] };
+ * log.type; // 'error' — 'pageerror' marks an uncaught exception rather than a console call
+ * ```
+ */
+export interface BrowserLog {
+  /** The page console type (`log`/`warning`/`error`/`info`/`debug`), or `pageerror`. */
+  type: string;
+  /** The rendered single-line text. Always present. */
+  text: string;
+  /** The call's arguments, resolved to JSON values where the page could serialize them. */
+  args: unknown[];
 }
 
 /**

--- a/lib/setup/browser.ts
+++ b/lib/setup/browser.ts
@@ -53,7 +53,7 @@ export async function launch(config: Config, skipPrelaunch = false): Promise<Bro
     const waitStart = Date.now();
     const [playwrightCore, prelaunch] = await Promise.all([
       playwrightCorePromise,
-      skipPrelaunch ? Promise.resolve(null) : prelaunchPromise,
+      skipPrelaunch ? Promise.resolve(null) : prelaunchPromise(),
     ]);
     perfLog(
       `browser.js: playwright-core + prelaunch resolved in ${Date.now() - waitStart}ms, prelaunch:`,

--- a/lib/setup/browser.ts
+++ b/lib/setup/browser.ts
@@ -1,4 +1,6 @@
+import { format } from 'node:util';
 import * as WebServer from './web-server.ts';
+import * as Reporter from '../reporters/index.ts';
 import { Task } from '../task/index.ts';
 import { bindServerToPort } from './bind-server-to-port.ts';
 import * as Chrome from '../chrome/index.ts';
@@ -228,18 +230,22 @@ export async function setup(
     // events asynchronously after QUnit done, and arg.evaluate() round-trips fail
     // when the browser closes mid-flight, falling back to the useless "JSHandle@object".
     const handler = (async () => {
-      try {
-        const values = await Promise.all(msg.args().map((arg) => arg.jsonValue()));
-        console.log(...values);
-      } catch {
-        console.log(msg.text());
-      }
+      // `args` is best-effort: Firefox BiDi can fail to serialize a handle after the page is
+      // gone, in which case the pre-rendered text is all there is.
+      const args = await Promise.all(msg.args().map((arg) => arg.jsonValue())).catch(() => null);
+      Reporter.browserLog(config, {
+        // `format` is what console.log itself uses to turn its arguments into a line, so the
+        // rendered text is byte-identical to the `console.log(...values)` this replaces.
+        type,
+        text: args ? format(...args) : msg.text(),
+        args: args ?? [],
+      });
     })();
     config.state.group.pendingConsoleHandlers!.add(handler);
     handler.finally(() => config.state.group.pendingConsoleHandlers?.delete(handler));
   });
   page.on('pageerror', (error) => {
-    console.error(error.toString());
+    Reporter.browserLog(config, { type: 'pageerror', text: error.toString(), args: [error] });
     config.state.results.counter.failCount++;
   });
 

--- a/lib/setup/config.ts
+++ b/lib/setup/config.ts
@@ -15,6 +15,8 @@ import * as RunState from './run-state.ts';
 import * as Result from '../result/index.ts';
 import { Task } from '../task/index.ts';
 import type { Config, FSTree as FSTreeShape } from '../types.ts';
+import type { Reporter as ReporterInstance } from '../reporters/types.ts';
+import type { Output } from '../reporters/output.ts';
 import type { Plugin as EsbuildPlugin } from 'esbuild';
 
 /**
@@ -89,6 +91,17 @@ export interface ConfigOptions extends Partial<Args.ParsedFlags> {
   cwd?: string;
   /** Live esbuild plugin objects, appended after any resolved from `package.json#qunitx.plugins`. */
   esbuildPlugins?: EsbuildPlugin[];
+  /**
+   * Reporter instances for this run, replacing the one `reporter`/`junit` would have selected.
+   * The way a caller observes a run as data rather than as text.
+   */
+  reporters?: ReporterInstance[];
+  /**
+   * Where reporter text and `#` diagnostics go. Defaults to the process streams; pass
+   * `silentOutput` for a run that prints nothing at all. Named apart from `output` — the build
+   * directory — because they are unrelated and both spellings are load-bearing.
+   */
+  reporterOutput?: Output;
 }
 
 /**
@@ -123,7 +136,13 @@ export function setup(options?: ConfigOptions): Task<Config, ConfigFailure> {
     // them, so the guard-and-return-it ladder this function used to open with is gone. Args.parse
     // is synchronous, so it hands back a union rather than a Task — `unwrap` is the union's own
     // way into that channel, throwing the failure by identity so its stack still points at Args.
-    const { cwd: requestedCwd, esbuildPlugins, ...provided } = options ?? {};
+    const {
+      cwd: requestedCwd,
+      esbuildPlugins,
+      reporters,
+      reporterOutput,
+      ...provided
+    } = options ?? {};
     const cwd = requestedCwd ? path.resolve(requestedCwd) : process.cwd();
     const projectRoot = await findProjectRoot(cwd);
     // Given options, the positional grammar still applies — `applyInputs` is the same
@@ -152,6 +171,11 @@ export function setup(options?: ConfigOptions): Task<Config, ConfigFailure> {
       // complete Config is only guaranteed at the return. The later `as Config` casts this
       // function used to repeat are now redundant.
     } as Config;
+    // Wired before anything below can emit: `pruneSupersededLineTargets` and the narrowing
+    // filters all announce what they decided through `Reporter.notice`, and a run whose
+    // reporters were still an empty array at that point would drop those diagnostics.
+    if (reporterOutput) config.state.output = reporterOutput;
+    config.state.reporters = reporters ?? Reporter.create(config);
     // `--debug` also reveals `.ignore(context)`-suppressed rejections as TAP comments —
     // one flag lights every deliberate swallow. (QUNITX_DEBUG covers the env path at
     // failure.ts load; enable-only, so a daemon run without the flag never turns it off.)
@@ -175,11 +199,7 @@ export function setup(options?: ConfigOptions): Task<Config, ConfigFailure> {
     // include a changed file. Watch mode skips this — watch is for fast feedback
     // on every save, not "what does my working tree affect" semantics.
     if (config.changedSince && !config.watch) {
-      config.fsTree = await getChangedFsTree(
-        config.fsTree,
-        config.projectRoot,
-        config.changedSince,
-      );
+      config.fsTree = await getChangedFsTree(config.fsTree, config, config.changedSince);
     }
 
     // --only-failed: restrict the whole run to files that failed on the previous run (persistent
@@ -189,10 +209,6 @@ export function setup(options?: ConfigOptions): Task<Config, ConfigFailure> {
     if (config.onlyFailed && !config.watch) {
       config.fsTree = await applyOnlyFailedFilter(config);
     }
-
-    // Built last: reporter selection reads the fully-merged flags. One instance per run, shared
-    // by every concurrent group via the group-config spread in run.ts.
-    config.state.reporters = Reporter.create(config);
 
     return config;
   });
@@ -218,12 +234,12 @@ function pruneSupersededLineTargets(config: Config): void {
     const coveredBy = wholeInputs.find((input) => coversFileWhole(input, file));
     if (!coveredBy) continue;
     const rel = path.relative(config.projectRoot, file).replaceAll('\\', '/');
-    console.log(
-      '#',
-      blue(
+    Reporter.notice(config, {
+      level: 'warning',
+      message: blue(
         `qunitx: ${rel}#${lineTargets[file].join(',')} line target ignored — a broader input runs the whole file`,
       ),
-    );
+    });
     delete lineTargets[file];
   }
 
@@ -262,17 +278,21 @@ async function applyOnlyFailedFilter(config: Config): Promise<FSTreeShape> {
     config.fsTree,
   );
   if (failed === null) {
-    console.log('#', `qunitx --only-failed: no failure cache found — running all tests`);
+    Reporter.notice(config, {
+      level: 'info',
+      message: `qunitx --only-failed: no failure cache found — running all tests`,
+    });
     return config.fsTree;
   }
 
   const count = failed.length;
-  console.log(
-    '#',
-    count === 0
-      ? `qunitx --only-failed: no previously-failing test files to run`
-      : `qunitx --only-failed: re-running ${count} previously-failing test file${count === 1 ? '' : 's'}`,
-  );
+  Reporter.notice(config, {
+    level: 'info',
+    message:
+      count === 0
+        ? `qunitx --only-failed: no previously-failing test files to run`
+        : `qunitx --only-failed: re-running ${count} previously-failing test file${count === 1 ? '' : 's'}`,
+  });
   return Object.fromEntries(failed.map((file) => [file, config.fsTree[file] ?? null]));
 }
 

--- a/lib/setup/config.ts
+++ b/lib/setup/config.ts
@@ -69,16 +69,42 @@ export type ConfigFailure =
   | Result.Failure.Of<typeof InvalidPlugins | typeof PluginLoadFailed>;
 
 /**
- * Builds the merged qunitx config from package.json settings and CLI flags.
- * `package.json#qunitx.plugins` entries are dynamic-imported into esbuild plugin objects.
+ * Resolved settings handed to {@link setup} in place of an argv, by the JS API and by anyone
+ * else assembling a run programmatically. Every CLI flag has a field here — they are the same
+ * settings, arrived at by a different route — plus the two things argv cannot express: a working
+ * directory, and esbuild plugins as live objects rather than module specifiers.
+ *
+ * `inputs` are raw targets, exactly as they would be typed on the command line: relative or
+ * absolute, `.html` fixtures, `file.ts#34` line targets. {@link Args.applyInputs} classifies them.
+ *
+ * ```ts
+ * import * as Config from './config.ts';
+ *
+ * const options: Config.ConfigOptions = { inputs: ['test/cart-test.ts#34'], filter: 'Cart' };
+ * options.inputs; // ['test/cart-test.ts#34'] — resolved against `cwd` by setup()
+ * ```
+ */
+export interface ConfigOptions extends Partial<Args.ParsedFlags> {
+  /** Directory the project root and relative inputs resolve against. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Live esbuild plugin objects, appended after any resolved from `package.json#qunitx.plugins`. */
+  esbuildPlugins?: EsbuildPlugin[];
+}
+
+/**
+ * Builds the merged qunitx config from package.json settings and either an argv or an explicit
+ * {@link ConfigOptions}. `package.json#qunitx.plugins` entries are dynamic-imported into esbuild
+ * plugin objects.
  *
  * `ConfigFailure` is *declared*, so `.result()` hands back the bare union to branch on with
  * `Failure.is`. It reports rather than exits so the daemon — which assembles a config per client
  * request — can reject one bad flag and stay up; `cli.ts` turns a failure into an exit.
  *
- * Lazy, like every Task: nothing is read until it is awaited. `setup` reads `process.argv` and
- * `process.env` at that moment, so a caller that lends those globals (the daemon, via
- * `borrowArgv`/`borrowEnv`) must await INSIDE the borrowing scope, not hold the Task past it.
+ * Lazy, like every Task: nothing is read until it is awaited. With no argument `setup` reads
+ * `process.argv` and `process.env` at that moment, so a caller that lends those globals (the
+ * daemon, via `borrowArgv`/`borrowEnv`) must await INSIDE the borrowing scope, not hold the Task
+ * past it. Passing options instead skips the argv read entirely — which is why the JS API needs
+ * no such borrowing.
  *
  * ```ts
  * import * as Config from './config.ts';
@@ -86,19 +112,25 @@ export type ConfigFailure =
  *
  * // Defined, not invoked: reads package.json and walks the real fs.
  * async function example() {
- *   const config = await Config.setup().result();
+ *   const config = await Config.setup({ inputs: ['test/'] }).result();
  *   return Result.Failure.is(config) ? config.code : config.inputs; // ConfigFailure, or the Config
  * }
  * ```
  */
-export function setup(): Task<Config, ConfigFailure> {
+export function setup(options?: ConfigOptions): Task<Config, ConfigFailure> {
   return Task(async () => {
     // Every declared failure below rejects rather than returning: the Task's E channel carries
     // them, so the guard-and-return-it ladder this function used to open with is gone. Args.parse
     // is synchronous, so it hands back a union rather than a Task — `unwrap` is the union's own
     // way into that channel, throwing the failure by identity so its stack still points at Args.
-    const projectRoot = await findProjectRoot();
-    const flags = Result.unwrap(Args.parse(projectRoot));
+    const { cwd: requestedCwd, esbuildPlugins, ...provided } = options ?? {};
+    const cwd = requestedCwd ? path.resolve(requestedCwd) : process.cwd();
+    const projectRoot = await findProjectRoot(cwd);
+    // Given options, the positional grammar still applies — `applyInputs` is the same
+    // classification argv positionals go through, so `'a.ts#34'` targets a line either way.
+    const flags = options
+      ? Args.applyInputs({ ...provided, inputs: [] }, projectRoot, cwd, provided.inputs ?? [])
+      : Result.unwrap(Args.parse(projectRoot, process.argv.slice(2), cwd));
     const projectPackageJSON = await readConfigFromPackageJSON(projectRoot);
     const { plugins: rawPlugins, ...userQunitx } =
       (projectPackageJSON.qunitx as Partial<Config> & {
@@ -111,6 +143,7 @@ export function setup(): Task<Config, ConfigFailure> {
       ...userQunitx,
       ...flags,
       projectRoot,
+      cwd,
       inputs,
       testFileLookupPaths: TestFilePaths.setup(inputs),
       state: RunState.create(),
@@ -127,10 +160,14 @@ export function setup(): Task<Config, ConfigFailure> {
     // Started together, so plugin dynamic-imports overlap fsTree's I/O. The two used to be kicked
     // off on separate lines to get that overlap; they didn't need to be, because everything between
     // those lines was synchronous and no import could progress during it.
-    [config.fsTree, config.plugins] = await Task.all([
+    const [fsTree, resolvedPlugins] = await Task.all([
       FSTree.build(config.testFileLookupPaths, config),
       resolvePlugins(rawPlugins, projectRoot),
     ]);
+    config.fsTree = fsTree;
+    // package.json specifiers first, then the caller's live objects — the same order the two
+    // sources are declared in, so an API-supplied plugin can override an earlier one's handlers.
+    config.plugins = esbuildPlugins ? resolvedPlugins.concat(esbuildPlugins) : resolvedPlugins;
 
     pruneSupersededLineTargets(config);
 

--- a/lib/setup/config.ts
+++ b/lib/setup/config.ts
@@ -29,11 +29,12 @@ import type { Plugin as EsbuildPlugin } from 'esbuild';
  * failure.message; // 'package.json#qunitx.plugins must be an array, received string'
  * ```
  */
-export const InvalidPlugins = Result.Failure.define(
-  'InvalidPlugins',
-  (data: { received: string }) =>
-    `package.json#qunitx.plugins must be an array, received ${data.received}`,
-);
+export const InvalidPlugins: Result.Failure.FailureFactory<'InvalidPlugins', { received: string }> =
+  Result.Failure.define(
+    'InvalidPlugins',
+    (data: { received: string }) =>
+      `package.json#qunitx.plugins must be an array, received ${data.received}`,
+  );
 
 /**
  * A plugin specifier could not be resolved or imported.
@@ -49,7 +50,10 @@ export const InvalidPlugins = Result.Failure.define(
  * failure.data.specifier; // 'esbuild-plugin-vue' — the entry at fault, resolver error under `.cause`
  * ```
  */
-export const PluginLoadFailed = Result.Failure.define(
+export const PluginLoadFailed: Result.Failure.FailureFactory<
+  'PluginLoadFailed',
+  { specifier: string }
+> = Result.Failure.define(
   'PluginLoadFailed',
   (data: { specifier: string }) => `could not load esbuild plugin "${data.specifier}"`,
 );

--- a/lib/setup/file-watcher.ts
+++ b/lib/setup/file-watcher.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 // See lib/commands/run.ts: node:timers preserves .unref() across Node and Deno.
 import { setInterval, clearInterval, setTimeout, clearTimeout } from 'node:timers';
 import { green, magenta, red, yellow } from '../utils/color.ts';
+import * as Reporter from '../reporters/index.ts';
 import { defaultProjectConfigValues } from './default-project-config-values.ts';
 import type { FSWatcher } from 'node:fs';
 import type { Config, FSTree } from '../types.ts';
@@ -503,18 +504,13 @@ export function handleWatchEvent(
 
   mutateFSTree(config.fsTree, event, filePath);
 
-  console.log(
-    '#',
-    magenta().bold('=================================================================='),
-  );
   const displayPath = filePath.startsWith(config.projectRoot)
     ? filePath.slice(config.projectRoot.length)
     : filePath;
-  console.log('#', colorEvent(event), displayPath);
-  console.log(
-    '#',
-    magenta().bold('=================================================================='),
-  );
+  const rule = magenta().bold('==================================================================');
+  Reporter.notice(config, { level: 'info', message: rule });
+  Reporter.notice(config, { level: 'info', message: `${colorEvent(event)} ${displayPath}` });
+  Reporter.notice(config, { level: 'info', message: rule });
 
   if (event === 'add') config.state.watch.justAddedAt.set(filePath, Date.now());
 
@@ -539,7 +535,13 @@ export function handleWatchEvent(
 
   return result
     .then(() => onFinishFunc?.(filePath, event))
-    .catch((error) => console.error('#', red('Build error:'), error.message || error))
+    .catch((error) =>
+      Reporter.notice(config, {
+        level: 'error',
+        stream: 'error',
+        message: `${red('Build error:')} ${error.message || error}`,
+      }),
+    )
     .finally(() => {
       config.state.watch.building = false;
       // Only advance the "last successful build" timestamp on a clean build. A failed

--- a/lib/setup/fs-tree.ts
+++ b/lib/setup/fs-tree.ts
@@ -14,10 +14,11 @@ import type { FSTree } from '../types.ts';
  * InputUnreadable({ input: 'test/**' }).message; // "could not read test input test/**"
  * ```
  */
-export const InputUnreadable = Failure.define(
-  'InputUnreadable',
-  (data: { input: string }) => `could not read test input ${data.input}`,
-);
+export const InputUnreadable: Failure.FailureFactory<'InputUnreadable', { input: string }> =
+  Failure.define(
+    'InputUnreadable',
+    (data: { input: string }) => `could not read test input ${data.input}`,
+  );
 
 /** The one failure {@link build} declares. */
 export type InputUnreadableFailure = Failure.Of<typeof InputUnreadable>;

--- a/lib/setup/get-changed-fs-tree.ts
+++ b/lib/setup/get-changed-fs-tree.ts
@@ -2,13 +2,14 @@ import { getChangedFiles } from '../utils/get-changed-files.ts';
 import { getChangedFilePathsInGitSince } from '../utils/get-changed-file-paths-in-git-since.ts';
 import * as MetafileCache from '../utils/metafile-cache.ts';
 import * as Failure from '../result/failure.ts';
-import type { FSTree } from '../types.ts';
+import * as Reporter from '../reporters/index.ts';
+import type { Config, FSTree } from '../types.ts';
 
 /**
  * Returns a new fsTree containing only the test files affected by changes
  * since `ref`, per the cached esbuild metafile's reverse-dependency graph.
  *
- * Falls back to returning the input fsTree unchanged (with a stdout note)
+ * Falls back to returning the input fsTree unchanged (with a notice)
  * when any of these hold — they are "run-all is the safe answer" scenarios,
  * not bugs:
  *   - blast-radius file changed (package.json, tsconfig.json, …): full graph
@@ -16,21 +17,21 @@ import type { FSTree } from '../types.ts';
  *   - no metafile cache yet: nothing built before this run.
  *   - git failed: not a repo, ref doesn't exist, git binary missing.
  *
- * Always logs how the filter resolved (full / filtered / fallback) so users can
+ * Always announces how the filter resolved (full / filtered / fallback) so users can
  * reason about why their selected suite ran.
  *
  * ```ts
- * import type { FSTree } from '../types.ts';
+ * import type { Config, FSTree } from '../types.ts';
  *
  * // Defined, not invoked: reads the metafile cache and runs git.
- * async function narrow(fsTree: FSTree, projectRoot: string) {
- *   return getChangedFsTree(fsTree, projectRoot, 'HEAD'); // only tests affected since HEAD
+ * async function narrow(fsTree: FSTree, config: Config) {
+ *   return getChangedFsTree(fsTree, config, 'HEAD'); // only tests affected since HEAD
  * }
  * ```
  */
 export async function getChangedFsTree(
   fsTree: FSTree,
-  projectRoot: string,
+  config: Config,
   changedSince: string,
   // The git-backed change detector is injectable so the filter branches can be
   // unit-tested deterministically — without spawning a real git subprocess, whose
@@ -42,11 +43,13 @@ export async function getChangedFsTree(
   const testFiles = Object.keys(fsTree);
   if (testFiles.length === 0) return fsTree;
 
+  const { projectRoot } = config;
   const cache = await MetafileCache.read(projectRoot);
   if (!cache) {
-    process.stdout.write(
-      `# --changed: no metafile cache yet — running all ${testFiles.length} test files (cache populates on this run)\n`,
-    );
+    Reporter.notice(config, {
+      level: 'info',
+      message: `--changed: no metafile cache yet — running all ${testFiles.length} test files (cache populates on this run)`,
+    });
     return fsTree;
   }
 
@@ -61,25 +64,29 @@ export async function getChangedFsTree(
   // scanner still rejects and crashes the run loudly.
   const scan = await getChanged(projectRoot, changedSince).result();
   if (Failure.is(scan)) {
-    process.stdout.write(
-      `# --changed: ${scan.message} — running all ${testFiles.length} test files\n`,
-    );
+    Reporter.notice(config, {
+      level: 'info',
+      message: `--changed: ${scan.message} — running all ${testFiles.length} test files`,
+    });
     return fsTree;
   } else if (scan.scope === 'everything') {
-    process.stdout.write(
-      `# --changed: blast-radius file changed (${scan.trigger}) — running all ${testFiles.length} test files\n`,
-    );
+    Reporter.notice(config, {
+      level: 'info',
+      message: `--changed: blast-radius file changed (${scan.trigger}) — running all ${testFiles.length} test files`,
+    });
     return fsTree;
   } else if (scan.paths.size === 0) {
-    process.stdout.write(
-      `# --changed: 0 files changed since ${changedSince} — running 0 test files\n`,
-    );
+    Reporter.notice(config, {
+      level: 'info',
+      message: `--changed: 0 files changed since ${changedSince} — running 0 test files`,
+    });
     return {};
   }
 
   const affected = getChangedFiles(cache.metafile, cache.esbuildCwd, scan.paths, testFiles);
-  process.stdout.write(
-    `# --changed: ${affected.size} of ${testFiles.length} test files affected by changes since ${changedSince}\n`,
-  );
+  Reporter.notice(config, {
+    level: 'info',
+    message: `--changed: ${affected.size} of ${testFiles.length} test files affected by changes since ${changedSince}`,
+  });
   return Object.fromEntries(testFiles.filter((f) => affected.has(f)).map((f) => [f, null]));
 }

--- a/lib/setup/keyboard-events.ts
+++ b/lib/setup/keyboard-events.ts
@@ -1,48 +1,35 @@
-import { blue } from '../utils/color.ts';
 import { listenToKeyboardKey } from '../utils/listen-to-keyboard-key.ts';
-import { run } from '../commands/run/tests-in-browser.ts';
-import type { Config, Connections } from '../types.ts';
+import type { WatchSession } from '../commands/run.ts';
 
 /**
- * Registers watch-mode keyboard shortcuts: `qq` to abort, `qa` to run all, `qf` for last failed, `ql` for last run.
+ * Binds watch-mode keyboard shortcuts to the session's verbs: `qq` aborts, `qa` runs all, `qf`
+ * re-runs the last failures, `ql` repeats the last run.
+ *
+ * Nothing but the binding lives here. What each shortcut *means* is a method on
+ * {@link WatchSession}, so the JS API and a future TUI get the same four behaviours without
+ * reimplementing them — and a rerun asked for by a keystroke now goes through the same serializer
+ * as the file watcher's, which is what the session's one-run-at-a-time guarantee assumed all along.
  *
  * ```ts
  * import * as KeyboardEvents from './keyboard-events.ts';
- *
- * import type { Config, Connections } from '../types.ts';
+ * import type { WatchSession } from '../commands/run.ts';
  *
  * // Defined, not invoked: attaches stdin key listeners.
- * function enableShortcuts(config: Config, connections: Connections) {
- *   KeyboardEvents.setup(config, connections); // qq abort · qa run all · qf last failed · ql last run
+ * function enableShortcuts(session: WatchSession) {
+ *   KeyboardEvents.setup(session); // qq abort · qa run all · qf last failed · ql last run
  * }
  * ```
  * @returns {void}
  */
-export function setup(config: Config, connections: Connections): void {
-  listenToKeyboardKey('qq', () => abortBrowserQUnit(config, connections));
-  listenToKeyboardKey('qa', () => {
-    abortBrowserQUnit(config, connections);
-    // "run all" means all: drop the line-target selections that scoped this session. -t/-m stay
-    // — those are a standing instruction about which tests to run, not a starting point.
-    config.state.group.selectors = undefined;
-    run(config, connections);
-  });
-  listenToKeyboardKey('qf', () => {
-    abortBrowserQUnit(config, connections);
-
-    if (!config.state.group.lastFailedFiles) {
-      console.log('#', blue(`QUnitX: No tests failed so far, so repeating the last test run`));
-      return run(config, connections, config.state.group.lastRanFiles);
-    }
-
-    run(config, connections, config.state.group.lastFailedFiles);
-  });
+export function setup(session: WatchSession): void {
+  // Every handler discards its promise: a keystroke is nobody's `await`, and an unhandled
+  // rejection from a rerun would take the process down. Reruns report themselves through the
+  // reporters either way, so there is nothing here left to say.
+  listenToKeyboardKey('qq', () => session.abort());
+  listenToKeyboardKey('qa', () => void session.runAll().catch(() => {}));
+  listenToKeyboardKey('qf', () => void session.runFailed().catch(() => {}));
   listenToKeyboardKey('ql', () => {
-    abortBrowserQUnit(config, connections);
-    run(config, connections, config.state.group.lastRanFiles);
+    session.abort();
+    void session.run(session.config.state.group.lastRanFiles ?? undefined).catch(() => {});
   });
-}
-
-function abortBrowserQUnit(_config: Config, connections: Connections): void {
-  connections.server.publish('abort');
 }

--- a/lib/setup/qunitx-runtime-plugin.ts
+++ b/lib/setup/qunitx-runtime-plugin.ts
@@ -22,7 +22,7 @@ const NAMESPACE = 'qunitx-runtime';
  * plugin.name; // 'qunitx-runtime' — hand it to esbuild's `plugins` alongside the user's own
  * ```
  */
-export function qunitxRuntimePlugin(): Plugin {
+export function qunitxRuntimePlugin(cwd: string = process.cwd()): Plugin {
   return {
     name: 'qunitx-runtime',
     setup(build) {
@@ -44,7 +44,7 @@ export function qunitxRuntimePlugin(): Plugin {
       build.onLoad({ filter: /.*/, namespace: NAMESPACE }, async () => ({
         contents: await readTemplate('vendor/qunitx-runtime.js'),
         loader: 'js',
-        resolveDir: process.cwd(),
+        resolveDir: cwd,
       }));
     },
   };

--- a/lib/setup/run-state.ts
+++ b/lib/setup/run-state.ts
@@ -63,7 +63,6 @@ export function newGroup(index = 0, selectors?: QUnitSelector[]): GroupState {
     phase: 'bundling',
     selectors,
     lastRanFiles: null,
-    lastFailedFiles: null,
     testEndCounts: new Map(),
     wsConnectionCount: 0,
     lastQUnitResult: null,
@@ -93,6 +92,7 @@ export function create(): RunState {
     daemon: null,
     group: newGroup(),
     groupCount: 1,
+    aborters: new Set(),
     reporters: [],
     output: processOutput,
     htmlAssets: {
@@ -114,6 +114,7 @@ export function create(): RunState {
       failedFiles: new Set(),
       failedTests: [],
       coverage: null,
+      aborted: false,
     },
   };
 }
@@ -141,6 +142,32 @@ export function reset(results: RunResults, coverageEnabled: boolean): void {
   results.failedFiles.clear();
   results.failedTests.length = 0;
   results.coverage = coverageEnabled ? new Map() : null;
+  results.aborted = false;
+}
+
+/**
+ * Asks every live server to tell its pages to drop the rest of the QUnit queue, and records that
+ * this run was cut short.
+ *
+ * The flag is set on intent, not on the browser's acknowledgement, and that is deliberate: an
+ * abort that arrives before any page has connected — a `signal` already aborted, a `qq` during
+ * start-up — would otherwise reach nobody and go unrecorded. `WebServer.setup` re-sends it to
+ * pages that connect afterwards, so the request survives the gap either way.
+ *
+ * Cleared by {@link reset} at the start of every run, so an abort while idle does not follow the
+ * session into its next run.
+ *
+ * ```ts
+ * import * as RunState from './run-state.ts';
+ *
+ * const state = RunState.create();
+ * RunState.requestAbort(state);
+ * state.results.aborted; // true — even with no server listening yet
+ * ```
+ */
+export function requestAbort(state: RunState): void {
+  state.results.aborted = true;
+  state.aborters.forEach((stop) => stop());
 }
 
 /**

--- a/lib/setup/run-state.ts
+++ b/lib/setup/run-state.ts
@@ -1,6 +1,7 @@
 import type { BuildState, Counter, GroupState, RunResults, RunState } from '../types.ts';
 import type { QUnitSelector } from '../selection/line-targets.ts';
 import type { Page } from 'playwright-core';
+import { processOutput } from '../reporters/output.ts';
 
 /**
  * The daemon's reusable Page slot, or `null` when reuse does not apply.
@@ -93,6 +94,7 @@ export function create(): RunState {
     group: newGroup(),
     groupCount: 1,
     reporters: [],
+    output: processOutput,
     htmlAssets: {
       assets: new Set(),
       mainHTML: { filePath: null, html: null },

--- a/lib/setup/web-server.ts
+++ b/lib/setup/web-server.ts
@@ -12,6 +12,7 @@ import { HTTPServer, MIME_TYPES } from '../web/index.ts';
 import { createReconnectingSocket } from './ws-client.js';
 import { readTemplate } from '../utils/read-template.ts';
 import type { Config } from '../types.ts';
+import type { QUnitSelector } from '../selection/line-targets.ts';
 import { Task } from '../task/index.ts';
 
 const fsPromise = fs.promises;
@@ -83,29 +84,47 @@ export function setup(config: Config): HTTPServer {
   const STATIC_FILES_PATH = path.resolve(config.projectRoot, config.output);
   const consumerQunitCssCandidate = resolveConsumerQunitCssCandidate(config.projectRoot);
   const server = new HTTPServer();
+  // Registered at construction rather than by the caller, so every server that can run tests can
+  // also be told to stop — including the per-group servers a custom HTML template forces.
+  config.state.aborters.add(() => server.publish('abort'));
   const mainHTMLWithReplacedAssets = replaceAssetPaths(
     config.state.htmlAssets.mainHTML.html ?? '',
     config.state.htmlAssets.mainHTML.filePath,
     config.projectRoot,
   );
-  // Cache the runtime script and both normal HTML responses — stable for this server's lifetime.
-  const runtimeScript = testRuntimeToInject(config);
-  const mainIndexHTML = escapeAndInjectTestsToHTML(
-    mainHTMLWithReplacedAssets,
-    runtimeScript,
-    './tests.js',
-  );
-  const mainQunitxHTML = escapeAndInjectTestsToHTML(
-    mainHTMLWithReplacedAssets,
-    runtimeScript,
-    './filtered-tests.js',
-  );
+  // Cached, but keyed on the selectors rather than for the server's whole lifetime: the runtime
+  // script bakes the line-target filter into the page, so a session that cleared its selectors
+  // (`qa`, `session.runAll()`) went on being served the pinned page and kept running one test.
+  // Recomputed only when they actually change, which in a normal run is never.
+  let pages: { selectors: QUnitSelector[] | undefined; index: string; qunitx: string } | null =
+    null;
+  const htmlPages = () => {
+    const selectors = config.state.group.selectors;
+    if (!pages || pages.selectors !== selectors) {
+      const runtimeScript = testRuntimeToInject(config);
+      pages = {
+        selectors,
+        index: escapeAndInjectTestsToHTML(mainHTMLWithReplacedAssets, runtimeScript, './tests.js'),
+        qunitx: escapeAndInjectTestsToHTML(
+          mainHTMLWithReplacedAssets,
+          runtimeScript,
+          './filtered-tests.js',
+        ),
+      };
+    }
+
+    return pages;
+  };
   const saveHTML = (filePath: string, html: string) =>
     Task(fsPromise.writeFile(filePath, html)).ignore(`writeFile ${filePath}`);
 
   config.state.group.wsConnectionCount = 0;
   server.wss.on('connection', function connection(socket) {
     config.state.group.wsConnectionCount = (config.state.group.wsConnectionCount ?? 0) + 1;
+    // The abort was requested before this page existed — `signal` already aborted, or `qq` pressed
+    // while the browser was still starting. Without this the request would reach nobody and the
+    // run it was meant to stop would go on to completion.
+    if (config.state.results.aborted) socket.send('abort');
     // A second WS connection is expected in watch/--open mode — the user opening http://localhost:PORT
     // in their own browser (the watch banner invites it) or a headed reload — so warning there is
     // noise. In a plain single run (e.g. CI) the lone headless page must connect exactly once, so a
@@ -175,7 +194,6 @@ export function setup(config: Config): HTTPServer {
         }
 
         if (details.status === 'failed') {
-          config.state.group.lastFailedFiles = config.state.group.lastRanFiles;
           FailureCache.record(config, details);
         }
 
@@ -325,12 +343,10 @@ export function setup(config: Config): HTTPServer {
       res.writeHead(200, HTML_HEADERS);
       return res.end(buildNoTestsHTML(fallback.files));
     }
+    const { index } = htmlPages();
     res.writeHead(200, HTML_HEADERS);
-    res.end(mainIndexHTML);
-    saveHTML(
-      path.join(path.resolve(config.projectRoot, config.output), 'index.html'),
-      mainIndexHTML,
-    );
+    res.end(index);
+    saveHTML(path.join(path.resolve(config.projectRoot, config.output), 'index.html'), index);
   });
 
   server.get('/qunitx.html', (_req, res) => {
@@ -348,12 +364,10 @@ export function setup(config: Config): HTTPServer {
       res.writeHead(200, HTML_HEADERS);
       return res.end(buildNoTestsHTML(fallback.files));
     }
+    const { qunitx } = htmlPages();
     res.writeHead(200, HTML_HEADERS);
-    res.end(mainQunitxHTML);
-    saveHTML(
-      path.join(path.resolve(config.projectRoot, config.output), 'qunitx.html'),
-      mainQunitxHTML,
-    );
+    res.end(qunitx);
+    saveHTML(path.join(path.resolve(config.projectRoot, config.output), 'qunitx.html'), qunitx);
   });
 
   server.get('/*', (req, res) => {
@@ -362,7 +376,7 @@ export function setup(config: Config): HTTPServer {
     if (possibleDynamicHTML) {
       const htmlContent = escapeAndInjectTestsToHTML(
         possibleDynamicHTML,
-        runtimeScript,
+        testRuntimeToInject(config),
         '/tests.js',
       );
       res.writeHead(200, HTML_HEADERS);
@@ -792,7 +806,6 @@ export function setupGroupWSHandler(server: HTTPServer, groupConfigs: Config[]):
           return;
         }
         if (details.status === 'failed') {
-          config.state.group.lastFailedFiles = config.state.group.lastRanFiles;
           FailureCache.record(config, details);
         }
         if (config.debug && details.runtime > config.timeout * 0.8) {

--- a/lib/setup/web-server.ts
+++ b/lib/setup/web-server.ts
@@ -115,12 +115,15 @@ export function setup(config: Config): HTTPServer {
       config.state.group.wsConnectionCount > 1 &&
       (config.debug || !(config.watch || config.open))
     ) {
-      diagWrite(
-        `# [qunitx][diag] wss accepted connection #${config.state.group.wsConnectionCount} — ` +
+      Reporter.notice(config, {
+        level: 'warning',
+        stream: 'both',
+        message:
+          `[qunitx][diag] wss accepted connection #${config.state.group.wsConnectionCount} — ` +
           `single-group runs should see exactly one WS connection per run. ` +
           `Multiple connections from one page are the prime suspect for the 2× testEnd flake ` +
-          `(WS retry race in the injected runtime).\n`,
-      );
+          `(WS retry race in the injected runtime).`,
+      });
     }
     socket.on('message', function message(data) {
       const { event, details, qunitResult, abort } = JSON.parse(String(data));
@@ -160,11 +163,14 @@ export function setup(config: Config): HTTPServer {
         const count = (config.state.group.testEndCounts?.get(fullName) ?? 0) + 1;
         config.state.group.testEndCounts?.set(fullName, count);
         if (count > 1) {
-          diagWrite(
-            `# [qunitx] WARNING: duplicate testEnd ignored for "${fullName}" — ` +
+          Reporter.notice(config, {
+            level: 'warning',
+            stream: 'both',
+            message:
+              `[qunitx] WARNING: duplicate testEnd ignored for "${fullName}" — ` +
               `browser/Playwright fired the event twice in one run. ` +
-              `Counter not incremented; see Config.state.group.testEndCounts for details.\n`,
-          );
+              `Counter not incremented; see Config.state.group.testEndCounts for details.`,
+          });
           return;
         }
 
@@ -776,10 +782,13 @@ export function setupGroupWSHandler(server: HTTPServer, groupConfigs: Config[]):
         const count = (config.state.group.testEndCounts?.get(fullName) ?? 0) + 1;
         config.state.group.testEndCounts?.set(fullName, count);
         if (count > 1) {
-          diagWrite(
-            `# [qunitx] WARNING: group ${resolvedGroupId} duplicate testEnd ignored for "${fullName}" — ` +
-              `single-run testEnds should be unique.\n`,
-          );
+          Reporter.notice(config, {
+            level: 'warning',
+            stream: 'both',
+            message:
+              `[qunitx] WARNING: group ${resolvedGroupId} duplicate testEnd ignored for "${fullName}" — ` +
+              `single-run testEnds should be unique.`,
+          });
           return;
         }
         if (details.status === 'failed') {
@@ -1106,17 +1115,4 @@ function debugGroupHeader(config: Config): void {
   process.stdout.write(
     `# ${blue(`── ${shown.join('  ')}${rest > 0 ? `  +${rest} more` : ''} ──`)}\n`,
   );
-}
-
-// Writes a diagnostic warning to BOTH stdout and stderr. stderr is the natural
-// stream for warnings but is captured-then-discarded by many test helpers
-// (e.g. test/inputs/plugins-test.ts's runFixtureCli), making warnings invisible
-// when a test fails. stdout writes the same text as a TAP `#` comment — TAP
-// parsers ignore `#` lines, so it does not affect test outcomes, and assertion-
-// failure dumps that snapshot stdout (custom-asserts.tapResult) now include the
-// warning surface. Dual write keeps either stream a sufficient signal in CI
-// logs.
-function diagWrite(msg: string): void {
-  process.stderr.write(msg);
-  process.stdout.write(msg);
 }

--- a/lib/tap/display-final-result.ts
+++ b/lib/tap/display-final-result.ts
@@ -1,3 +1,4 @@
+import { processOutput, type Output } from '../reporters/output.ts';
 import type { Counter } from '../types.ts';
 
 /**
@@ -8,7 +9,7 @@ import type { Counter } from '../types.ts';
  *
  * import type { Counter } from '../types.ts';
  *
- * // Defined, not invoked: writes the plan and summary comments to stdout.
+ * // Defined, not invoked: writes the plan and summary comments to the run's output.
  * function example(counter: Counter) {
  *   TAP.displayFinalResult(counter, 1240);
  *   // "1..8" then "# tests 8", "# pass 7", … "# duration 1240"
@@ -21,14 +22,15 @@ import type { Counter } from '../types.ts';
 export function displayFinalResult(
   { testCount, passCount, skipCount, todoCount, failCount }: Counter,
   timeTaken: number,
+  output: Output = processOutput,
 ): void {
-  process.stdout.write('\n');
-  process.stdout.write(`1..${testCount}\n`);
-  process.stdout.write(`# tests ${testCount}\n`);
-  process.stdout.write(`# pass ${passCount}\n`);
-  process.stdout.write(`# skip ${skipCount}\n`);
-  process.stdout.write(`# todo ${todoCount}\n`);
-  process.stdout.write(`# fail ${failCount}\n`);
-  process.stdout.write(`# duration ${timeTaken}\n`);
-  process.stdout.write('\n');
+  output.write('\n');
+  output.write(`1..${testCount}\n`);
+  output.write(`# tests ${testCount}\n`);
+  output.write(`# pass ${passCount}\n`);
+  output.write(`# skip ${skipCount}\n`);
+  output.write(`# todo ${todoCount}\n`);
+  output.write(`# fail ${failCount}\n`);
+  output.write(`# duration ${timeTaken}\n`);
+  output.write('\n');
 }

--- a/lib/tap/display-test-result.ts
+++ b/lib/tap/display-test-result.ts
@@ -1,4 +1,5 @@
 import { dumpYaml } from './dump-yaml.ts';
+import { processOutput, type Output } from '../reporters/output.ts';
 import { indentString } from '../utils/indent-string.ts';
 import type { TestDetails } from '../reporters/types.ts';
 import type { FailureInfo } from '../reporters/failure.ts';
@@ -16,7 +17,7 @@ import type { FailureInfo } from '../reporters/failure.ts';
  * import type { TestDetails } from '../reporters/types.ts';
  * import type { FailureInfo } from '../reporters/failure.ts';
  *
- * // Defined, not invoked: writes the TAP line (plus YAML failure blocks) to stdout.
+ * // Defined, not invoked: writes the TAP line (plus YAML failure blocks) to the run's output.
  * function example(details: TestDetails, failures: FailureInfo[]) {
  *   TAP.displayTestResult(3, details, failures);
  *   // "not ok 3 Math | adds # (2 ms)" then one "  ---" YAML block per failure
@@ -29,19 +30,20 @@ export function displayTestResult(
   testNumber: number,
   details: TestDetails,
   failures: FailureInfo[] = [],
+  output: Output = processOutput,
 ): void {
   // NOTE: https://github.com/qunitjs/qunit/blob/master/src/html-reporter/diff.js
   const name = details.fullName.join(' | ');
 
   if (details.status === 'skipped') {
-    process.stdout.write(`ok ${testNumber} ${name} # skip\n`);
+    output.write(`ok ${testNumber} ${name} # skip\n`);
   } else if (details.status === 'todo') {
-    process.stdout.write(`not ok ${testNumber} ${name} # TODO\n`);
+    output.write(`not ok ${testNumber} ${name} # TODO\n`);
   } else if (details.status === 'failed') {
-    process.stdout.write(`not ok ${testNumber} ${name} # (${details.runtime.toFixed(0)} ms)\n`);
+    output.write(`not ok ${testNumber} ${name} # (${details.runtime.toFixed(0)} ms)\n`);
     failures.forEach((failure) => {
-      process.stdout.write('  ---\n');
-      process.stdout.write(
+      output.write('  ---\n');
+      output.write(
         indentString(
           dumpYaml({
             name: `Assertion #${failure.index}`,
@@ -55,10 +57,10 @@ export function displayTestResult(
           4,
         ),
       );
-      process.stdout.write('  ...\n');
+      output.write('  ...\n');
     });
   } else if (details.status === 'passed') {
-    process.stdout.write(`ok ${testNumber} ${name} # (${details.runtime.toFixed(0)} ms)\n`);
+    output.write(`ok ${testNumber} ${name} # (${details.runtime.toFixed(0)} ms)\n`);
   }
 }
 

--- a/lib/task/index.ts
+++ b/lib/task/index.ts
@@ -24,4 +24,15 @@ export { AwaitTimeout, Shutdown, Abandoned } from './task.ts';
  */
 export * as Failure from '../result/failure.ts';
 
+/**
+ * The value half, re-exported so a Task's `.result()` and its union can be handled without a
+ * second import: `Result<T, E>` is the bare `T | E` that settles out of it, `unwrap` moves a
+ * failure back into a throwing channel, and `partition` splits a batch of them.
+ *
+ * ```ts
+ * import { partition } from './index.ts';
+ *
+ * partition([1, new Error('nope'), 3]); // one pass, values and errors separated
+ * ```
+ */
 export { type Result, unwrap, partition } from '../result/result.ts';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -260,9 +260,8 @@ export interface RunState {
   reporters: Reporter[];
   /**
    * Non-null exactly when this run is executing inside the persistent daemon process — it is
-   * the daemon-mode flag as well as the handles. Daemon runs throw `DaemonRunError` instead of
-   * calling `process.exit`, suppress the per-connection TAP header, and leave the shared browser
-   * open at the end of the run.
+   * the daemon-mode flag as well as the handles. Daemon runs reuse the shared browser, suppress
+   * the per-connection TAP header, and leave that browser open at the end of the run.
    */
   daemon: DaemonState | null;
   /** Number of concurrent groups in this run; 1 for watch and single-group runs. */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -502,6 +502,14 @@ export interface Config {
   browser: 'chromium' | 'firefox' | 'webkit';
   /** Absolute path to the project root (directory containing `package.json`). */
   projectRoot: string;
+  /**
+   * Working directory this run resolves against: relative inputs, bare-specifier resolution
+   * inside the test bundle, and `--before`/`--after` hook paths. `process.cwd()` for the CLI;
+   * the JS API's `cwd` option otherwise. Distinct from {@link projectRoot}, which is wherever
+   * the nearest `package.json` sits — running from a subdirectory keeps that subdirectory's
+   * `node_modules` on the resolution chain, exactly as Node itself would.
+   */
+  cwd: string;
   /** CLI input paths (files or directories) from which test files are discovered. */
   inputs: string[];
   /** Absolute paths to HTML fixture files that wrap the compiled test bundle. */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -273,6 +273,16 @@ export interface RunState {
   daemon: DaemonState | null;
   /** Number of concurrent groups in this run; 1 for watch and single-group runs. */
   groupCount: number;
+  /**
+   * One callback per live server that tells its connected pages to drop the rest of the QUnit
+   * queue — what `qq`, `session.abort()` and an aborted `signal` all go through.
+   *
+   * A set rather than a slot because a concurrent run may have one server per group, and
+   * aborting half a run is not aborting it. Shared by reference across groups, so a group
+   * registering its own server marks it for everyone. Entries for closed servers are harmless:
+   * publishing to a server with no clients reaches nobody.
+   */
+  aborters: Set<() => void>;
   /** File-watcher build bookkeeping. Only meaningful in watch mode, where there is one group. */
   watch: WatchState;
   /**
@@ -337,12 +347,10 @@ export interface GroupState {
    * failing assertion's stack can't be resolved to one file — scoped per group so an
    * unattributable failure blames only the files that group ran, not the whole invocation.
    *
-   * Watch mode runs exactly one group, so this doubles as the `ql` rerun target there. Named to
-   * pair with {@link lastFailedFiles}.
+   * Watch mode runs exactly one group, so this doubles as the `ql` rerun target there, and the
+   * `qf` fallback when the last run had no failures to scope to.
    */
   lastRanFiles: string[] | null;
-  /** Files treated as failed for the `qf` rerun shortcut. Watch mode only, hence single-group. */
-  lastFailedFiles: string[] | null;
   /**
    * Tracks `testEnd` arrivals per test fullName in this group's run. Reset in lockstep with the
    * run counter — explicitly NOT on every WS 'connection' event, which was the bug that broke
@@ -475,6 +483,15 @@ export interface RunResults {
    * Reassigned only by `RunState.reset` (a fresh Map per run), never by a group.
    */
   coverage: CoverageFileMap | null;
+  /**
+   * Whether the browser confirmed it dropped this run's remaining queue — `qq`, `session.abort()`,
+   * or an aborted `signal`. Lives here rather than on the group because groups share this object
+   * by reference, so one aborted group marks the whole run without any cross-group plumbing.
+   *
+   * Load-bearing for the result: an aborted run and a red run both end with failures and exit 1,
+   * and nothing else distinguishes "I stopped it" from "it broke".
+   */
+  aborted: boolean;
 }
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,7 @@ import type { Buffer } from 'node:buffer';
 import type { BuildContext, Plugin as EsbuildPlugin } from 'esbuild';
 import type { SourceMapDecoder } from './utils/source-map.ts';
 import type { Reporter, ReporterName } from './reporters/types.ts';
+import type { Output } from './reporters/output.ts';
 import type { QUnitSelector } from './selection/line-targets.ts';
 import type { FailedTestRecord } from './utils/failure-cache.ts';
 
@@ -258,6 +259,12 @@ export interface RunState {
    * One set for the whole run, so a stateful reporter sees every group rather than one slice.
    */
   reporters: Reporter[];
+  /**
+   * Where this run's text goes: every reporter line and every `#` diagnostic. `processOutput`
+   * for the CLI, `silentOutput` for a programmatic run that only wants the result value.
+   * Shared by reference across concurrent groups, like everything else outside `group`.
+   */
+  output: Output;
   /**
    * Non-null exactly when this run is executing inside the persistent daemon process — it is
    * the daemon-mode flag as well as the handles. Daemon runs reuse the shared browser, suppress

--- a/lib/utils/find-project-root.ts
+++ b/lib/utils/find-project-root.ts
@@ -13,11 +13,12 @@ import { searchInParentDirectories } from './search-in-parent-directories.ts';
  * ProjectRootNotFound.is(ProjectRootNotFound({ cwd: '/tmp' })); // true
  * ```
  */
-export const ProjectRootNotFound = Failure.define(
-  'ProjectRootNotFound',
-  (data: { cwd: string }) =>
-    `couldn't find a package.json at or above ${data.cwd} — did you run \`npm init\`?`,
-);
+export const ProjectRootNotFound: Failure.FailureFactory<'ProjectRootNotFound', { cwd: string }> =
+  Failure.define(
+    'ProjectRootNotFound',
+    (data: { cwd: string }) =>
+      `couldn't find a package.json at or above ${data.cwd} — did you run \`npm init\`?`,
+  );
 
 /** The one failure {@link findProjectRoot} declares. */
 export type ProjectRootNotFoundFailure = Failure.Of<typeof ProjectRootNotFound>;

--- a/lib/utils/find-project-root.ts
+++ b/lib/utils/find-project-root.ts
@@ -29,6 +29,9 @@ export type ProjectRootNotFoundFailure = Failure.Of<typeof ProjectRootNotFound>;
  * `process.exit(1)` from inside a library function — untestable, and unanswerable by the
  * daemon, which serves many projects and must not die because one of them lacks a manifest.
  *
+ * `cwd` defaults to the working directory, which is what the CLI wants. It is a parameter so the
+ * JS API can resolve a project other than the one the host process happens to sit in.
+ *
  * ```ts
  * import { findProjectRoot } from './find-project-root.ts';
  * import * as Failure from '../result/failure.ts';
@@ -40,14 +43,16 @@ export type ProjectRootNotFoundFailure = Failure.Of<typeof ProjectRootNotFound>;
  * }
  * ```
  */
-export function findProjectRoot(): Task<string, ProjectRootNotFoundFailure> {
+export function findProjectRoot(
+  cwd: string = process.cwd(),
+): Task<string, ProjectRootNotFoundFailure> {
   return Task(async () => {
-    const absolutePath = await searchInParentDirectories('.', 'package.json');
+    const absolutePath = await searchInParentDirectories(cwd, 'package.json');
     // Thrown at the condition rather than classified afterwards with `.mapErr`. A trailing
     // `.mapErr(ProjectRootNotFound, …)` would see EVERY rejection — so an EACCES part-way up the
     // tree, which is a bug, would be reported as "there is no project here", which is a lie. It
     // also builds a second, derived Task for a failure this function can name itself.
-    if (!absolutePath?.includes('package.json')) throw ProjectRootNotFound({ cwd: process.cwd() });
+    if (!absolutePath?.includes('package.json')) throw ProjectRootNotFound({ cwd });
 
     // path.dirname strips the basename using the platform separator — `.replace('/package.json', '')`
     // missed Windows paths like `C:\foo\package.json`, leaving the literal filename in the result.

--- a/lib/utils/kill-process-group.ts
+++ b/lib/utils/kill-process-group.ts
@@ -7,7 +7,8 @@ import * as Result from '../result/index.ts';
  *
  * On Windows, uses `taskkill /F /T` to kill the process and its entire child tree
  * (renderer, GPU, crashpad helpers etc. that survive a plain process.kill() on Windows).
- * All errors are silently suppressed — ESRCH means the process already exited.
+ * Errors are silently suppressed — ESRCH means the process already exited, which is what
+ * we were asking for.
  *
  * ```ts
  * import type { ChildProcess } from 'node:child_process';
@@ -19,7 +20,8 @@ import * as Result from '../result/index.ts';
  * ```
  */
 export function killProcessGroup(pid: number): void {
-  // ESRCH: the process is already dead, which is what we were asking for.
+  if (!isTargetablePid(pid)) return;
+
   Result.try(() => {
     if (process.platform === 'win32') {
       // /T kills the process tree; /F forces termination of running processes.
@@ -28,4 +30,37 @@ export function killProcessGroup(pid: number): void {
       process.kill(-pid, 'SIGKILL');
     }
   });
+}
+
+/**
+ * Whether `pid` is safe to hand to a **negated** `process.kill`.
+ *
+ * This guard is the whole reason this module is not a one-liner. `process.kill(-pid)` is the
+ * POSIX "signal the whole group" form, and two pid values turn it into something catastrophically
+ * broader:
+ *
+ * - `0` negates to `0`, and `kill(0, …)` signals **every process in the caller's own group** —
+ *   for a CLI run from a terminal, that is the shell and everything sharing its job.
+ * - `1` negates to `-1`, and `kill(-1, …)` signals **every process the user is permitted to
+ *   signal**. On a desktop session that is the session: it logs the user out.
+ *
+ * Neither is hypothetical from a caller's point of view — `pid` arrives from `ChildProcess.pid`
+ * (typed `number | undefined`), from `parseInt` over a `/proc` entry, and from a pid parsed out of
+ * a file on disk. Any of those can produce a value the caller believed was a real child's. And
+ * because the kill itself is deliberately error-swallowing, a wrong pid leaves no trace at all.
+ *
+ * So the check lives here, at the primitive, rather than being re-derived at each call site:
+ * a group kill is only ever attempted for a pid that could actually be a spawned child.
+ *
+ * ```ts
+ * isTargetablePid(4242); // true
+ * isTargetablePid(1); // false — negates to kill(-1), every process the user owns
+ * isTargetablePid(0); // false — negates to kill(0), the caller's own process group
+ * isTargetablePid(Number.NaN); // false
+ * ```
+ */
+export function isTargetablePid(pid: number): boolean {
+  // `> 1` rather than `> 0`: pid 1 is init/systemd, which is never a child of ours, and is the
+  // one value whose negation means "everything".
+  return Number.isInteger(pid) && pid > 1 && pid !== process.pid;
 }

--- a/lib/web/index.ts
+++ b/lib/web/index.ts
@@ -1,18 +1,50 @@
 import http from 'node:http';
-// @deno-types="npm:@types/ws"
+// Constraint spelled out because this specifier bypasses the import map, and JSR requires
+// every npm specifier to carry one.
+// @deno-types="npm:@types/ws@^8"
 import WebSocket, { WebSocketServer } from 'ws';
 import { bindServerToPort } from '../setup/bind-server-to-port.ts';
 
-declare module 'node:http' {
-  interface IncomingMessage {
-    send: (data: string) => void;
-    path: string;
-    query: Record<string, string>;
-    params: Record<string, string>;
-  }
-  interface ServerResponse {
-    json: (data: unknown) => void;
-  }
+/**
+ * The request a route handler receives: node's, plus the four conveniences this server attaches
+ * before dispatching.
+ *
+ * An interface that *extends* `IncomingMessage` rather than a `declare module` augmenting it.
+ * The augmentation put `path`/`query`/`params`/`send` on every `node:http` request in the entire
+ * program — including ones this server never touched, where they were a lie the type checker
+ * would have vouched for. (It is also a global side effect JSR rejects outright.)
+ *
+ * ```ts
+ * // Defined, not invoked: a real request comes from the server's own dispatch.
+ * function routeOf(req: Request) {
+ *   return `${req.path}?${new URLSearchParams(req.query)}`;
+ * }
+ * ```
+ */
+export interface Request extends http.IncomingMessage {
+  /** Responds with `data` as `text/plain` and ends the response. */
+  send: (data: string) => void;
+  /** The URL's pathname, without the query string. */
+  path: string;
+  /** The parsed query string. */
+  query: Record<string, string>;
+  /** Values captured by the matched route's `:name` segments; `{}` for a literal route. */
+  params: Record<string, string>;
+}
+
+/**
+ * The response a route handler receives: node's, plus a JSON shorthand.
+ *
+ * ```ts
+ * // Defined, not invoked: a real response comes from the server's own dispatch.
+ * function ok(res: Response) {
+ *   return res.json({ ok: true });
+ * }
+ * ```
+ */
+export interface Response extends http.ServerResponse {
+  /** Responds with `data` as `application/json` and ends the response. */
+  json: (data: unknown) => void;
 }
 
 type NodeServerWithWSS = http.Server & { wss: WebSocketServer };
@@ -28,10 +60,7 @@ type NodeServerWithWSS = http.Server & { wss: WebSocketServer };
  * const handler: RouteHandler = (_req, res) => res.end('served');
  * ```
  */
-export type RouteHandler = (
-  req: http.IncomingMessage,
-  res: http.ServerResponse,
-) => unknown | Promise<unknown>;
+export type RouteHandler = (req: Request, res: Response) => unknown | Promise<unknown>;
 /**
  * Middleware function signature — call `next()` to continue the chain.
  *
@@ -42,11 +71,7 @@ export type RouteHandler = (
  * };
  * ```
  */
-export type Middleware = (
-  req: http.IncomingMessage,
-  res: http.ServerResponse,
-  next: () => void,
-) => void;
+export type Middleware = (req: Request, res: Response, next: () => void) => void;
 
 /**
  * One registered route: the parsed shape `get()`/`post()`/… store and `#findRouteHandler`
@@ -121,6 +146,10 @@ export class HTTPServer {
   /**
    * Creates and starts a plain `http.createServer` instance on the given port.
    *
+   * The handler gets node's own request and response, NOT this server's {@link Request} and
+   * {@link Response}: nothing in this path attaches `path`/`query`/`params`/`json`, so promising
+   * them would be a lie. The ambient augmentation this replaced told exactly that lie.
+   *
    * ```ts
    * // Defined, not invoked: binds a real port.
    * function example() {
@@ -169,7 +198,11 @@ export class HTTPServer {
       PUT: {},
     };
     this.middleware = [];
-    this._server = http.createServer((req, res) => {
+    this._server = http.createServer((rawReq, rawRes) => {
+      // The single cast in the file, and the only place one is honest: the four properties
+      // `Request`/`Response` promise are attached on the next lines, before anything reads them.
+      const req = rawReq as Request;
+      const res = rawRes as Response;
       req.send = (data: string) => {
         res.setHeader('Content-Type', 'text/plain');
         res.end(data);
@@ -334,7 +367,7 @@ export class HTTPServer {
     };
   }
 
-  #handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
+  #handleRequest(req: Request, res: Response): void {
     const { method, url } = req;
     const urlObj = new URL(url!, 'http://localhost');
     const pathname = urlObj.pathname;
@@ -352,11 +385,7 @@ export class HTTPServer {
     }
   }
 
-  #runMiddleware(
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
-    callback: RouteHandler,
-  ): void {
+  #runMiddleware(req: Request, res: Response, callback: RouteHandler): void {
     let index = 0;
     const next = () => {
       if (index >= this.middleware.length) {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,18 @@
   "files": [
     "bin/",
     "dist/",
+    "lib/",
     "templates/"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/types/lib/api/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./lib/*": "./lib/*",
+    "./package.json": "./package.json"
+  },
+  "types": "./dist/types/lib/api/index.d.ts",
   "scripts": {
     "build": "node scripts/build-cli.js",
     "bin": "chmod +x cli.ts && ./cli.ts",

--- a/scripts/build-cli.js
+++ b/scripts/build-cli.js
@@ -1,21 +1,113 @@
 #!/usr/bin/env node
-// Bundles cli.ts into dist/cli.js for npm distribution.
-// All local TypeScript is bundled and types are stripped by esbuild.
-// npm dependencies (esbuild, playwright-core, ws) remain external so they
-// continue to be resolved from the consumer's node_modules at runtime.
+// Builds the two npm entry points and the type declarations for the JS API.
+//
+//   dist/cli.js    ← cli.ts          the `qunitx` binary's fallback entry
+//   dist/index.js  ← lib/api/index.ts  what `import 'qunitx-cli'` resolves to
+//   dist/types/    ← lib/api/index.ts  .d.ts tree for the same
+//
+// All local TypeScript is bundled and types are stripped by esbuild. npm dependencies
+// (esbuild, playwright-core, ws) remain external so they continue to be resolved from the
+// consumer's node_modules at runtime.
 import { build } from 'esbuild';
-import { mkdir } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const EXTERNAL = ['esbuild', 'playwright-core', 'ws'];
+const TYPES_DIR = 'dist/types';
+const API_ENTRY = 'lib/api/index.ts';
 
 await mkdir('dist', { recursive: true });
 
-await build({
-  entryPoints: ['cli.ts'],
-  bundle: true,
-  platform: 'node',
-  format: 'esm',
-  outfile: 'dist/cli.js',
-  external: ['esbuild', 'playwright-core', 'ws'],
-  logLevel: 'warning',
-});
+await Promise.all([
+  build({
+    entryPoints: ['cli.ts'],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    outfile: 'dist/cli.js',
+    external: EXTERNAL,
+    logLevel: 'warning',
+  }),
+  build({
+    entryPoints: [API_ENTRY],
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    outfile: 'dist/index.js',
+    external: EXTERNAL,
+    logLevel: 'warning',
+  }),
+]);
+console.log('Built dist/cli.js and dist/index.js');
 
-console.log('Built dist/cli.js');
+await buildTypes();
+
+/**
+ * Emits the API's `.d.ts` tree.
+ *
+ * `--noCheck` because this is an emit, not a gate: `npm run typecheck` (deno check, including
+ * every doc example) is what decides whether the types are right, and running a second, slower
+ * checker here would only produce a second opinion to reconcile.
+ *
+ * Flags rather than a tsconfig.json, so the repo keeps one source of truth for how its
+ * TypeScript is configured instead of gaining a second one that only the build reads.
+ */
+async function buildTypes() {
+  const result = spawnSync(
+    process.execPath,
+    [
+      path.join('node_modules', 'typescript', 'bin', 'tsc'),
+      API_ENTRY,
+      '--declaration',
+      '--emitDeclarationOnly',
+      '--noCheck',
+      '--skipLibCheck',
+      '--outDir',
+      TYPES_DIR,
+      '--module',
+      'nodenext',
+      '--moduleResolution',
+      'nodenext',
+      '--target',
+      'esnext',
+      '--allowImportingTsExtensions',
+    ],
+    { stdio: 'inherit' },
+  );
+  if (result.status !== 0) throw new Error(`tsc declaration emit failed (${result.status})`);
+
+  await rewriteTsSpecifiers(TYPES_DIR);
+  console.log(`Built ${TYPES_DIR}/`);
+}
+
+/**
+ * Rewrites `./x.ts` specifiers to `./x.js` throughout the emitted declarations.
+ *
+ * The source imports carry explicit `.ts` extensions (Node 24 and Deno both want them), and
+ * `--rewriteRelativeImportExtensions` is not honoured by the TypeScript 7 compiler this repo
+ * pins — so the emitted `.d.ts` files inherit specifiers that a consumer's resolver, which has
+ * no `allowImportingTsExtensions`, cannot follow. Rewriting them here is what makes the shipped
+ * types resolvable from an ordinary project.
+ */
+async function rewriteTsSpecifiers(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) return rewriteTsSpecifiers(entryPath);
+      if (!entry.name.endsWith('.d.ts')) return;
+
+      const source = await readFile(entryPath, 'utf8');
+      // Anchored on `from`/`import(` plus a relative prefix, so a bare `.ts` mention in prose is
+      // left alone. An `import … from './x.ts'` inside a doc example is rewritten along with the
+      // real ones, which is right: a reader of the shipped declarations is importing the built
+      // `.js`, not the source.
+      const rewritten = source.replace(
+        /(\bfrom\s+|\bimport\s*\()(['"])(\.\.?\/[^'"]+)\.ts\2/g,
+        (_match, keyword, quote, specifier) => `${keyword}${quote}${specifier}.js${quote}`,
+      );
+      if (rewritten !== source) await writeFile(entryPath, rewritten);
+    }),
+  );
+}

--- a/scripts/stage-jsr-library.ts
+++ b/scripts/stage-jsr-library.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+// Stages the library into jsr/ so `deno publish` can ship it.
+//
+// JSR resolves every export relative to the package root — a specifier may not climb above it —
+// and this package's root is jsr/, because `.` must stay the binary bootstrap that
+// `deno install -Agf jsr:@izelnakri/qunitx-cli` runs. So the sources the `./api` export needs
+// are copied in rather than referenced upward.
+//
+// Three things move, and each is load-bearing:
+//   lib/        the library itself
+//   templates/  read at runtime by readTemplate, whose `../../templates` candidate resolves to
+//               jsr/templates from jsr/lib/utils/ — which is why the layout is mirrored exactly
+//   package.json  imported by lib/commands/daemon/index.ts as '../../../package.json'
+//
+// Everything staged is generated, and .gitignore'd as such. Run before `deno publish`; the
+// release recipe in the Makefile does exactly that.
+import { cp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const jsr = path.join(root, 'jsr');
+const STAGED = ['lib', 'templates', 'package.json'];
+
+await Promise.all(
+  STAGED.map((entry) => rm(path.join(jsr, entry), { recursive: true, force: true })),
+);
+await Promise.all(
+  STAGED.map((entry) => cp(path.join(root, entry), path.join(jsr, entry), { recursive: true })),
+);
+
+console.log(`Staged ${STAGED.join(', ')} into jsr/`);

--- a/test/api/artifacts-test.ts
+++ b/test/api/artifacts-test.ts
@@ -1,0 +1,69 @@
+import { module, test } from 'qunitx';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { apiRun } from './helpers.ts';
+import '../helpers/custom-asserts.ts';
+
+const PASSING = 'test/fixtures/passing-tests.ts';
+const COVERED = 'test/fixtures/coverage/calculator-test.ts';
+
+module('API | artifacts | junit', { concurrency: true }, () => {
+  test('the XML comes back on the result, not only as a file', async (assert) => {
+    const result = await apiRun({ inputs: [PASSING], junit: true });
+
+    assert.ok(result.junitXml, 'the document is on the result');
+    assert.includes(result.junitXml!, '<?xml');
+    assert.includes(result.junitXml!, '<testsuites');
+    assert.includes(result.junitXml!, 'assert true works');
+  });
+
+  test('and is still written to disk, byte-identical', async (assert) => {
+    const output = `tmp/api-junit-${crypto.randomUUID()}`;
+    const result = await apiRun({ inputs: [PASSING], junit: true, output });
+
+    const onDisk = await fs.readFile(path.join(output, 'junit.xml'), 'utf8');
+    assert.equal(onDisk, result.junitXml, 'the same document, two ways to reach it');
+    await fs.rm(output, { recursive: true, force: true });
+  });
+
+  test('no junit option means no document', async (assert) => {
+    const result = await apiRun({ inputs: [PASSING] });
+
+    assert.equal(result.junitXml, null);
+  });
+});
+
+module('API | artifacts | coverage', { concurrency: true }, () => {
+  test('per-file line coverage comes back as data', async (assert) => {
+    const result = await apiRun({ inputs: [COVERED], coverage: true });
+
+    assert.ok(result.coverage, 'a summary is present when coverage was asked for');
+    assert.true(result.coverage!.files.length > 0, 'with at least one source file');
+    assert.true(
+      result.coverage!.files.every(
+        (file) => file.coverableLines > 0 && file.percent >= 0 && file.percent <= 100,
+      ),
+      'each file reports sane counts',
+    );
+    assert.true(
+      result.coverage!.coverableLines >= result.coverage!.coveredLines,
+      'you cannot cover more lines than exist',
+    );
+  });
+
+  test('the test file itself is excluded from the report', async (assert) => {
+    const result = await apiRun({ inputs: [COVERED], coverage: true });
+
+    assert.false(
+      result.coverage!.files.some((file) => file.path.endsWith('calculator-test.ts')),
+      'a test file covering itself is noise',
+    );
+    assert.true(result.coverage!.files.some((file) => file.path.endsWith('calculator.ts')));
+  });
+
+  test('no coverage option means no summary', async (assert) => {
+    const result = await apiRun({ inputs: [PASSING] });
+
+    assert.equal(result.coverage, null);
+  });
+});

--- a/test/api/daemon-test.ts
+++ b/test/api/daemon-test.ts
@@ -1,0 +1,130 @@
+import { module, test } from 'qunitx';
+import { daemon } from '../../lib/api/index.ts';
+import { acquireBrowser } from '../helpers/browser-semaphore-queue.ts';
+import { outputDir } from '../helpers/temp-dir.ts';
+import '../helpers/custom-asserts.ts';
+
+const PASSING = 'test/fixtures/passing-tests.ts';
+const FAILING = 'test/fixtures/failing-tests.ts';
+
+// One daemon serves one project directory, and this suite starts and stops the real thing — so
+// its tests share that single daemon and must not interleave with each other.
+//
+// Skipped on Windows for the same reason test/commands/daemon-test.ts is: the daemon spawn path
+// there is covered by the CLI suite, and doubling it doubles the flakiest lane's cost.
+const SKIP = process.platform === 'win32';
+
+module('API | daemon', { concurrency: false, skip: SKIP }, () => {
+  test('status reports no daemon before one is started', async (assert) => {
+    await daemon.stop();
+
+    assert.deepEqual(await daemon.status(), { running: false });
+  });
+
+  test('start brings one up, status describes it, stop takes it down', async (assert) => {
+    const permit = await acquireBrowser();
+    try {
+      assert.true(await daemon.start(), 'started');
+
+      const running = await daemon.status();
+      assert.true(running.running);
+      if (running.running) {
+        assert.true(running.pid > 0, 'with a pid');
+        assert.equal(running.cwd, process.cwd(), 'serving this project');
+        assert.includes(running.socketPath, 'qunitx');
+      }
+
+      assert.true(await daemon.stop(), 'stopped');
+      assert.deepEqual(await daemon.status(), { running: false });
+    } finally {
+      permit.release();
+    }
+  });
+
+  test('start is idempotent', async (assert) => {
+    const permit = await acquireBrowser();
+    try {
+      assert.true(await daemon.start());
+      assert.true(await daemon.start(), 'a second call is a liveness probe, not a second daemon');
+    } finally {
+      await daemon.stop();
+      permit.release();
+    }
+  });
+
+  test('stop on nothing reports false rather than failing', async (assert) => {
+    await daemon.stop();
+
+    assert.false(await daemon.stop(), 'nothing was running');
+  });
+
+  test('run returns the same structured result a local run does', async (assert) => {
+    await using output = outputDir('api-daemon-run');
+    const permit = await acquireBrowser();
+    try {
+      const result = await daemon.run({ inputs: [PASSING], output: output.path });
+
+      assert.true(result.ok);
+      assert.equal(result.counts.total, 3);
+      assert.equal(result.tests.length, 3, 'the per-test detail survives the socket');
+      assert.true(result.files[0].endsWith('passing-tests.ts'));
+    } finally {
+      await daemon.stop();
+      permit.release();
+    }
+  });
+
+  test('a failing run through the daemon is a result, not a rejection', async (assert) => {
+    await using output = outputDir('api-daemon-fail');
+    const permit = await acquireBrowser();
+    try {
+      const result = await daemon.run({ inputs: [FAILING], output: output.path });
+
+      assert.false(result.ok);
+      assert.true(result.failures.length > 0);
+      assert.true(result.failedFiles[0].endsWith('failing-tests.ts'));
+    } finally {
+      await daemon.stop();
+      permit.release();
+    }
+  });
+
+  test('two consecutive runs both answer, the second on a warm browser', async (assert) => {
+    await using output = outputDir('api-daemon-warm');
+    const permit = await acquireBrowser();
+    try {
+      const first = await daemon.run({ inputs: [PASSING], output: output.path });
+      const second = await daemon.run({ inputs: [PASSING], output: output.path });
+
+      assert.equal(first.counts.total, 3);
+      assert.equal(second.counts.total, 3, 'reuse does not leak state between runs');
+      assert.deepEqual(
+        second.tests.map((one) => one.fullName),
+        first.tests.map((one) => one.fullName),
+      );
+    } finally {
+      await daemon.stop();
+      permit.release();
+    }
+  });
+
+  test('a named reporter streams the daemon text into the given stdout', async (assert) => {
+    await using output = outputDir('api-daemon-tap');
+    const chunks: string[] = [];
+    const permit = await acquireBrowser();
+    try {
+      const result = await daemon.run({
+        inputs: [PASSING],
+        output: output.path,
+        reporter: 'tap',
+        stdout: { write: (text) => void chunks.push(text) },
+      });
+
+      assert.includes(chunks.join(''), 'TAP version 13', 'the daemon-side output arrives here');
+      assert.equal(result.counts.passed, 3, 'and the structured result comes back too');
+    } finally {
+      await daemon.stop();
+      permit.release();
+    }
+  });
+});

--- a/test/api/daemon-test.ts
+++ b/test/api/daemon-test.ts
@@ -58,10 +58,19 @@ module('API | daemon', { concurrency: false, skip: SKIP }, () => {
     assert.false(await daemon.stop(), 'nothing was running');
   });
 
+  // From here on the tests SHARE one daemon: the first spawns it, the rest reuse it, and only
+  // the last stops it. Spawning per test paid up to SPAWN_TIMEOUT_MS of exposure each — four
+  // spawns for four assertions — and under CI contention that is exactly what went red. Sharing
+  // is also the situation these tests are about: a daemon serving several runs in a row.
+
   test('run returns the same structured result a local run does', async (assert) => {
     await using output = outputDir('api-daemon-run');
     const permit = await acquireBrowser();
     try {
+      // Spawned explicitly rather than left to `run`'s auto-spawn, so a spawn that never became
+      // reachable is reported as such instead of surfacing as `DaemonUnreachable` mid-assertion.
+      assert.true(await daemon.start(), 'the shared daemon came up');
+
       const result = await daemon.run({ inputs: [PASSING], output: output.path });
 
       assert.true(result.ok);
@@ -69,7 +78,6 @@ module('API | daemon', { concurrency: false, skip: SKIP }, () => {
       assert.equal(result.tests.length, 3, 'the per-test detail survives the socket');
       assert.true(result.files[0].endsWith('passing-tests.ts'));
     } finally {
-      await daemon.stop();
       permit.release();
     }
   });
@@ -84,7 +92,6 @@ module('API | daemon', { concurrency: false, skip: SKIP }, () => {
       assert.true(result.failures.length > 0);
       assert.true(result.failedFiles[0].endsWith('failing-tests.ts'));
     } finally {
-      await daemon.stop();
       permit.release();
     }
   });
@@ -103,7 +110,6 @@ module('API | daemon', { concurrency: false, skip: SKIP }, () => {
         first.tests.map((one) => one.fullName),
       );
     } finally {
-      await daemon.stop();
       permit.release();
     }
   });
@@ -123,6 +129,7 @@ module('API | daemon', { concurrency: false, skip: SKIP }, () => {
       assert.includes(chunks.join(''), 'TAP version 13', 'the daemon-side output arrives here');
       assert.equal(result.counts.passed, 3, 'and the structured result comes back too');
     } finally {
+      // The last of the shared-daemon tests owns the teardown.
       await daemon.stop();
       permit.release();
     }

--- a/test/api/events-test.ts
+++ b/test/api/events-test.ts
@@ -1,0 +1,141 @@
+import { module, test } from 'qunitx';
+import {
+  Channel,
+  MAX_BUFFERED_EVENTS,
+  eventReporter,
+  type RunEvent,
+} from '../../lib/api/events.ts';
+import type { Config } from '../../lib/types.ts';
+import '../helpers/custom-asserts.ts';
+
+// No browser here: the channel is the piece both sessions are built on, and its awkward cases —
+// a consumer arriving late, a producer flooding, a close with values still buffered — are far
+// easier to provoke directly than through a real run.
+
+const CONFIG = {} as Config;
+
+module('API | events | Channel', { concurrency: true }, () => {
+  test('a late consumer still sees everything that was pushed', async (assert) => {
+    const channel = new Channel<number>();
+    channel.push(1);
+    channel.push(2);
+    channel.close();
+
+    const seen: number[] = [];
+    for await (const value of channel) seen.push(value);
+
+    assert.deepEqual(seen, [1, 2], 'buffered until someone asked');
+  });
+
+  test('a waiting consumer is handed values as they arrive', async (assert) => {
+    const channel = new Channel<string>();
+    const iterator = channel[Symbol.asyncIterator]();
+    const pending = iterator.next();
+
+    assert.equal(channel.buffered, 0, 'nothing buffers while a consumer is parked');
+    channel.push('a');
+
+    assert.deepEqual(await pending, { done: false, value: 'a' });
+  });
+
+  test('close() drains the buffer before ending', async (assert) => {
+    const channel = new Channel<number>();
+    channel.push(1);
+    channel.close();
+
+    const iterator = channel[Symbol.asyncIterator]();
+
+    assert.deepEqual(await iterator.next(), { done: false, value: 1 }, 'the queued value survives');
+    assert.deepEqual(await iterator.next(), { done: true, value: undefined });
+  });
+
+  test('close() wakes a consumer parked on a value that never comes', async (assert) => {
+    const channel = new Channel<number>();
+    const pending = channel[Symbol.asyncIterator]().next();
+    channel.close();
+
+    assert.deepEqual(await pending, { done: true, value: undefined }, 'released rather than hung');
+  });
+
+  test('pushing after close is ignored rather than thrown', (assert) => {
+    const channel = new Channel<number>();
+    channel.close();
+    channel.push(1);
+
+    assert.equal(channel.buffered, 0, 'a late event from a run being torn down is dropped');
+  });
+
+  test('close() is idempotent', (assert) => {
+    const channel = new Channel<number>();
+    channel.close();
+    channel.close();
+
+    assert.true(channel.closed);
+  });
+
+  test('a flood past the cap drops the oldest and counts what it dropped', async (assert) => {
+    const channel = new Channel<number>();
+    for (let index = 0; index < MAX_BUFFERED_EVENTS + 10; index++) channel.push(index);
+
+    assert.equal(channel.buffered, MAX_BUFFERED_EVENTS, 'the buffer holds at the cap');
+    assert.equal(channel.dropped, 10, 'and says how many it lost');
+
+    const iterator = channel[Symbol.asyncIterator]();
+
+    assert.deepEqual(
+      await iterator.next(),
+      { done: false, value: 10 },
+      'the oldest went, the newest stayed — they are the ones next to whatever went wrong',
+    );
+  });
+
+  test('an ordinary run drops nothing', (assert) => {
+    const channel = new Channel<number>();
+    for (let index = 0; index < 500; index++) channel.push(index);
+
+    assert.equal(channel.dropped, 0, 'the cap is far above any real suite');
+  });
+
+  test('breaking out of the loop closes the channel', async (assert) => {
+    const channel = new Channel<number>();
+    channel.push(1);
+    channel.push(2);
+
+    for await (const _value of channel) break;
+
+    assert.true(channel.closed);
+  });
+});
+
+module('API | events | eventReporter', { concurrency: true }, () => {
+  test('projects each reporter callback into one ordered feed', async (assert) => {
+    const channel = new Channel<RunEvent>();
+    const reporter = eventReporter(channel);
+
+    reporter.onRunStart?.(CONFIG, { fileCount: 2, groupCount: 1 });
+    reporter.onTestEnd?.(CONFIG, { status: 'passed', fullName: ['Cart', 'adds'], runtime: 3 });
+    reporter.onNotice?.(CONFIG, { level: 'info', message: 'scoped to 2 files' });
+    reporter.onBrowserLog?.(CONFIG, { type: 'error', text: 'boom', args: [] });
+    channel.close();
+
+    const seen = (await Array.fromAsync(channel)).map((event) => event.kind);
+
+    assert.deepEqual(seen, ['runStart', 'test', 'notice', 'browserLog'], 'in emission order');
+  });
+
+  test('test events carry the same projection the result does', async (assert) => {
+    const channel = new Channel<RunEvent>();
+    const reporter = eventReporter(channel);
+
+    reporter.onTestEnd?.(CONFIG, { status: 'failed', fullName: ['Cart', 'empties'], runtime: 1 });
+    channel.close();
+
+    const [event] = await Array.fromAsync(channel);
+
+    assert.equal(
+      event.kind === 'test' && event.test.fullName,
+      'Cart: empties',
+      'the display name, not the raw array',
+    );
+  });
+});

--- a/test/api/helpers.ts
+++ b/test/api/helpers.ts
@@ -1,0 +1,77 @@
+import { acquireBrowser } from '../helpers/browser-semaphore-queue.ts';
+import { outputDir } from '../helpers/temp-dir.ts';
+import * as Qunitx from '../../lib/api/index.ts';
+import type { RunOptions } from '../../lib/api/options.ts';
+import type { RunResult } from '../../lib/api/result.ts';
+import type { WatchSession } from '../../lib/api/watch.ts';
+
+// The API tests are the only ones that drive a browser *in this process* rather than through
+// `node cli.ts`. Two things have to be arranged by hand as a result:
+//
+//   1. The Chrome semaphore. The shell helper acquires a permit for every CLI invocation it
+//      spawns; there is no spawn here, so these helpers take the permit themselves. Without it
+//      the API suite launches browsers outside the run-wide concurrency cap.
+//   2. A private output directory per run, so concurrent test files cannot overwrite each
+//      other's bundle. The shell helper appends `--output=tmp/run-<uuid>` for the same reason.
+
+/**
+ * Runs the API against `options` with a permit held and a private output directory, and cleans
+ * both up afterwards.
+ *
+ * ```ts
+ * import { apiRun } from './helpers.ts';
+ *
+ * // Defined, not invoked: launches a real browser.
+ * async function green() {
+ *   const result = await apiRun({ inputs: ['test/fixtures/passing-tests.ts'] });
+ *   return result.ok;
+ * }
+ * ```
+ */
+export async function apiRun(options: RunOptions): Promise<RunResult> {
+  await using output = outputDir('api-run');
+  const permit = await acquireBrowser();
+  try {
+    return await Qunitx.run({ output: output.path, ...options });
+  } finally {
+    permit.release();
+  }
+}
+
+/**
+ * Starts a watch session with a permit held, hands it to `body`, and closes it — releasing the
+ * permit only once the browser is actually down, since a session holds one for its whole life.
+ *
+ * ```ts
+ * import { withWatch } from './helpers.ts';
+ *
+ * // Defined, not invoked: launches a real browser and leaves it watching.
+ * async function firstRunCount() {
+ *   return await withWatch({}, (session) => session.initial.counts.total);
+ * }
+ * ```
+ */
+export async function withWatch<T>(
+  options: RunOptions,
+  body: (session: WatchSession) => Promise<T> | T,
+): Promise<T> {
+  await using output = outputDir('api-watch');
+  const permit = await acquireBrowser();
+  const session = await Qunitx.watch({ output: output.path, ...options });
+  try {
+    return await body(session);
+  } finally {
+    await session.close();
+    permit.release();
+  }
+}
+
+/** Collects everything written to a `stdout`/`stderr` option, for asserting on reporter output. */
+export function captureStream(): { write(text: string): void; text(): string } {
+  const chunks: string[] = [];
+
+  return {
+    write: (text: string) => void chunks.push(text),
+    text: () => chunks.join(''),
+  };
+}

--- a/test/api/helpers.ts
+++ b/test/api/helpers.ts
@@ -4,6 +4,7 @@ import * as Qunitx from '../../lib/api/index.ts';
 import type { RunOptions } from '../../lib/api/options.ts';
 import type { RunResult } from '../../lib/api/result.ts';
 import type { WatchSession } from '../../lib/api/watch.ts';
+import type { RunSession } from '../../lib/api/session.ts';
 
 // The API tests are the only ones that drive a browser *in this process* rather than through
 // `node cli.ts`. Two things have to be arranged by hand as a result:
@@ -58,6 +59,33 @@ export async function withWatch<T>(
   await using output = outputDir('api-watch');
   const permit = await acquireBrowser();
   const session = await Qunitx.watch({ output: output.path, ...options });
+  try {
+    return await body(session);
+  } finally {
+    await session.close();
+    permit.release();
+  }
+}
+
+/**
+ * Starts a run session with a permit held, hands it to `body`, and closes it.
+ *
+ * ```ts
+ * import { withRunSession } from './helpers.ts';
+ *
+ * // Defined, not invoked: launches a real browser.
+ * async function eventCount() {
+ *   return await withRunSession({}, async (session) => (await session.result()).counts.total);
+ * }
+ * ```
+ */
+export async function withRunSession<T>(
+  options: RunOptions,
+  body: (session: RunSession) => Promise<T> | T,
+): Promise<T> {
+  await using output = outputDir('api-session');
+  const permit = await acquireBrowser();
+  const session = await Qunitx.runSession({ output: output.path, ...options });
   try {
     return await body(session);
   } finally {

--- a/test/api/options-test.ts
+++ b/test/api/options-test.ts
@@ -1,0 +1,184 @@
+import { module, test } from 'qunitx';
+import {
+  InvalidOption,
+  normalizeOptions,
+  resolveReporting,
+  toConfigOptions,
+  validate,
+} from '../../lib/api/options.ts';
+import { Collector } from '../../lib/api/result.ts';
+import { TAPReporter } from '../../lib/reporters/tap.ts';
+import { processOutput, silentOutput } from '../../lib/reporters/output.ts';
+import '../helpers/custom-asserts.ts';
+
+module('API | options | shorthands', { concurrency: true }, () => {
+  test('a bare string is one input', (assert) => {
+    assert.deepEqual(normalizeOptions('test/cart-test.ts').inputs, ['test/cart-test.ts']);
+  });
+
+  test('a bare array is the input list', (assert) => {
+    assert.deepEqual(normalizeOptions(['a.ts', 'b.ts']).inputs, ['a.ts', 'b.ts']);
+  });
+
+  test('an options object passes through untouched', (assert) => {
+    const options = { filter: 'Cart', coverage: true };
+    assert.equal(normalizeOptions(options), options, 'the same object, not a copy');
+  });
+
+  test('no argument at all is an empty run request', (assert) => {
+    assert.deepEqual(normalizeOptions(), {});
+  });
+});
+
+module('API | options | reporting', { concurrency: true }, () => {
+  test('silence is the default — no reporter, and an output that discards', (assert) => {
+    const reporting = resolveReporting({});
+
+    assert.equal(reporting.reporters.length, 1, 'only the collector');
+    assert.true(reporting.reporters[0] instanceof Collector);
+    assert.equal(reporting.output, silentOutput);
+  });
+
+  test('naming a reporter opts back into the process streams', (assert) => {
+    const reporting = resolveReporting({ reporter: 'tap' });
+
+    assert.equal(reporting.reporters.length, 2);
+    assert.true(reporting.reporters[0] instanceof Collector, 'collector first');
+    assert.true(reporting.reporters[1] instanceof TAPReporter);
+    assert.equal(reporting.output, processOutput);
+  });
+
+  test('a stdout of your own is used instead, reporter or not', (assert) => {
+    const chunks: string[] = [];
+    const reporting = resolveReporting({ stdout: { write: (text) => void chunks.push(text) } });
+
+    reporting.output.write('hello');
+    reporting.output.error('problem');
+
+    assert.deepEqual(chunks, ['hello', 'problem'], 'stderr falls back to the one stream given');
+  });
+
+  test('a reporter instance is used as-is, and several stack', (assert) => {
+    const mine = { onTestEnd: () => {} };
+    const reporting = resolveReporting({ reporter: ['dot', mine] });
+
+    assert.equal(reporting.reporters.length, 3);
+    assert.equal(reporting.reporters[2], mine, 'the object is not copied or wrapped');
+  });
+
+  test('`reporter: false` is silence even alongside a stdout', (assert) => {
+    const reporting = resolveReporting({ reporter: false });
+
+    assert.equal(reporting.reporters.length, 1, 'the collector, and nothing that prints');
+  });
+
+  test('junit is additive rather than a choice of format', (assert) => {
+    const reporting = resolveReporting({ reporter: 'spec', junit: true });
+
+    assert.equal(reporting.reporters.length, 3, 'collector + spec + junit');
+  });
+
+  test('the callbacks become one reporter', (assert) => {
+    const reporting = resolveReporting({ onTest: () => {}, onNotice: () => {} });
+
+    assert.equal(reporting.reporters.length, 2, 'collector + the callback adapter');
+  });
+});
+
+module('API | options | config translation', { concurrency: true }, () => {
+  const reporting = () => resolveReporting({});
+
+  test('an unset option is absent, not undefined', (assert) => {
+    // Load-bearing: `Config.setup` spreads these over `package.json#qunitx`, so a key present
+    // with an undefined value would erase the project's own setting.
+    const config = toConfigOptions({}, reporting());
+
+    assert.false('browser' in config, 'browser');
+    assert.false('coverage' in config, 'coverage');
+    assert.false('portExplicit' in config, 'portExplicit');
+  });
+
+  test('coverage formats come out of the nested shape', (assert) => {
+    const config = toConfigOptions({ coverage: { formats: ['lcov'] } }, reporting());
+
+    assert.true(config.coverage);
+    assert.deepEqual(config.coverageFormats, ['lcov']);
+  });
+
+  test('bare `coverage: true` asks for the terminal summary only', (assert) => {
+    const config = toConfigOptions({ coverage: true }, reporting());
+
+    assert.true(config.coverage);
+    assert.deepEqual(config.coverageFormats, undefined, 'no artifact formats');
+  });
+
+  test('an explicit port is marked explicit, so a busy port fails rather than sliding', (assert) => {
+    assert.true(toConfigOptions({ port: 4321 }, reporting()).portExplicit);
+    assert.false('portExplicit' in toConfigOptions({}, reporting()));
+  });
+
+  test('`html` maps onto the internal htmlPaths', (assert) => {
+    assert.deepEqual(toConfigOptions({ html: ['test/index.html'] }, reporting()).htmlPaths, [
+      'test/index.html',
+    ]);
+  });
+});
+
+module('API | options | validation', { concurrency: true }, () => {
+  // `validate` throws the Failure by identity — the two-tier rule at the option boundary — so a
+  // bare try/catch is what a caller sees, and `Result.try` would box it in a `Caught` instead.
+  const failureOf = (fn: () => void): unknown => {
+    try {
+      fn();
+      return null;
+    } catch (error) {
+      return error;
+    }
+  };
+
+  test('an unknown browser names what it would have accepted', (assert) => {
+    const failure = failureOf(() => validate({ browser: 'netscape' as 'chromium' }));
+
+    assert.true(InvalidOption.is(failure));
+    assert.includes(InvalidOption.is(failure) ? failure.message : '', 'chromium, firefox, webkit');
+  });
+
+  test('an unknown reporter name is rejected; an object is not', (assert) => {
+    assert.true(InvalidOption.is(failureOf(() => validate({ reporter: 'json' as 'tap' }))));
+    assert.false(InvalidOption.is(failureOf(() => validate({ reporter: { onTestEnd() {} } }))));
+  });
+
+  test('an out-of-range port is rejected before anything binds', (assert) => {
+    assert.true(InvalidOption.is(failureOf(() => validate({ port: 99999 }))));
+    assert.true(InvalidOption.is(failureOf(() => validate({ port: 1.5 }))));
+    assert.false(InvalidOption.is(failureOf(() => validate({ port: 0 }))), '0 means "pick one"');
+  });
+
+  test('a non-positive timeout is rejected', (assert) => {
+    assert.true(InvalidOption.is(failureOf(() => validate({ timeout: 0 }))));
+    assert.true(InvalidOption.is(failureOf(() => validate({ timeout: -1 }))));
+    assert.false(InvalidOption.is(failureOf(() => validate({ timeout: 1 }))));
+  });
+
+  test('an unknown coverage format is rejected', (assert) => {
+    const failure = failureOf(() => validate({ coverage: { formats: ['pdf' as 'lcov'] } }));
+
+    assert.true(InvalidOption.is(failure));
+    assert.includes(InvalidOption.is(failure) ? failure.message : '', 'coverage.formats');
+  });
+
+  test('the options a real caller passes are accepted', (assert) => {
+    const failure = failureOf(() =>
+      validate({
+        inputs: ['test/'],
+        browser: 'firefox',
+        reporter: ['tap', 'github'],
+        coverage: { formats: ['lcov', 'html'] },
+        port: 8080,
+        timeout: 5000,
+      }),
+    );
+
+    assert.false(InvalidOption.is(failure), 'no false positives on a full option set');
+  });
+});

--- a/test/api/options-test.ts
+++ b/test/api/options-test.ts
@@ -72,6 +72,20 @@ module('API | options | reporting', { concurrency: true }, () => {
     assert.equal(reporting.reporters.length, 1, 'the collector, and nothing that prints');
   });
 
+  test('a reporter OBJECT does not turn on the process streams', (assert) => {
+    // Passing a collector is a request to observe, not to print. Only a named built-in — or an
+    // explicit stdout — means "put text on my terminal".
+    const reporting = resolveReporting({ reporter: { onTestEnd: () => {} } });
+
+    assert.equal(reporting.output, silentOutput);
+  });
+
+  test('a named reporter among objects still opts into them', (assert) => {
+    const reporting = resolveReporting({ reporter: [{ onTestEnd: () => {} }, 'dot'] });
+
+    assert.equal(reporting.output, processOutput);
+  });
+
   test('junit is additive rather than a choice of format', (assert) => {
     const reporting = resolveReporting({ reporter: 'spec', junit: true });
 

--- a/test/api/run-test.ts
+++ b/test/api/run-test.ts
@@ -248,6 +248,34 @@ module('API | run | failures', { concurrency: true }, () => {
     assert.equal(Qunitx.Failure.is(outcome) ? outcome.code : null, 'InvalidOption');
   });
 
+  test('an already-aborted signal answers without launching a browser', async (assert) => {
+    await using output = outputDir('api-signal-pre');
+    // No permit: not launching a browser is exactly what is being asserted.
+    const result = await Qunitx.run({
+      inputs: [PASSING],
+      output: output.path,
+      signal: AbortSignal.abort(),
+    });
+
+    assert.true(result.aborted, 'the result says it was cancelled');
+    assert.equal(result.counts.total, 0, 'and nothing ran');
+    assert.equal(result.exitCode, 1, 'a run that never happened is not a pass');
+    assert.false(result.ok);
+  });
+
+  test('an ordinary run is not marked aborted', async (assert) => {
+    const result = await apiRun({ inputs: [PASSING] });
+
+    assert.false(result.aborted, 'green and complete');
+  });
+
+  test('a red run is not marked aborted either', async (assert) => {
+    const result = await apiRun({ inputs: [FAILING] });
+
+    assert.false(result.ok);
+    assert.false(result.aborted, 'failing is not the same as interrupted');
+  });
+
   test('the Task is lazy — nothing runs until it is awaited', async (assert) => {
     await using output = outputDir('api-lazy');
     const task = Qunitx.run({ inputs: [PASSING], output: output.path });

--- a/test/api/run-test.ts
+++ b/test/api/run-test.ts
@@ -64,6 +64,46 @@ module('API | run | results', { concurrency: true }, () => {
     assert.true(result.ok, 'so the run is green');
   });
 
+  test('the result carries what the run resolved to, not just what was asked', async (assert) => {
+    const result = await apiRun({ inputs: [PASSING] });
+
+    assert.equal(result.resolved.browser, 'chromium');
+    assert.equal(result.resolved.projectRoot, process.cwd());
+    assert.true(result.resolved.port > 0, 'the port actually bound');
+    assert.true(result.resolved.output.startsWith(process.cwd()), 'output is absolute');
+    assert.equal(result.groupCount, 1, 'one file, one group');
+  });
+
+  test('timings bracket the run', async (assert) => {
+    const before = Date.now();
+    const result = await apiRun({ inputs: [PASSING] });
+
+    assert.true(result.startedAt >= before, 'started after we asked');
+    assert.true(result.finishedAt >= result.startedAt, 'and finished after it started');
+    assert.true(
+      Math.abs(result.finishedAt - result.startedAt - result.durationMs) < 50,
+      'the span agrees with durationMs',
+    );
+  });
+
+  test('a failing test is attributed to its source file', async (assert) => {
+    const result = await apiRun({ inputs: [FAILING] });
+
+    assert.true(
+      result.failures.every((one) => one.file?.endsWith('failing-tests.ts')),
+      'every failure names the file it came from',
+    );
+  });
+
+  test('a passing test has no file — QUnit gives no stack to map', async (assert) => {
+    const result = await apiRun({ inputs: [PASSING] });
+
+    assert.true(
+      result.tests.every((one) => one.file === null),
+      'null rather than a guess',
+    );
+  });
+
   test('`files` reports what actually ran', async (assert) => {
     const result = await apiRun({ inputs: [PASSING] });
 

--- a/test/api/run-test.ts
+++ b/test/api/run-test.ts
@@ -1,0 +1,226 @@
+import { module, test } from 'qunitx';
+import { apiRun, captureStream } from './helpers.ts';
+import * as Qunitx from '../../lib/api/index.ts';
+import { outputDir } from '../helpers/temp-dir.ts';
+import { acquireBrowser } from '../helpers/browser-semaphore-queue.ts';
+import '../helpers/custom-asserts.ts';
+
+const PASSING = 'test/fixtures/passing-tests.ts';
+const FAILING = 'test/fixtures/failing-tests.ts';
+const SKIP_TODO = 'test/fixtures/skip-todo-tests.ts';
+
+module('API | run | results', { concurrency: true }, () => {
+  test('a green run resolves ok with every test recorded', async (assert) => {
+    const result = await apiRun({ inputs: [PASSING] });
+
+    assert.true(result.ok);
+    assert.equal(result.exitCode, 0);
+    assert.deepEqual(
+      { total: result.counts.total, passed: result.counts.passed, failed: result.counts.failed },
+      { total: 3, passed: 3, failed: 0 },
+    );
+    assert.equal(result.tests.length, 3, 'every test is on the result, not just the failures');
+    assert.deepEqual(result.failures, []);
+    assert.true(
+      result.tests.every((one) => one.status === 'passed' && one.fullName.length > 0),
+      'each carries its status and display name',
+    );
+  });
+
+  test('failing tests are a result, not a rejection', async (assert) => {
+    // The whole contract in one test: `run` resolves for a red suite. Rejection is reserved for
+    // the run not happening, so `catch` never has to mean "some tests failed".
+    const result = await apiRun({ inputs: [FAILING] });
+
+    assert.false(result.ok);
+    assert.equal(result.exitCode, 1);
+    assert.true(result.counts.failed > 0);
+    assert.equal(result.failures.length, result.counts.failed);
+    assert.true(
+      result.failures.every((one) => one.status === 'failed'),
+      '`failures` is exactly the failed subset of `tests`',
+    );
+  });
+
+  test('failures carry their assertions and the file they came from', async (assert) => {
+    const result = await apiRun({ inputs: [FAILING] });
+    const withAssertions = result.failures.find((one) => one.assertions.length > 0);
+
+    assert.ok(withAssertions, 'a failing test reports its assertions');
+    assert.true(
+      withAssertions!.assertions.some((one) => one.passed === false),
+      'including the one that failed',
+    );
+    assert.equal(result.failedFiles.length, 1);
+    assert.true(result.failedFiles[0].endsWith('failing-tests.ts'));
+  });
+
+  test('skip and todo are counted apart from passes and failures', async (assert) => {
+    const result = await apiRun({ inputs: [SKIP_TODO] });
+
+    assert.true(result.counts.skipped > 0, 'skipped tests are counted');
+    assert.true(result.counts.todo > 0, 'todo tests are counted');
+    assert.equal(result.counts.failed, 0, 'a todo is not a failure');
+    assert.true(result.ok, 'so the run is green');
+  });
+
+  test('`files` reports what actually ran', async (assert) => {
+    const result = await apiRun({ inputs: [PASSING] });
+
+    assert.equal(result.files.length, 1);
+    assert.true(result.files[0].endsWith('passing-tests.ts'));
+  });
+});
+
+module('API | run | options', { concurrency: true }, () => {
+  test('filter narrows the run the way -t does', async (assert) => {
+    const result = await apiRun({ inputs: [PASSING], filter: 'assert true works' });
+
+    assert.equal(result.counts.total, 1, 'only the matching test ran');
+    assert.includes(result.tests[0].fullName, 'assert true works');
+  });
+
+  test('a filter that matches nothing fails the run rather than passing empty', async (assert) => {
+    const result = await apiRun({ inputs: [PASSING], filter: 'no-such-test-anywhere' });
+
+    assert.false(result.ok, 'a mistyped filter is a mistake, not a green run');
+    assert.equal(result.counts.total, 0);
+    assert.true(
+      result.notices.some((notice) => notice.message.includes('No tests matched')),
+      'and says so as a notice',
+    );
+  });
+
+  test('a line target runs just that test', async (assert) => {
+    const declarations = await Qunitx.search({ inputs: [PASSING] });
+    const target = declarations.matches[1];
+
+    const result = await apiRun({ inputs: [`${target.file}#${target.line}`] });
+
+    assert.equal(result.counts.total, 1);
+    assert.equal(result.tests[0].fullName, target.fullName);
+  });
+});
+
+module('API | run | reporters', { concurrency: true }, () => {
+  test('nothing is printed unless a reporter is asked for', async (assert) => {
+    const stdout = captureStream();
+    // `stdout` alone still routes the run's own `#` diagnostics, so the assertion below is about
+    // the test document: with no reporter there is no TAP, no spec output, nothing.
+    const result = await apiRun({ inputs: [PASSING], stdout });
+
+    assert.true(result.ok);
+    assert.notIncludes(stdout.text(), 'TAP version 13');
+    assert.notIncludes(stdout.text(), 'ok 1');
+  });
+
+  test('a named reporter writes to the given stream and still returns the result', async (assert) => {
+    const stdout = captureStream();
+
+    const result = await apiRun({ inputs: [PASSING], reporter: 'tap', stdout });
+
+    assert.includes(stdout.text(), 'TAP version 13');
+    assert.includes(stdout.text(), 'ok 1');
+    assert.includes(stdout.text(), '# pass 3');
+    assert.equal(result.counts.passed, 3, 'the result is unaffected by printing');
+  });
+
+  test('a custom reporter object receives the lifecycle', async (assert) => {
+    const events: string[] = [];
+
+    const result = await apiRun({
+      inputs: [PASSING],
+      reporter: {
+        onRunStart: () => void events.push('start'),
+        onTestEnd: (_config, details) => void events.push(`test:${details.status}`),
+        onRunEnd: () => void events.push('end'),
+      },
+    });
+
+    assert.equal(events[0], 'start');
+    assert.equal(events[events.length - 1], 'end');
+    assert.equal(events.filter((one) => one === 'test:passed').length, 3);
+    assert.equal(result.counts.passed, 3);
+  });
+
+  test('a reporter that throws costs output, never the result', async (assert) => {
+    // The collector is first in the fan-out precisely so this holds.
+    const result = await apiRun({
+      inputs: [PASSING],
+      reporter: {
+        onTestEnd: () => {
+          throw new Error('reporter blew up');
+        },
+      },
+    });
+
+    assert.equal(result.counts.passed, 3, 'every test still reached the result');
+    assert.equal(result.tests.length, 3);
+  });
+
+  test('onTest streams the same shape the result collects', async (assert) => {
+    const streamed: string[] = [];
+
+    const result = await apiRun({
+      inputs: [PASSING],
+      onTest: (one) => void streamed.push(one.fullName),
+    });
+
+    assert.deepEqual(
+      streamed,
+      result.tests.map((one) => one.fullName),
+      'same tests, same order',
+    );
+  });
+});
+
+module('API | run | failures', { concurrency: true }, () => {
+  test('an unreadable project rejects with a discriminable failure', async (assert) => {
+    const outcome = await Qunitx.run({ inputs: ['nope'], cwd: '/' }).result();
+
+    assert.true(Qunitx.Failure.is(outcome), 'a run that cannot happen is a Failure');
+    assert.equal(
+      Qunitx.Failure.is(outcome) ? outcome.code : null,
+      'ProjectRootNotFound',
+      'named, so a caller can branch on it rather than parse a message',
+    );
+  });
+
+  test('an invalid option is reported rather than thrown as a bug', async (assert) => {
+    const outcome = await Qunitx.run({
+      inputs: ['test/'],
+      browser: 'netscape' as 'chromium',
+    }).result();
+
+    assert.true(Qunitx.Failure.is(outcome), 'a value the runner cannot honour is a Failure');
+    assert.equal(Qunitx.Failure.is(outcome) ? outcome.code : null, 'InvalidOption');
+    assert.includes(
+      Qunitx.Failure.is(outcome) ? outcome.message : '',
+      'chromium, firefox, webkit',
+      'and names what it would have accepted',
+    );
+  });
+
+  test('a bad option is caught before a browser is launched', async (assert) => {
+    // No semaphore permit taken, and none needed: rejecting here is the point.
+    const outcome = await Qunitx.run({ inputs: ['test/'], port: 99999 }).result();
+
+    assert.equal(Qunitx.Failure.is(outcome) ? outcome.code : null, 'InvalidOption');
+  });
+
+  test('the Task is lazy — nothing runs until it is awaited', async (assert) => {
+    await using output = outputDir('api-lazy');
+    const task = Qunitx.run({ inputs: [PASSING], output: output.path });
+
+    // Nothing has happened yet: no browser, no bundle, no result. The proof is that the same
+    // Task can be discarded without ever having cost a browser launch.
+    assert.ok(task, 'a Task, not an in-flight run');
+
+    const permit = await acquireBrowser();
+    try {
+      assert.true((await task).ok, 'awaiting is what starts it');
+    } finally {
+      permit.release();
+    }
+  });
+});

--- a/test/api/scaffold-test.ts
+++ b/test/api/scaffold-test.ts
@@ -1,0 +1,120 @@
+import { module, test } from 'qunitx';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import * as Qunitx from '../../lib/api/index.ts';
+import { tempDir } from '../helpers/temp-dir.ts';
+import '../helpers/custom-asserts.ts';
+
+// No browser: these write files and report what they wrote.
+
+/** A throwaway project directory with just enough package.json to be a project root. */
+async function project() {
+  const dir = await tempDir('api-scaffold');
+  await fs.writeFile(
+    path.join(dir.path, 'package.json'),
+    JSON.stringify({ name: 'scaffold-fixture', type: 'module' }),
+  );
+
+  return dir;
+}
+
+module('API | init', { concurrency: true }, () => {
+  test('reports the files it created', async (assert) => {
+    await using dir = await project();
+
+    const result = await Qunitx.init({ cwd: dir.path });
+
+    assert.deepEqual(result.skipped, []);
+    assert.true(
+      result.written.some((file) => file.endsWith('tests.html')),
+      'the HTML fixture',
+    );
+    assert.true(
+      result.written.some((file) => file.endsWith('tsconfig.json')),
+      'and a tsconfig, since there was none',
+    );
+  });
+
+  test('writes the qunitx block into package.json', async (assert) => {
+    await using dir = await project();
+
+    await Qunitx.init({ cwd: dir.path });
+    const packageJSON = JSON.parse(
+      await fs.readFile(path.join(dir.path, 'package.json'), 'utf8'),
+    ) as { qunitx?: { htmlPaths?: string[] } };
+
+    assert.deepEqual(packageJSON.qunitx?.htmlPaths, ['test/tests.html']);
+  });
+
+  test('never overwrites — a second call reports skips instead', async (assert) => {
+    await using dir = await project();
+
+    await Qunitx.init({ cwd: dir.path });
+    const again = await Qunitx.init({ cwd: dir.path });
+
+    assert.deepEqual(again.written, [], 'nothing was rewritten');
+    assert.deepEqual(again.skipped, ['test/tests.html']);
+  });
+
+  test('honours the html paths it is given', async (assert) => {
+    await using dir = await project();
+
+    const result = await Qunitx.init({ cwd: dir.path, htmlPaths: ['test/custom.html'] });
+
+    assert.true(result.written.some((file) => file.endsWith('test/custom.html')));
+  });
+
+  test('a directory with no package.json above it is a named failure', async (assert) => {
+    await using dir = await tempDir('api-scaffold-bare');
+    // os.tmpdir() has no package.json above it on any supported platform, so the walk bottoms out.
+    const outcome = await Qunitx.init({ cwd: dir.path }).result();
+
+    assert.equal(
+      Qunitx.Failure.is(outcome) ? outcome.code : 'not-a-failure',
+      'ProjectRootNotFound',
+    );
+  });
+});
+
+module('API | generate', { concurrency: true }, () => {
+  test('writes the file and says where', async (assert) => {
+    await using dir = await project();
+
+    const result = await Qunitx.generate({ cwd: dir.path, target: 'test/login-test.ts' });
+
+    assert.true(result.created);
+    assert.true(result.path.endsWith('test/login-test.ts'));
+    assert.includes(await fs.readFile(result.path, 'utf8'), "module('");
+  });
+
+  test('derives the module name from the path, minus the test/ segment', async (assert) => {
+    await using dir = await project();
+
+    const { path: written } = await Qunitx.generate({
+      cwd: dir.path,
+      target: 'test/users/contact-details-test.ts',
+    });
+
+    assert.includes(await fs.readFile(written, 'utf8'), "module('Users | ContactDetails");
+  });
+
+  test('appends .js when the target has no extension', async (assert) => {
+    await using dir = await project();
+
+    const result = await Qunitx.generate({ cwd: dir.path, target: 'test/login-test' });
+
+    assert.true(result.path.endsWith('test/login-test.js'));
+  });
+
+  test('never overwrites — an existing file is reported, not replaced', async (assert) => {
+    await using dir = await project();
+    const target = 'test/login-test.ts';
+
+    const first = await Qunitx.generate({ cwd: dir.path, target });
+    await fs.writeFile(first.path, '// mine\n');
+    const second = await Qunitx.generate({ cwd: dir.path, target });
+
+    assert.false(second.created);
+    assert.equal(await fs.readFile(second.path, 'utf8'), '// mine\n', 'left exactly as it was');
+  });
+});

--- a/test/api/search-test.ts
+++ b/test/api/search-test.ts
@@ -1,0 +1,65 @@
+import { module, test } from 'qunitx';
+import * as Qunitx from '../../lib/api/index.ts';
+import '../helpers/custom-asserts.ts';
+
+const NESTED = 'test/fixtures/nested-module-tests.ts';
+const PASSING = 'test/fixtures/passing-tests.ts';
+
+// No browser and no bundle: `search` parses declarations, so these tests take no semaphore
+// permit and run in milliseconds.
+
+module('API | search', { concurrency: true }, () => {
+  test('lists every test with a location you can pass straight back in', async (assert) => {
+    const result = await Qunitx.search({ inputs: [PASSING] });
+
+    assert.equal(result.matches.length, 3);
+    assert.equal(result.total, 3);
+    assert.equal(result.files, 1);
+    assert.true(
+      result.matches.every((one) => one.file.endsWith('passing-tests.ts') && one.line > 0),
+      'each carries an absolute file and a 1-based line',
+    );
+  });
+
+  test('a filter narrows the matches without changing the total', async (assert) => {
+    const result = await Qunitx.search({ inputs: [PASSING], filter: 'assert true works' });
+
+    assert.equal(result.matches.length, 1, 'matched');
+    assert.equal(result.total, 3, 'out of every listable test in the file');
+    assert.equal(result.filter, 'assert true works');
+  });
+
+  test('nested modules come back as a path, not a joined string', async (assert) => {
+    const result = await Qunitx.search({ inputs: [NESTED] });
+    const nested = result.matches.find((one) => one.modules.length > 1);
+
+    assert.ok(nested, 'the fixture declares a nested module');
+    assert.includes(nested!.fullName, nested!.modules.join(' > '));
+    assert.includes(nested!.fullName, nested!.name);
+  });
+
+  test('a filter matching nothing is an empty list, not a failure', async (assert) => {
+    const result = await Qunitx.search({ inputs: [PASSING], filter: 'no-such-test' });
+
+    assert.deepEqual(result.matches, []);
+    assert.equal(result.total, 3, 'the scan still reports what is there');
+  });
+
+  test('what search finds is what a run would select', async (assert) => {
+    // The point of the preview: same scanner, same matcher, same answer. Verified against a real
+    // run in test/flags/search-test.ts; here it is the API surface reporting the same selection.
+    const previewed = await Qunitx.search({ inputs: [PASSING], filter: 'works' });
+    const everything = await Qunitx.search({ inputs: [PASSING] });
+
+    assert.deepEqual(
+      previewed.matches.map((one) => one.fullName),
+      everything.matches.filter((one) => one.fullName.includes('works')).map((one) => one.fullName),
+    );
+  });
+
+  test('an invalid option is rejected here too', async (assert) => {
+    const outcome = await Qunitx.search({ browser: 'netscape' as 'chromium' }).result();
+
+    assert.equal(Qunitx.Failure.is(outcome) ? outcome.code : null, 'InvalidOption');
+  });
+});

--- a/test/api/session-test.ts
+++ b/test/api/session-test.ts
@@ -1,0 +1,190 @@
+import { module, test } from 'qunitx';
+import { runSession } from '../../lib/api/index.ts';
+import { withRunSession } from './helpers.ts';
+import { acquireBrowser } from '../helpers/browser-semaphore-queue.ts';
+import { outputDir } from '../helpers/temp-dir.ts';
+import type { RunEvent } from '../../lib/api/events.ts';
+import '../helpers/custom-asserts.ts';
+
+const PASSING = 'test/fixtures/passing-tests.ts';
+const FAILING = 'test/fixtures/failing-tests.ts';
+
+module('API | runSession | events', { concurrency: true }, () => {
+  test('yields runStart, one test per test, then runEnd carrying the result', async (assert) => {
+    await withRunSession({ inputs: [PASSING] }, async (session) => {
+      const kinds: RunEvent['kind'][] = [];
+      let final = null;
+      for await (const event of session) {
+        kinds.push(event.kind);
+        if (event.kind === 'runEnd') final = event.result;
+      }
+
+      assert.equal(kinds[0], 'runStart', 'the run announces itself first');
+      assert.equal(kinds.at(-1), 'runEnd', 'and the last event is always the end');
+      assert.equal(
+        kinds.filter((kind) => kind === 'test').length,
+        3,
+        'one event per test in the fixture',
+      );
+      assert.true(final?.ok, 'the final event carries the whole result');
+      assert.equal(final?.counts.total, 3);
+    });
+  });
+
+  test('result() resolves with the same result the final event carried', async (assert) => {
+    await withRunSession({ inputs: [PASSING] }, async (session) => {
+      let fromEvent = null;
+      for await (const event of session) {
+        if (event.kind === 'runEnd') fromEvent = event.result;
+      }
+
+      assert.equal(await session.result(), fromEvent, 'the very same object, not a rebuild');
+    });
+  });
+
+  test('result() alone runs the suite without anyone iterating', async (assert) => {
+    await withRunSession({ inputs: [PASSING] }, async (session) => {
+      const result = await session.result();
+
+      assert.true(result.ok);
+      assert.equal(result.counts.total, 3, 'awaiting the result is enough to start the run');
+    });
+  });
+
+  test('result() is idempotent — a second await does not run again', async (assert) => {
+    await withRunSession({ inputs: [PASSING] }, async (session) => {
+      const first = await session.result();
+      const second = await session.result();
+
+      assert.equal(first, second, 'one run, one result');
+    });
+  });
+
+  test('a failing suite is a result, not a rejection', async (assert) => {
+    await withRunSession({ inputs: [FAILING] }, async (session) => {
+      const result = await session.result();
+
+      assert.false(result.ok);
+      assert.true(result.failures.length > 0);
+      assert.false(result.aborted, 'red is not the same as interrupted');
+    });
+  });
+
+  test('the events carry the same tests the result does', async (assert) => {
+    await withRunSession({ inputs: [PASSING] }, async (session) => {
+      const streamed: string[] = [];
+      for await (const event of session) {
+        if (event.kind === 'test') streamed.push(event.test.fullName);
+      }
+
+      assert.deepEqual(
+        streamed,
+        (await session.result()).tests.map((one) => one.fullName),
+        'the live view and the summary agree',
+      );
+    });
+  });
+});
+
+module('API | runSession | lifecycle', { concurrency: true }, () => {
+  test('nothing runs until the session is consumed', async (assert) => {
+    await using output = outputDir('api-session-lazy');
+    const permit = await acquireBrowser();
+    try {
+      const session = await runSession({ inputs: [PASSING], output: output.path });
+
+      // The proof that the run has not started: closing without ever consuming it produces the
+      // empty result rather than a suite's worth of tests. If `runSession` ran eagerly this would
+      // come back with 3.
+      await session.close();
+
+      assert.equal((await session.result()).counts.total, 0, 'no tests ran');
+      assert.true((await session.result()).aborted, 'and it says why');
+    } finally {
+      permit.release();
+    }
+  });
+
+  test('close() before consuming answers rather than hanging', async (assert) => {
+    await using output = outputDir('api-session-closed');
+    const permit = await acquireBrowser();
+    try {
+      const session = await runSession({ inputs: [PASSING], output: output.path });
+      await session.close();
+
+      const seen: RunEvent[] = [];
+      for await (const event of session) seen.push(event);
+
+      assert.deepEqual(seen, [], 'a closed session iterates zero times');
+      assert.equal((await session.result()).exitCode, 1, 'a run that never happened is not a pass');
+    } finally {
+      permit.release();
+    }
+  });
+
+  test('close() is idempotent', async (assert) => {
+    await using output = outputDir('api-session-idempotent');
+    const permit = await acquireBrowser();
+    try {
+      const session = await runSession({ inputs: [PASSING], output: output.path });
+      await session.close();
+      await session.close();
+
+      assert.true(true, 'the second close is a no-op rather than a throw');
+    } finally {
+      permit.release();
+    }
+  });
+
+  test('await using disposes the session at the end of the block', async (assert) => {
+    await using output = outputDir('api-session-dispose');
+    const permit = await acquireBrowser();
+    let result = null;
+    try {
+      {
+        await using session = await runSession({ inputs: [PASSING], output: output.path });
+        result = await session.result();
+      }
+
+      assert.true(result.ok, 'the run completed inside the block');
+    } finally {
+      permit.release();
+    }
+  });
+
+  test('an already-aborted signal launches no browser', async (assert) => {
+    await using output = outputDir('api-session-signal');
+    const permit = await acquireBrowser();
+    try {
+      const session = await runSession({
+        inputs: [PASSING],
+        output: output.path,
+        signal: AbortSignal.abort(),
+      });
+      const result = await session.result();
+
+      assert.true(result.aborted);
+      assert.equal(result.counts.total, 0, 'cancelled before it began');
+    } finally {
+      permit.release();
+    }
+  });
+
+  test('breaking out of the loop closes the session', async (assert) => {
+    await using output = outputDir('api-session-break');
+    const permit = await acquireBrowser();
+    try {
+      const session = await runSession({ inputs: [PASSING], output: output.path });
+      for await (const event of session) {
+        if (event.kind === 'runStart') break;
+      }
+
+      // Nothing to assert but the absence of a hang: an unclosed session would leave a browser
+      // running and the test file would not exit.
+      assert.true(true, 'the loop ended and the session closed itself');
+      await session.close();
+    } finally {
+      permit.release();
+    }
+  });
+});

--- a/test/api/watch-test.ts
+++ b/test/api/watch-test.ts
@@ -6,6 +6,7 @@ import { outputDir } from '../helpers/temp-dir.ts';
 import '../helpers/custom-asserts.ts';
 
 const PASSING = 'test/fixtures/passing-tests.ts';
+const FAILING = 'test/fixtures/failing-tests.ts';
 
 const GREEN_TEST = `import { module, test } from 'qunitx';
 module('Watched', () => {
@@ -27,9 +28,9 @@ module('API | watch | session', { concurrency: true }, () => {
     });
   });
 
-  test('rerun() resolves with that run, not the previous one', async (assert) => {
+  test('run() resolves with that run, not the previous one', async (assert) => {
     await withWatch({ inputs: [PASSING] }, async (session) => {
-      const again = await session.rerun();
+      const again = await session.run();
 
       assert.true(again.ok);
       assert.equal(again.counts.total, 3, 'a full result, not an empty snapshot');
@@ -47,7 +48,7 @@ module('API | watch | session', { concurrency: true }, () => {
         }
       })();
 
-      await session.rerun();
+      await session.run();
       await consume;
 
       assert.deepEqual(seen, [3, 3], 'the initial run and the rerun both arrive');
@@ -63,6 +64,121 @@ module('API | watch | session', { concurrency: true }, () => {
       for await (const result of session) seen.push(result.counts.total);
 
       assert.deepEqual(seen, [3], 'the queued initial result still drains, then it ends');
+    });
+  });
+});
+
+module('API | watch | verbs', { concurrency: true }, () => {
+  test('latest tracks the most recent run without consuming the iteration', async (assert) => {
+    await withWatch({ inputs: [PASSING] }, async (session) => {
+      assert.equal(session.latest, session.initial, 'it starts at the initial run');
+
+      const again = await session.run();
+
+      assert.equal(session.latest, again, 'and follows each rerun');
+
+      const seen: number[] = [];
+      for await (const result of session) {
+        seen.push(result.counts.total);
+        if (seen.length === 2) break;
+      }
+
+      assert.deepEqual(seen, [3, 3], 'reading latest did not steal either result');
+    });
+  });
+
+  test('running says whether a run is in flight', async (assert) => {
+    await withWatch({ inputs: [PASSING] }, async (session) => {
+      assert.false(session.running, 'idle once the initial run has finished');
+
+      const inFlight = session.run();
+      assert.true(session.running, 'true while a rerun is happening');
+
+      await inFlight;
+      assert.false(session.running, 'and false again once it settles');
+    });
+  });
+
+  test('runAll() runs the whole suite and clears the session selectors', async (assert) => {
+    // Line 4 is the first `test(...)` — line 3 is the `module(...)` wrapper, which selects all
+    // three. Scoped to one test, so a plain rerun stays pinned to it and only runAll unpins.
+    await withWatch({ inputs: [`${PASSING}#4`] }, async (session) => {
+      assert.equal(session.initial.counts.total, 1, 'the line target scoped the initial run');
+
+      const all = await session.runAll();
+
+      assert.equal(all.counts.total, 3, 'runAll dropped the line target');
+      assert.equal(session.latest, all);
+    });
+  });
+
+  test('runFailed() re-runs only the files that failed', async (assert) => {
+    await withWatch({ inputs: [PASSING, FAILING] }, async (session) => {
+      assert.false(session.initial.ok, 'the pair starts red');
+
+      const failed = await session.runFailed();
+
+      assert.true(
+        failed.files.every((file) => file.endsWith('failing-tests.ts')),
+        'the rerun is scoped to the failing file alone',
+      );
+    });
+  });
+
+  test('runFailed() with nothing failing repeats the last run and says so', async (assert) => {
+    await withWatch({ inputs: [PASSING] }, async (session) => {
+      assert.true(session.initial.ok, 'nothing has failed');
+
+      const repeated = await session.runFailed();
+
+      assert.equal(repeated.counts.total, 3, 'it repeated the last run');
+      assert.true(
+        repeated.notices.some((notice) =>
+          notice.message.includes('No tests failed in the last run'),
+        ),
+        'and reported the fallback rather than silently doing something else',
+      );
+    });
+  });
+
+  test('abort() while idle is a no-op that publishes no result', async (assert) => {
+    await withWatch({ inputs: [PASSING] }, async (session) => {
+      await session.abort();
+
+      assert.equal(session.latest, session.initial, 'no phantom result was manufactured');
+      assert.false(session.running);
+    });
+  });
+});
+
+module('API | watch | events', { concurrency: true }, () => {
+  test('events() is flat across reruns and ends each with runEnd', async (assert) => {
+    await withWatch({ inputs: [PASSING] }, async (session) => {
+      const kinds: string[] = [];
+      const consume = (async () => {
+        for await (const event of session.events()) {
+          kinds.push(event.kind);
+          if (kinds.filter((kind) => kind === 'runEnd').length === 2) break;
+        }
+      })();
+
+      await session.run();
+      await session.run();
+      await consume;
+
+      assert.equal(kinds.filter((kind) => kind === 'runEnd').length, 2, 'one end per rerun');
+      assert.equal(
+        kinds.filter((kind) => kind === 'runStart').length,
+        2,
+        'and one start per rerun',
+      );
+      assert.true(kinds.filter((kind) => kind === 'test').length >= 6, 'with every test between');
+    });
+  });
+
+  test('events() returns the same feed on every call', async (assert) => {
+    await withWatch({ inputs: [PASSING] }, (session) => {
+      assert.equal(session.events(), session.events(), 'a second call must not double the events');
     });
   });
 });
@@ -93,7 +209,7 @@ module('API | watch | reruns', { concurrency: true }, () => {
     });
   });
 
-  test('rerun() picks up an edit rather than replaying the cached bundle', async (assert) => {
+  test('run() picks up an edit rather than replaying the cached bundle', async (assert) => {
     await using project = outputDir('api-watch-manual');
     const testFile = path.join(project.path, 'sample-test.ts');
     await fs.mkdir(project.path, { recursive: true });
@@ -103,7 +219,7 @@ module('API | watch | reruns', { concurrency: true }, () => {
       assert.true(session.initial.ok);
 
       await fs.writeFile(testFile, RED_TEST);
-      const afterEdit = await session.rerun();
+      const afterEdit = await session.run();
 
       assert.false(afterEdit.ok, 'an explicit rerun rebuilds too');
       assert.equal(afterEdit.counts.failed, 1);

--- a/test/api/watch-test.ts
+++ b/test/api/watch-test.ts
@@ -1,0 +1,112 @@
+import { module, test } from 'qunitx';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { withWatch } from './helpers.ts';
+import { outputDir } from '../helpers/temp-dir.ts';
+import '../helpers/custom-asserts.ts';
+
+const PASSING = 'test/fixtures/passing-tests.ts';
+
+const GREEN_TEST = `import { module, test } from 'qunitx';
+module('Watched', () => {
+  test('is green', (assert) => assert.true(true));
+});
+`;
+const RED_TEST = `import { module, test } from 'qunitx';
+module('Watched', () => {
+  test('is red', (assert) => assert.true(false));
+});
+`;
+
+module('API | watch | session', { concurrency: true }, () => {
+  test('resolves once the first run has finished, with its result in hand', async (assert) => {
+    await withWatch({ inputs: [PASSING] }, (session) => {
+      assert.true(session.initial.ok);
+      assert.equal(session.initial.counts.total, 3);
+      assert.includes(session.url, 'http://localhost:');
+    });
+  });
+
+  test('rerun() resolves with that run, not the previous one', async (assert) => {
+    await withWatch({ inputs: [PASSING] }, async (session) => {
+      const again = await session.rerun();
+
+      assert.true(again.ok);
+      assert.equal(again.counts.total, 3, 'a full result, not an empty snapshot');
+      assert.notEqual(again, session.initial, 'a distinct result object per run');
+    });
+  });
+
+  test('iteration yields the initial run first, then each rerun', async (assert) => {
+    await withWatch({ inputs: [PASSING] }, async (session) => {
+      const seen: number[] = [];
+      const consume = (async () => {
+        for await (const result of session) {
+          seen.push(result.counts.total);
+          if (seen.length === 2) break;
+        }
+      })();
+
+      await session.rerun();
+      await consume;
+
+      assert.deepEqual(seen, [3, 3], 'the initial run and the rerun both arrive');
+    });
+  });
+
+  test('close() is idempotent and ends the iteration', async (assert) => {
+    await withWatch({ inputs: [PASSING] }, async (session) => {
+      await session.close();
+      await session.close();
+
+      const seen: number[] = [];
+      for await (const result of session) seen.push(result.counts.total);
+
+      assert.deepEqual(seen, [3], 'the queued initial result still drains, then it ends');
+    });
+  });
+});
+
+module('API | watch | reruns', { concurrency: true }, () => {
+  test('a save produces a fresh result on the iterator', async (assert) => {
+    // The whole feature, end to end: a file inside the watched tree changes on disk, the watcher
+    // notices, the bundle is rebuilt, and the new result arrives on the session's iteration.
+    await using project = outputDir('api-watch-project');
+    const testFile = path.join(project.path, 'sample-test.ts');
+    await fs.mkdir(project.path, { recursive: true });
+    await fs.writeFile(testFile, GREEN_TEST);
+
+    await withWatch({ inputs: [testFile] }, async (session) => {
+      assert.equal(session.initial.counts.total, 1, 'the fixture registers one test');
+      assert.true(session.initial.ok, 'and starts green');
+
+      const iterator = session[Symbol.asyncIterator]();
+      await iterator.next(); // the initial run, already queued
+      const afterSave = iterator.next();
+
+      await fs.writeFile(testFile, RED_TEST);
+      const { value } = await afterSave;
+
+      assert.false(value.ok, 'the rerun ran the edited file');
+      assert.equal(value.counts.failed, 1);
+      assert.true(session.initial.ok, 'and the initial result is not retroactively changed');
+    });
+  });
+
+  test('rerun() picks up an edit rather than replaying the cached bundle', async (assert) => {
+    await using project = outputDir('api-watch-manual');
+    const testFile = path.join(project.path, 'sample-test.ts');
+    await fs.mkdir(project.path, { recursive: true });
+    await fs.writeFile(testFile, GREEN_TEST);
+
+    await withWatch({ inputs: [testFile] }, async (session) => {
+      assert.true(session.initial.ok);
+
+      await fs.writeFile(testFile, RED_TEST);
+      const afterEdit = await session.rerun();
+
+      assert.false(afterEdit.ok, 'an explicit rerun rebuilds too');
+      assert.equal(afterEdit.counts.failed, 1);
+    });
+  });
+});

--- a/test/args/parse-test.ts
+++ b/test/args/parse-test.ts
@@ -581,6 +581,58 @@ module('Args | parse | --reporter validation', { concurrency: true }, () => {
   });
 });
 
+module('Args | parse | explicit argv and cwd', { concurrency: true }, () => {
+  test('argv is a parameter, so no process.argv borrowing is needed to parse someone else', (assert) => {
+    const original = process.argv;
+    process.argv = ['node', 'cli.ts', '--watch'];
+    try {
+      const flags = Result.unwrap(Args.parse(PROJECT_ROOT, ['--timeout=5000']));
+      assert.equal(flags.timeout, 5000);
+      assert.equal(flags.watch, undefined, 'the live process.argv is not consulted');
+    } finally {
+      process.argv = original;
+    }
+  });
+
+  test('relative inputs resolve against the cwd argument, not process.cwd()', (assert) => {
+    const flags = Result.unwrap(Args.parse(PROJECT_ROOT, ['tests/foo.ts'], '/elsewhere'));
+    assert.deepEqual(flags.inputs, [path.normalize('/elsewhere/tests/foo.ts')]);
+  });
+});
+
+module('Args | applyInputs', { concurrency: true }, () => {
+  test('classifies the same grammar argv positionals get', (assert) => {
+    const flags = Args.applyInputs({ inputs: [] }, PROJECT_ROOT, '/proj', [
+      'test/a-test.ts#34',
+      'test/b-test.ts',
+      'test/tests.html',
+    ]);
+
+    assert.deepEqual(flags.lineTargets, { [path.normalize('/proj/test/a-test.ts')]: [34] });
+    assert.deepEqual(flags.htmlPaths, ['test/tests.html']);
+    assert.deepEqual(flags.wholeInputPaths, [path.normalize('/proj/test/b-test.ts')]);
+    assert.deepEqual(flags.inputs, [
+      path.normalize('/proj/test/a-test.ts'),
+      path.normalize('/proj/test/b-test.ts'),
+    ]);
+  });
+
+  test('is idempotent for already-absolute inputs, so re-normalizing parsed flags is safe', (assert) => {
+    const once = Args.applyInputs({ inputs: [] }, PROJECT_ROOT, '/proj', ['test/a-test.ts']);
+    const twice = Args.applyInputs({ ...once, inputs: [] }, PROJECT_ROOT, '/proj', once.inputs);
+
+    assert.deepEqual(twice.inputs, once.inputs);
+  });
+
+  test('deduplicates a path mentioned both bare and with a line target', (assert) => {
+    const flags = Args.applyInputs({ inputs: [] }, PROJECT_ROOT, '/proj', ['a.ts', 'a.ts#7']);
+
+    assert.deepEqual(flags.inputs, [path.normalize('/proj/a.ts')], 'one entry, not two');
+    assert.deepEqual(flags.lineTargets, { [path.normalize('/proj/a.ts')]: [7] });
+    assert.deepEqual(flags.wholeInputPaths, [path.normalize('/proj/a.ts')]);
+  });
+});
+
 function withArgv(args, fn) {
   const original = process.argv;
   process.argv = ['node', 'cli.ts', ...args];

--- a/test/commands/build-error-test.ts
+++ b/test/commands/build-error-test.ts
@@ -327,6 +327,7 @@ function makeConfig(testFiles: string[], watch = false): Config {
     extensions: ['ts', 'js'],
     browser: 'chromium',
     projectRoot: CWD,
+    cwd: CWD,
     inputs: [],
     htmlPaths: [],
     testFileLookupPaths: [],

--- a/test/commands/build-test.ts
+++ b/test/commands/build-test.ts
@@ -339,6 +339,7 @@ function makeConfig(testFiles: string[], watch = false): Config {
     extensions: ['ts', 'js'],
     browser: 'chromium',
     projectRoot: CWD,
+    cwd: CWD,
     inputs: [],
     htmlPaths: [],
     testFileLookupPaths: [],

--- a/test/commands/generate-test.ts
+++ b/test/commands/generate-test.ts
@@ -9,35 +9,13 @@ import '../helpers/custom-asserts.ts';
 const CWD = process.cwd();
 
 /**
- * Runs the generate command in-process against `target`, exactly as `qunitx generate <target>`
- * would: the command reads its argument off process.argv[3] and resolves paths from
- * findProjectRoot(), which walks up from the test worker's cwd to this repository's root.
- * Returns whatever the command printed.
- *
- * argv and console are process-wide, hence the `concurrency: false` on the modules below —
- * Generate.run() awaits, so a concurrent sibling could otherwise observe the stubs.
- *
- * console.log is swapped rather than process.stdout.write (what helpers/capture-stdout.ts
- * does): the node:test reporter writes this worker's results straight to the stdout stream,
- * and holding that stream across an await swallows the result lines of whatever else the
- * worker reports meanwhile — tests then silently disappear from the run summary.
+ * Runs `generate` the way the CLI does and returns the line the CLI would print, so these tests
+ * keep asserting on the user-visible message while `Generate.run` itself only reports facts.
  */
 async function generate(target: string): Promise<string> {
-  const originalArgv = process.argv;
-  const originalLog = console.log;
-  let printed = '';
+  const { path, created } = await Generate.run({ target });
 
-  process.argv = ['node', 'cli.ts', 'generate', target];
-  console.log = (...args: unknown[]) => {
-    printed += `${args.join(' ')}\n`;
-  };
-  try {
-    await Generate.run();
-  } finally {
-    console.log = originalLog;
-    process.argv = originalArgv;
-  }
-  return printed;
+  return created ? `${path} written\n` : `${path} already exists!\n`;
 }
 
 const readGenerated = (relativePath: string): Promise<string> =>

--- a/test/setup/file-watcher-test.ts
+++ b/test/setup/file-watcher-test.ts
@@ -8,6 +8,7 @@ import * as FileWatcher from '../../lib/setup/file-watcher.ts';
 import type { RescanDeps } from '../../lib/setup/file-watcher.ts';
 import '../helpers/custom-asserts.ts';
 import * as RunState from '../../lib/setup/run-state.ts';
+import { captureStdout } from '../helpers/capture-stdout.ts';
 import type { Config, FSTree, RunState as RunStateShape } from '../../lib/types.ts';
 
 const sha1 = (content: string) => createHash('sha1').update(content).digest('hex');
@@ -353,19 +354,11 @@ module('Setup | FileWatcher.handleWatchEvent', { concurrency: true }, () => {
   test('CHANGED: log shows the full absolute path for files outside projectRoot', (assert) => {
     // Regression guard: the original code used `filePath.split(config.projectRoot)[1]`, which
     // returns undefined when filePath doesn't contain projectRoot. The fix uses startsWith/slice.
-    // console.log('#', colorEvent(event), displayPath) — the path is always the third arg.
     const config = { fsTree: { '/tmp/external.ts': null }, projectRoot: '/project' };
-    const logged: unknown[][] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => logged.push(args);
-    try {
-      trackCalls(config, 'change', '/tmp/external.ts');
-    } finally {
-      console.log = origLog;
-    }
-    const allOutput = logged.flat().map(String).join(' ');
-    assert.includes(allOutput, '/tmp/external.ts');
-    assert.notIncludes(allOutput, 'undefined');
+    const output = captureStdout(() => void trackCalls(config, 'change', '/tmp/external.ts'));
+
+    assert.includes(output, '/tmp/external.ts');
+    assert.notIncludes(output, 'undefined');
   });
 
   test('onFinishFunc receives (filePath, event) — path first, event second', async (assert) => {

--- a/test/setup/get-changed-fs-tree-test.ts
+++ b/test/setup/get-changed-fs-tree-test.ts
@@ -13,7 +13,8 @@ import {
 } from '../../lib/utils/get-changed-file-paths-in-git-since.ts';
 import { Task } from '../../lib/task/index.ts';
 import type { AffectedMetafile } from '../../lib/utils/get-changed-files.ts';
-import type { FSTree } from '../../lib/types.ts';
+import * as RunState from '../../lib/setup/run-state.ts';
+import type { Config, FSTree } from '../../lib/types.ts';
 
 // getChangedFsTree's job is metafile-based FILTERING; git change-detection is an
 // injectable dependency. These tests drive the four outcome branches
@@ -23,6 +24,12 @@ import type { FSTree } from '../../lib/types.ts';
 // the full 300s per-test budget when a git child's exit event never arrived. The live
 // git integration is covered end-to-end against a real subprocess in
 // test/flags/changed-test.ts, so nothing is lost here.
+
+// getChangedFsTree announces how it resolved through `Reporter.notice`, which reads
+// `config.state`. A bare RunState is all it needs — nothing here asserts on the notices.
+function configFor(projectRoot: string): Config {
+  return { projectRoot, state: RunState.create() } as Config;
+}
 
 async function makeProject(): Promise<string> {
   const root = path.join(os.tmpdir(), `qunitx-get-changed-fs-tree-${crypto.randomUUID()}`);
@@ -65,7 +72,12 @@ module('Setup | getChangedFsTree | fallback paths', { concurrency: true }, () =>
   test('no metafile cache → returns input fsTree unchanged (git never consulted)', async (assert) => {
     const root = await makeProject();
     const tree = fsTreeFromAbs(root, ['test/a-test.ts']);
-    const result = await getChangedFsTree(tree, root, 'HEAD', gitChanged(root, ['src/a.ts']));
+    const result = await getChangedFsTree(
+      tree,
+      configFor(root),
+      'HEAD',
+      gitChanged(root, ['src/a.ts']),
+    );
     assert.strictEqual(result, tree);
   });
 
@@ -73,7 +85,7 @@ module('Setup | getChangedFsTree | fallback paths', { concurrency: true }, () =>
     const root = await makeProject();
     await MetafileCache.write(root, root, metafileFor({}));
     const tree = fsTreeFromAbs(root, ['test/a-test.ts']);
-    const result = await getChangedFsTree(tree, root, 'HEAD', gitFailed);
+    const result = await getChangedFsTree(tree, configFor(root), 'HEAD', gitFailed);
     assert.strictEqual(result, tree);
   });
 
@@ -81,7 +93,7 @@ module('Setup | getChangedFsTree | fallback paths', { concurrency: true }, () =>
     const root = await makeProject();
     await MetafileCache.write(root, root, metafileFor({ 'test/a-test.ts': [] }));
     const tree = fsTreeFromAbs(root, ['test/a-test.ts']);
-    const result = await getChangedFsTree(tree, root, 'HEAD', gitBlastRadius);
+    const result = await getChangedFsTree(tree, configFor(root), 'HEAD', gitBlastRadius);
     assert.strictEqual(result, tree);
   });
 });
@@ -100,7 +112,12 @@ module('Setup | getChangedFsTree | filtered runs', { concurrency: true }, () => 
       }),
     );
     const tree = fsTreeFromAbs(root, ['test/a-test.ts', 'test/b-test.ts']);
-    const result = await getChangedFsTree(tree, root, 'HEAD', gitChanged(root, ['src/a.ts']));
+    const result = await getChangedFsTree(
+      tree,
+      configFor(root),
+      'HEAD',
+      gitChanged(root, ['src/a.ts']),
+    );
     assert.deepEqual(
       Object.keys(result).sort(),
       [path.join(root, 'test/a-test.ts')],
@@ -112,14 +129,14 @@ module('Setup | getChangedFsTree | filtered runs', { concurrency: true }, () => 
     const root = await makeProject();
     await MetafileCache.write(root, root, metafileFor({ 'test/a-test.ts': [] }));
     const tree = fsTreeFromAbs(root, ['test/a-test.ts']);
-    const result = await getChangedFsTree(tree, root, 'HEAD', gitChanged(root, []));
+    const result = await getChangedFsTree(tree, configFor(root), 'HEAD', gitChanged(root, []));
     assert.equal(Object.keys(result).length, 0);
   });
 
   test('empty input fsTree short-circuits before any git or cache read', async (assert) => {
     const root = await makeProject();
     // Inject a detector that throws if called — proves the empty-tree guard returns first.
-    const result = await getChangedFsTree({}, root, 'HEAD', gitFailed);
+    const result = await getChangedFsTree({}, configFor(root), 'HEAD', gitFailed);
     assert.equal(Object.keys(result).length, 0);
   });
 });

--- a/test/utils/kill-process-group-test.ts
+++ b/test/utils/kill-process-group-test.ts
@@ -1,6 +1,53 @@
 import { module, test } from 'qunitx';
 import { spawn } from 'node:child_process';
-import { killProcessGroup } from '../../lib/utils/kill-process-group.ts';
+import { isTargetablePid, killProcessGroup } from '../../lib/utils/kill-process-group.ts';
+
+module('Utils | killProcessGroup | pid guard', { concurrency: true }, () => {
+  // The blast radius of getting this wrong is the user's whole login session, and the kill
+  // itself is deliberately error-swallowing — so there is no failure mode to observe after the
+  // fact. These assertions are the only thing standing between a bad pid and `kill(-1)`.
+
+  test('rejects 1 — negating it means every process the user owns', (assert) => {
+    assert.false(isTargetablePid(1));
+  });
+
+  test('rejects 0 — negating it means the caller’s own process group', (assert) => {
+    assert.false(isTargetablePid(0));
+    assert.false(isTargetablePid(-0), 'the negative-zero spelling is the same value');
+  });
+
+  test('rejects a negative pid, which is already a group selector', (assert) => {
+    assert.false(isTargetablePid(-1));
+    assert.false(isTargetablePid(-4242));
+  });
+
+  test('rejects what a failed spawn or a bad parse produces', (assert) => {
+    assert.false(isTargetablePid(Number.NaN), 'parseInt of a vanished /proc entry');
+    assert.false(
+      isTargetablePid(undefined as unknown as number),
+      'ChildProcess.pid when unspawned',
+    );
+    assert.false(isTargetablePid(1.5), 'a non-integer is not a pid');
+    assert.false(isTargetablePid(Number.POSITIVE_INFINITY));
+  });
+
+  test('rejects our own pid — we are not a process group to reap', (assert) => {
+    assert.false(isTargetablePid(process.pid));
+  });
+
+  test('accepts a plausible child pid', (assert) => {
+    assert.true(isTargetablePid(4242));
+    assert.true(isTargetablePid(2), 'the smallest value that is not init');
+  });
+
+  test('killProcessGroup is a no-op for every rejected pid', (assert) => {
+    // If the guard were absent, this call alone would take down the test runner and the shell
+    // that started it. Reaching the next line IS the assertion.
+    for (const pid of [0, 1, -1, Number.NaN, process.pid]) killProcessGroup(pid);
+
+    assert.ok(true, 'survived — no signal was sent');
+  });
+});
 
 module('Utils | killProcessGroup', { concurrency: true }, () => {
   // POSIX-only tests use `sh -c` rather than process.execPath so they're


### PR DESCRIPTION
> **How to review this.** Suggested order, and where the judgement calls are:
>
> 1. `lib/api/index.ts` — the whole public surface on one screen. If the shape is wrong, nothing
>    below matters.
> 2. `lib/api/options.ts` + `lib/api/result.ts` — what goes in, what comes out.
> 3. The four refactor commits (`c19e6ee1`, `1e2e1c60`, `6a2835c4`, and `1bff483b`) — these touch
>    the CLI path and are where a regression would hide.
> 4. Everything else is packaging, docs, and tests.
>
> **Three things I'd most like challenged:**
> - `lib/api/failure.ts` is a *hand-written* `{ is, format, hasCode }` surface rather than the
>   internal taxonomy re-exported. Deliberate (see the docs commit), but it is a boundary decision.
> - `Notice` carries `level` **and** `stream` **and** `raw`. Three fields to reproduce the CLI's
>   existing output exactly. Fewer would mean changing what the CLI prints.
> - The daemon's `DaemonRunOptions` narrows `RunOptions` by what cannot cross a socket. That makes
>   the limitation a compile error — but it is a second options type to keep in sync.
>
> **Not in this PR, by design:** `runSession()` (a handle over a single run, for streaming events
> as they happen) and `signal` for cancellation. Both are additive and neither needs the Stream
> module; they are a follow-up so this PR stays reviewable and stays green. See the discussion
> thread for the measurements behind that design.

Adds the JS API — `import { run } from 'qunitx-cli'` — and the internal inversion that makes it
possible without a second implementation of the runner.

```js
import { run } from 'qunitx-cli';

const result = await run({ inputs: ['test/'], filter: 'Cart' });
result.ok;        // false
result.failures;  // the failed tests, with their assertions
result.coverage;  // per-file line coverage
```

## The shape, and why

**Silent by default.** No `reporter`, no output; the `RunResult` is the whole answer. A reporter
*name* (`'tap'`, `'spec'`, `'dot'`, `'github'`) opts back into the CLI's text and `stdout` says
where it goes. A reporter *object* does not — passing a collector is a request to observe, not to
print.

**Failing tests are not an error.** `run()` resolves with `ok: false`. It rejects only when the
run could not happen — a rejected option, an unreadable input, no `package.json` — so `catch`
means something specific. `.result()` hands that back as a discriminable value instead.

**Options are validated where they are named.** `browser: 'netscape'` is an `InvalidOption`
before a browser launches. argv had this; an object literal did not.

**One engine.** `run(options)` and `qunitx <flags>` assemble the same `Config` through the same
`Args.applyInputs`, so `'a.ts#34'` targets a line identically either way. There is nothing to
drift.

## Surface

| | |
|---|---|
| `run(options)` | one-shot; full `RunResult` |
| `watch(options)` | async-iterable session, a complete result per rerun, `rerun()` / `close()` |
| `search(options)` | what a selection would run — no browser, milliseconds |
| `daemon.{start,stop,status,run}` | warm browser reuse; `run` returns the same `RunResult` over the socket |
| `init` / `generate` | scaffolding, reporting what they wrote |
| `Reporter` | public contract: `onRunStart` / `onTestEnd` / `onNotice` / `onBrowserLog` / `onRunEnd` |

Everything returns a `Task` (a lazy Promise superset), so nothing starts until awaited and
`.result()` is available throughout.

## The refactor underneath

Four commits before the API, each independently reviewable:

1. **`refactor(config)`** — `Config.setup(options?)` takes resolved settings instead of only
   reading `process.argv`. `Args.applyInputs` is lifted out so both routes share one positional
   grammar. `config.cwd` arrives with it: the run path resolved bare specifiers, hook paths and
   esbuild's `resolveDir` from `process.cwd()`, which a caller running someone else's project
   cannot set.

2. **`refactor(run)`** — `run()` resolves to a `RunOutcome` instead of calling `process.exit`,
   and `watch()` to a live `WatchSession`. `DaemonRunError` is deleted along with the unreachable
   branch it existed for — it was an exception thrown on the *success* path purely to unwind past
   an exit that should not have been there. The stdin keyboard shortcuts, the SIGTERM handler and
   the watch banner move to `cli.ts`, where terminal concerns belong.

3. **`feat(reporters)`** — reporters write through `config.state.output` rather than
   `process.stdout`, which is what makes silence expressible; the ~25 scattered
   `console.log('# …')` diagnostics become `Reporter.notice` events (same rendering, now also
   data); page `console.*` becomes `Reporter.browserLog`. The fan-out isolates each reporter, so
   a third-party one that throws costs its own output and nothing else.

4. **`fix`** — see below.

## A safety bug found on the way

`killProcessGroup` passed its argument straight to `process.kill(-pid, 'SIGKILL')` with no
validation. `pid === 1` negates to `kill(-1)` — every process the user owns, i.e. a logout —
and `pid === 0` to the caller's own process group. The pid arrives from `ChildProcess.pid`
(`number | undefined`, asserted away with `!`), from `parseInt` over a `/proc` entry that can
vanish mid-scan, and from a pid parsed out of a file; the kill deliberately swallows its errors,
so a wrong one left no trace. `isTargetablePid` now gates it at the primitive.

## Distribution

`qunitx-cli` had no `exports` and no `main` — it was bin-only, so `import 'qunitx-cli'` resolved
to nothing. Three entry points now:

```js
import { run } from 'qunitx-cli';                     // dist/index.js + .d.ts
import { run } from 'qunitx-cli/lib/api/index.ts';    // the TypeScript source (Node 24, Deno)
import { run } from 'jsr:@izelnakri/qunitx-cli/api';  // JSR
qunitx test/                                           // unchanged
```

Verified from a throwaway consumer project: runtime resolution through the exports map, the
source deep import under both Node and Deno, and `tsc --strict` against the shipped declarations.

**JSR** ships the library as `./api` on the *same* package — `.` stays the binary bootstrap that
`deno install -Agf` depends on. JSR resolves exports relative to the package root and specifiers
may not climb above it, so `scripts/stage-jsr-library.ts` copies `lib/`, `templates/` and
`package.json` into `jsr/` before publishing (the layout is mirrored exactly because
`readTemplate` resolves `../../templates` and `daemon/index.ts` imports `../../../package.json`).
`deno publish --dry-run` passes with zero slow-type errors.

Satisfying that rule fixed three real things rather than working around them:

- **The ambient module is gone.** `lib/web/index.ts` declared `module 'node:http'` to add
  `path`/`query`/`params`/`send`/`json` — putting them on *every* `node:http` request and
  response in the program, including ones this server never touches, where they were a lie the
  type checker vouched for. Now `Request`/`Response` interfaces extending node's, with one honest
  cast at the boundary that attaches them. It immediately caught `HTTPServer.serve`, which builds
  a plain server attaching nothing but whose handler was typed as if it did.
- **Eight exported `Failure.define` factories gained explicit types**, surfacing that
  `InputUnreadable` was annotated `{ path }` while its payload is `{ input }`.
- **npm specifiers carry version constraints**, taken from `package.json` so the two dependency
  declarations cannot drift.

## Tests

`test/api/` adds ~65 tests across run, options, result, search, watch, artifacts, scaffolding and
daemon — the first suite in this repo that drives a browser **in-process** rather than through
`node cli.ts`, so it takes the Chrome semaphore by hand.

Two real bugs surfaced while writing them, both fixed here:

- A rerun cleared its bundle cache when the fs event *arrived* rather than when the rebuild
  *started*, nulling `allTestCode` out from under an in-flight run. Reruns are now serialized
  through one queue — which also closes the pre-existing race between a `qa` keypress and a
  watcher rebuild.
- A throwing reporter aborted the run. The fan-out now isolates each one.

## Verification

Run locally: `typecheck`, `lint`, `lint:docs`, `format`, `test:doctest` (430 doctests), `deno publish --dry-run` for JSR, the
zero-browser API unit tests, and the example end to end. The full browser suite was **not** run
locally — this machine has `systemd-oomd` active and 8 cores, and `npm test`'s 8 concurrent
Chrome instances reliably triggered a session-wide OOM kill. CI is the gate for it.
